### PR TITLE
 fix: Add missing acrEditions.json data file for AcrService startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
   COPY tsconfig.json ./
   RUN npm ci
   COPY src ./src
+  COPY src/data ./src/data
   COPY prisma ./prisma
   RUN npx prisma generate
   RUN npm run build
@@ -35,6 +36,7 @@
 
   # Copy compiled code and dependencies
   COPY --from=builder /app/dist ./dist
+  COPY --from=builder /app/src/data ./dist/data
   COPY --from=builder /app/node_modules ./node_modules
   COPY --from=builder /app/prisma ./prisma
   COPY --from=builder /app/package*.json ./


### PR DESCRIPTION
 ## Summary
  - Added missing `src/data/acrEditions.json` file containing WCAG 2.1 criteria definitions
  - Updated Dockerfile to copy data folder to dist directory in production image

  ## Problem
  ECS container was crashing on startup with error:
  Error: ENOENT: no such file or directory, open '/app/dist/data/acrEditions.json'

  The `AcrService` constructor attempts to read this file at initialization, but the file was never
   created in the repository.

  ## Changes
  1. **src/data/acrEditions.json** - New file with VPAT editions (508, WCAG, EU, INT) and 37 WCAG
  2.1 Level A/AA criteria
  2. **Dockerfile** - Added `COPY` instruction to include data folder in production image

  ## Test Plan
  - [ ] ECS container starts without errors
  - [ ] Health check passes
  - [ ] ACR Workflow filter works on Jobs page
  - [ ] ACR edition endpoints return data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure proper data bundling in production deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->