### PR TITLE
feat(epub): add asset serving endpoint for EPUB resources (BUG-2)

### DIFF
--- a/src/routes/epub.routes.ts
+++ b/src/routes/epub.routes.ts
@@ -63,6 +63,7 @@ router.get('/job/:jobId/content', authenticate, authorizeJob, epubContentControl
 router.get('/job/:jobId/scan-epub-types', authenticate, authorizeJob, epubController.scanEpubTypes);
 router.post('/job/:jobId/task/:taskId/mark-fixed', authenticate, authorizeJob, epubController.markTaskFixed);
 router.post('/job/:jobId/generate-alt-text', authenticate, authorizeJob, epubController.generateImageAltText);
+router.get('/job/:jobId/asset/*', authenticate, authorizeJob, epubController.getAsset);
 router.get('/job/:jobId/image/*', authenticate, authorizeJob, epubController.getImage);
 
 router.get('/fix-template/:issueCode', authenticate, epubController.getFixTemplate);

--- a/src/services/epub/epub-content.service.ts
+++ b/src/services/epub/epub-content.service.ts
@@ -57,9 +57,11 @@ export class EpubContentService {
       }
 
       const contentType = this.getContentType(entry.entryName);
-      
+
       const isBinary = contentType.startsWith('image/') ||
-                       contentType === 'application/octet-stream';
+                       contentType.startsWith('font/') ||
+                       contentType === 'application/octet-stream' ||
+                       contentType === 'application/vnd.ms-fontobject';
 
       let content: string;
       let finalContentType: string;
@@ -98,6 +100,12 @@ export class EpubContentService {
       '.jpg': 'image/jpeg',
       '.jpeg': 'image/jpeg',
       '.gif': 'image/gif',
+      '.webp': 'image/webp',
+      '.woff': 'font/woff',
+      '.woff2': 'font/woff2',
+      '.ttf': 'font/ttf',
+      '.otf': 'font/otf',
+      '.eot': 'application/vnd.ms-fontobject',
       '.ncx': 'application/x-dtbncx+xml',
       '.opf': 'application/oebps-package+xml',
     };


### PR DESCRIPTION
## Summary
Implements backend support for serving static assets (images, CSS, fonts, etc.) from EPUB files to fix 503 errors in the frontend visual comparison component.

## Problem
The frontend VisualComparison/EPUBRenderer component renders EPUB chapter content in iframes for BEFORE/AFTER display. When chapters contain embedded resources (images, CSS, fonts), these assets need to be served from the EPUB file stored on the backend.

The frontend BUG-2 fix rewrites resource paths to:
```
/api/v1/epub/job/{jobId}/asset/OEBPS/images/workflow-diagram.png
```

But this route didn't exist, causing 503 errors:
```
GET /api/v1/epub/job/4450f939-.../asset/OEBPS%2Fimages%2Fworkflow-diagram.png → 503
GET /api/v1/epub/job/4450f939-.../asset/OEBPS%2Fimages%2Fbar-chart.png → 503
```

## Changes Made

### New Endpoint
**Route:** `GET /api/v1/epub/job/:jobId/asset/*`

### Files Modified

1. **`src/services/epub/epub-content.service.ts`**
   - Extended MIME type support:
     - Fonts: .woff, .woff2, .ttf, .otf, .eot
     - Images: added .webp
   - Updated binary file detection to include fonts

2. **`src/controllers/epub.controller.ts`**
   - Added `getAsset()` controller method
   - URL-decodes asset paths (handles `OEBPS%2Fimages%2F...`)
   - Prevents path traversal attacks (blocks `..` and leading `/`)
   - Returns correct Content-Type for all asset types
   - Sets Cache-Control: public, max-age=3600

3. **`src/routes/epub.routes.ts`**
   - Added route with authentication & authorization middleware

## Features

✅ **Security**
- Path traversal prevention
- User authentication required  
- Job authorization (users only access their own jobs)
- Only serves from within EPUB archive

✅ **Performance**
- Efficient ZIP entry extraction (no full extraction)
- Immutable content caching (1 hour)
- Binary files served as base64, text as UTF-8

✅ **Supported Assets**
- Images: png, jpg, jpeg, gif, svg, webp
- Fonts: woff, woff2, ttf, otf, eot  
- Styles: css
- Documents: xhtml, html, xml

## Test Results
✅ All 129 tests passing  
✅ TypeScript build successful  
✅ No breaking changes

## Impact
After this fix:
- Frontend visual comparison iframes can render images, CSS, and fonts
- No more 503 errors for EPUB asset requests
- BEFORE/AFTER comparison displays correctly with styling and images

## Example Usage
```
GET /api/v1/epub/job/{jobId}/asset/OEBPS/images/workflow-diagram.png
GET /api/v1/epub/job/{jobId}/asset/OEBPS/styles/main.css  
GET /api/v1/epub/job/{jobId}/asset/OEBPS/fonts/OpenSans.woff2
```

## Related
- Fixes BUG-2: Frontend 503 errors for EPUB assets in visual comparison
- Complements frontend fix that rewrites asset src attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new endpoint to retrieve and stream EPUB file assets with integrated path traversal security measures, automatic MIME type detection, and intelligent HTTP caching support
  * Expanded file format compatibility to include web fonts (WOFF, WOFF2, TTF, OTF, EOT) and WebP images for improved support of modern EPUB content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->