### PR TITLE
fix(pdf): resolve INVALID_PATH - use correct storage base path

### DIFF
--- a/src/controllers/pdf-remediation.controller.ts
+++ b/src/controllers/pdf-remediation.controller.ts
@@ -806,9 +806,14 @@ export class PdfRemediationController {
       }
 
       // Define canonical base directory for security
-      // Use EPUB_STORAGE_PATH to match file-storage.service.ts
-      const baseDir = path.resolve(process.env.EPUB_STORAGE_PATH || process.env.UPLOAD_DIR || './data/epub-storage');
-      logger.info('[PDF Download] Base directory resolved', { baseDir, jobId });
+      // MUST match file-storage.service.ts exactly: EPUB_STORAGE_PATH || '/tmp/epub-storage'
+      const baseDir = path.resolve(process.env.EPUB_STORAGE_PATH || '/tmp/epub-storage');
+      logger.info('[PDF Download] Base directory resolved', {
+        baseDir,
+        jobId,
+        epubStoragePath: process.env.EPUB_STORAGE_PATH,
+        usingDefault: !process.env.EPUB_STORAGE_PATH
+      });
 
       const output = job.output as Record<string, unknown>;
       logger.info('[PDF Download] Job output', {


### PR DESCRIPTION
## Root Cause Found!

From CloudWatch logs:
```
baseDir: /app/data/epub-storage
remediatedFileUrl: /tmp/epub-storage/jobId/remediated/file.pdf
relativePath: ../../../tmp/epub-storage/...
```

**The Problem:**
- `file-storage.service.ts` saves files to `/tmp/epub-storage` (default)
- Download endpoint looked in `/app/data/epub-storage` (wrong default)
- Files in one location, download looking in another!

## The Fix

Changed baseDir default to match `file-storage.service.ts`:

**Before:**
```typescript
const baseDir = path.resolve(
  process.env.EPUB_STORAGE_PATH || 
  process.env.UPLOAD_DIR ||           // Wrong fallback
  './data/epub-storage'                // Wrong default
);
```

**After:**
```typescript
const baseDir = path.resolve(
  process.env.EPUB_STORAGE_PATH || 
  '/tmp/epub-storage'                  // Matches file-storage.service
);
```

## Impact

✅ Download will find files in the correct location  
✅ Path validation will pass (file IS within baseDir)  
✅ Resolves staging 400 INVALID_PATH error

## Production Note

In production, set `EPUB_STORAGE_PATH` env var to a persistent volume (not `/tmp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved PDF storage path configuration with stricter defaults and consistent behavior across the application.
  * Enhanced logging for PDF storage directory resolution and usage, providing better debugging context for system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->