### PR TITLE
fix(pdf): use system temp directory for backups

### DIFF
--- a/src/services/pdf/pdf-modifier.service.ts
+++ b/src/services/pdf/pdf-modifier.service.ts
@@ -58,7 +58,7 @@ export interface ValidationResult {
 export class PdfModifierService {
   private backupDir: string;
 
-  constructor(backupDir: string = './tmp/pdf-backups') {
+  constructor(backupDir: string = '/tmp/pdf-backups') {
     this.backupDir = backupDir;
   }
 


### PR DESCRIPTION
## Summary
Fixes EACCES permission denied error when creating PDF backups during auto-remediation.

## Root Cause
The auto-remediation service was failing with:
```
EACCES: permission denied, mkdir './tmp'
```

This happened because:
- Docker containers run as non-root user with limited permissions
- Application directory is read-only in production
- Relative path `./tmp/pdf-backups` requires write permissions in the app directory

## Changes
- Changed backup directory from `'./tmp/pdf-backups'` to `'/tmp/pdf-backups'`
- Uses system temp directory which is always writable in containers

## Testing
1. Upload a PDF with accessibility issues
2. Click "Fix Automatically"
3. Verify that backup is created successfully
4. Verify that auto-remediation completes without permission errors

## Impact
- ✅ Auto-remediation now works in staging/production
- ✅ PDF backups are created successfully before modifications
- ✅ No breaking changes (only changes default backup location)

## Related Error Log
```json
{
  "error": {
    "errno": -13,
    "code": "EACCES",
    "syscall": "mkdir",
    "path": "./tmp"
  },
  "message": "Failed to create backup: EACCES: permission denied, mkdir './tmp'"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default backup directory path configuration for PDF handling from a relative path to an absolute system path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->