### PR TITLE
fix: Add ACR_WORKFLOW to job type validation schema

### DIFF
--- a/src/schemas/job.schemas.ts
+++ b/src/schemas/job.schemas.ts
@@ -7,7 +7,8 @@ export const jobTypeEnum = z.enum([
   'VPAT_GENERATION',
   'ALT_TEXT_GENERATION',
   'METADATA_EXTRACTION',
-  'BATCH_VALIDATION'
+  'BATCH_VALIDATION',
+  'ACR_WORKFLOW'
 ]);
 
 export const jobStatusEnum = z.enum([


### PR DESCRIPTION
## Summary
  - Added `ACR_WORKFLOW` to the `jobTypeEnum` Zod schema in `src/schemas/job.schemas.ts`
  - Fixes 400 Bad Request error when filtering jobs by "ACR Workflow" type

  ## Root Cause
  The `ACR_WORKFLOW` job type existed in:
  - Prisma schema (`JobType` enum)
  - Frontend (`JOB_TYPE_LABELS`)

  But was missing from the backend Zod validation schema, causing request validation to fail.

  ## Test Plan
  - [x] Go to Jobs page
  - [x] Select "ACR Workflow" from Type filter
  - [x] Verify jobs load without 400 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ACR_WORKFLOW as a new job type. This enhancement expands the range of available job processing options, allowing users to create and manage jobs of the new ACR_WORKFLOW type. The system now supports a broader range of job processing scenarios, providing increased flexibility and additional capabilities for job management and execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->