### PR TITLE
feat(pdf): add audit-file endpoint for file ID-based audits

### DIFF
--- a/src/routes/pdf.routes.ts
+++ b/src/routes/pdf.routes.ts
@@ -101,6 +101,25 @@ router.post(
 );
 
 /**
+ * POST /pdf/audit-file
+ * Audit a PDF file from an existing file ID
+ *
+ * Used for two-step upload flow:
+ * 1. Upload file to S3 (via presigned URL or /files/upload)
+ * 2. Call this endpoint with fileId to start audit
+ *
+ * @body fileId - File ID from previous upload
+ * @returns { jobId, status, message }
+ */
+router.post('/audit-file', authenticate, async (req, res, next) => {
+  try {
+    return await pdfController.auditFromFileId(req as any, res);
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
  * POST /pdf/job/:jobId/re-scan
  * Re-run audit with different scan level
  *


### PR DESCRIPTION
## Summary
Fixes the 404 error on staging by adding the missing `POST /pdf/audit-file` endpoint that the frontend was calling.

## Problem
After deploying the frontend ACR MVP, the PDF Accessibility page was showing:
- 404 error: `/v1/pdf/audit-file` not found
- Frontend calls this endpoint for two-step upload flow (upload to S3, then audit)
- Backend only had `/pdf/audit-upload` for direct uploads

## Solution
Added `/pdf/audit-file` endpoint matching the EPUB pattern:

### New Endpoint
```
POST /api/v1/pdf/audit-file
Body: { fileId: string }
Returns: { jobId, status: "QUEUED", message }
```

### Implementation Details
1. **PdfController.auditFromFileId()**
   - Validates authentication (tenantId, userId)
   - Atomically updates file status: UPLOADED → PROCESSING
   - Creates job record with type 'PDF_ACCESSIBILITY'
   - Returns 202 Accepted with jobId
   - Starts background processing

2. **processPdfAuditInBackground()**
   - Fetches file from S3 or local storage
   - Runs PDF audit using pdfAuditService
   - Updates job status to COMPLETED/FAILED
   - Updates file status to PROCESSED/ERROR
   - Handles rollback on errors

### Two-Step Upload Flow
```
1. Frontend uploads PDF → S3 (via presigned URL)
2. Frontend calls POST /pdf/audit-file with fileId
3. Backend queues audit job, returns jobId
4. Frontend polls GET /jobs/:jobId for status
```

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint warnings match existing pattern (any types)
- ✅ Follows same pattern as EPUB audit-file endpoint

## Files Changed
- `src/controllers/pdf.controller.ts` - Added auditFromFileId method and background processor
- `src/routes/pdf.routes.ts` - Added POST /pdf/audit-file route

## Related Issues
Fixes staging deployment error after PR #128 merge

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)