### PR TITLE
Fix heading hierarchy detection for Cheerio elements

### DIFF
--- a/attached_assets/Pasted-The-reviewer-raises-a-valid-point-When-a-document-has-h_1767583256234.txt
+++ b/attached_assets/Pasted-The-reviewer-raises-a-valid-point-When-a-document-has-h_1767583256234.txt
@@ -1,0 +1,46 @@
+The reviewer raises a valid point. When a document has h2, h1, h2, h3, shifting everything by 1 creates h1, h1, h1, h2 (flattened).
+
+  Better approach: Only shift headings BEFORE the first h1 (if one exists).
+
+  Replit prompt for backend:
+
+  In src/services/epub/epub-modifier.service.ts, in the fixHeadingHierarchy method, update Case 1 to only shift headings when there's no h1, OR only shift headings before the first h1.
+
+  Replace the Case 1 block with:
+
+        // Case 1: Document doesn't start with h1
+        if (firstHeadingLevel > 1) {
+          const shift = firstHeadingLevel - 1;
+
+          // Find if there's an existing h1 somewhere in the document
+          const firstH1Index = headings.findIndex(el => (el.name || '').toLowerCase() === 'h1');
+
+          // Determine how many headings to shift
+          // If no h1 exists, shift all; otherwise only shift headings before the first h1
+          const shiftUntilIndex = firstH1Index === -1 ? headings.length : firstH1Index;
+
+          // Process in reverse order to avoid conflicts
+          for (let i = shiftUntilIndex - 1; i >= 0; i--) {
+            const el = headings[i];
+            const oldLevel = parseInt((el.name || '').toLowerCase().charAt(1));
+            const newLevel = Math.max(1, oldLevel - shift);
+
+            if (oldLevel !== newLevel) {
+              const $el = $(el);
+              const headingContent = $el.html();
+              const attrs = el.attribs || {};
+              const attrString = Object.entries(attrs)
+                .map(([k, v]) => `${k}="${escapeAttr(v)}"`)
+                .join(' ');
+
+              const $newHeading = $(`<h${newLevel}${attrString ? ' ' + attrString : ''}>${headingContent}</h${newLevel}>`);
+              $el.replaceWith($newHeading);
+              changes.push(`h${oldLevel} → h${newLevel}`);
+              modified = true;
+            }
+          }
+        }
+
+  This ensures:
+  - h2, h1, h2, h3 → h1, h1, h2, h3 (only first h2 shifted, h1 and after preserved)
+  - h2, h2, h3 → h1, h1, h2 (no h1 exists, all shifted)

--- a/src/services/epub/epub-modifier.service.ts
+++ b/src/services/epub/epub-modifier.service.ts
@@ -1009,12 +1009,19 @@ class EPUBModifierService {
       // Find the first heading level in the document
       const firstHeadingLevel = headings.length > 0 ? parseInt((headings[0].name || '').toLowerCase().charAt(1)) : 1;
 
-      // Case 1: Document doesn't start with h1 - shift all headings up
+      // Case 1: Document doesn't start with h1
       if (firstHeadingLevel > 1) {
         const shift = firstHeadingLevel - 1;
 
+        // Find if there's an existing h1 somewhere in the document
+        const firstH1Index = headings.findIndex(el => (el.name || '').toLowerCase() === 'h1');
+
+        // Determine how many headings to shift
+        // If no h1 exists, shift all; otherwise only shift headings before the first h1
+        const shiftUntilIndex = firstH1Index === -1 ? headings.length : firstH1Index;
+
         // Process in reverse order to avoid conflicts
-        for (let i = headings.length - 1; i >= 0; i--) {
+        for (let i = shiftUntilIndex - 1; i >= 0; i--) {
           const el = headings[i];
           const oldLevel = parseInt((el.name || '').toLowerCase().charAt(1));
           const newLevel = Math.max(1, oldLevel - shift);
@@ -1033,31 +1040,32 @@ class EPUBModifierService {
             modified = true;
           }
         }
-      } else {
-        // Case 2: Document starts with h1 but may have skipped levels (h1→h3)
-        // Normalize each heading to at most one level deeper than expected
-        let expectedMaxLevel = 1;
+      }
 
-        for (const el of headings) {
-          const oldLevel = parseInt((el.name || '').toLowerCase().charAt(1));
+      // Case 2: Fix any skipped levels (h1→h3 becomes h1→h2)
+      // Re-read headings after Case 1 modifications
+      const updatedHeadings = $('h1, h2, h3, h4, h5, h6').toArray();
+      let expectedMaxLevel = 1;
 
-          if (oldLevel > expectedMaxLevel + 1) {
-            const newLevel = expectedMaxLevel + 1;
-            const $el = $(el);
-            const headingContent = $el.html();
-            const attrs = el.attribs || {};
-            const attrString = Object.entries(attrs)
-              .map(([k, v]) => `${k}="${escapeAttr(v)}"`)
-              .join(' ');
+      for (const el of updatedHeadings) {
+        const oldLevel = parseInt((el.name || '').toLowerCase().charAt(1));
 
-            const $newHeading = $(`<h${newLevel}${attrString ? ' ' + attrString : ''}>${headingContent}</h${newLevel}>`);
-            $el.replaceWith($newHeading);
-            changes.push(`h${oldLevel} → h${newLevel}`);
-            modified = true;
-            expectedMaxLevel = newLevel;
-          } else {
-            expectedMaxLevel = Math.max(expectedMaxLevel, oldLevel);
-          }
+        if (oldLevel > expectedMaxLevel + 1) {
+          const newLevel = expectedMaxLevel + 1;
+          const $el = $(el);
+          const headingContent = $el.html();
+          const attrs = el.attribs || {};
+          const attrString = Object.entries(attrs)
+            .map(([k, v]) => `${k}="${escapeAttr(v)}"`)
+            .join(' ');
+
+          const $newHeading = $(`<h${newLevel}${attrString ? ' ' + attrString : ''}>${headingContent}</h${newLevel}>`);
+          $el.replaceWith($newHeading);
+          changes.push(`h${oldLevel} → h${newLevel}`);
+          modified = true;
+          expectedMaxLevel = newLevel;
+        } else {
+          expectedMaxLevel = Math.max(expectedMaxLevel, oldLevel);
         }
       }
 


### PR DESCRIPTION
 ## Summary
  - Changed `el.tagName` to `el.name` (Cheerio uses `name` property, not `tagName`)
  - Changed condition from `minLevel > 1` to check if FIRST heading is h1
  - Fixes case where document starts with h2 but has h1 later (e.g., h2, h1, h2, h3...)

  ## Test plan
  - [x] Tested EPUB with 18 heading issues - all fixed, re-audit shows 0 issues
  - [ ] Verify in AWS staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB heading normalization to shift headings only up to the first top-level heading (or all if none exist), and to correct skipped heading levels in a two-phase pass — producing more consistent, user-visible heading structures.

* **Chores**
  * Added detailed debug logging for heading processing to aid troubleshooting; no public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->