### PR TITLE
fix: address CodeRabbit round-3 review comments

### DIFF
--- a/src/controllers/citation/citation-export.controller.ts
+++ b/src/controllers/citation/citation-export.controller.ts
@@ -544,8 +544,9 @@ export class CitationExportController {
           continue;
         }
 
-        // Skip [N] format ref-section RENUMBER — handled by REFERENCE_REORDER below
-        if (c.changeType === 'RENUMBER' && c.beforeText && /^\[\d+\]/.test(c.beforeText)) {
+        // Skip ref-section bracket RENUMBER (e.g. "[1] Author...") — handled by REFERENCE_REORDER below
+        // Only skip non-citationId entries where beforeText has content after the bracket number
+        if (c.changeType === 'RENUMBER' && !c.citationId && c.beforeText && /^\[\d+\]\s+/.test(c.beforeText)) {
           continue;
         }
 

--- a/src/controllers/citation/citation-reference.controller.ts
+++ b/src/controllers/citation/citation-reference.controller.ts
@@ -2491,9 +2491,9 @@ export class CitationReferenceController {
       const remapped = remapAndFormat(bracketMatch[1]);
       if (remapped === null) {
         // Remove citation and clean up adjacent space
-        const { start } = cleanDeletion(text, bracketMatch.index, bracketMatch.index + bracketMatch[0].length);
+        const { start, end } = cleanDeletion(text, bracketMatch.index, bracketMatch.index + bracketMatch[0].length);
         result += text.slice(lastIndex, start);
-        lastIndex = bracketMatch.index + bracketMatch[0].length;
+        lastIndex = end;
         replacements.push({ original: bracketMatch[0], replacement: '' });
       } else {
         const newCitation = `[${remapped}]`;
@@ -2517,9 +2517,9 @@ export class CitationReferenceController {
       const remapped = remapAndFormat(parenMatch[1]);
       if (remapped === null) {
         // Remove citation and clean up adjacent space
-        const { start } = cleanDeletion(textAfterBrackets, parenMatch.index, parenMatch.index + parenMatch[0].length);
+        const { start, end } = cleanDeletion(textAfterBrackets, parenMatch.index, parenMatch.index + parenMatch[0].length);
         result += textAfterBrackets.slice(lastIndex, start);
-        lastIndex = parenMatch.index + parenMatch[0].length;
+        lastIndex = end;
         replacements.push({ original: parenMatch[0], replacement: '' });
       } else {
         const newCitation = `(${remapped})`;

--- a/src/controllers/citation/citation-style.controller.ts
+++ b/src/controllers/citation/citation-style.controller.ts
@@ -337,9 +337,10 @@ export class CitationStyleController {
         });
 
         // Update Citation.rawText using ID-based lookup when available
+        // Scope to current document to prevent cross-document writes
         if (citConversion.citationId) {
           await prisma.citation.update({
-            where: { id: citConversion.citationId },
+            where: { id: citConversion.citationId, documentId: document.id },
             data: {
               rawText: citConversion.newText,
               detectedStyle: prismaStyle as import('@prisma/client').CitationStyle

--- a/src/services/citation/docx-processor.service.ts
+++ b/src/services/citation/docx-processor.service.ts
@@ -3154,8 +3154,10 @@ class DOCXProcessorService {
                   // Skip if this looks like an in-text citation paragraph (short, contains parentheses)
                   if (para.combinedText.length < 100 && para.combinedText.includes('(') && para.combinedText.includes(')')) {
                     // Check if this is actually a reference entry, not just a citation
-                    // Reference entries have a year pattern (various formats: "(2020).", "2020.", "(2020),")
-                    if (!/\b(19|20)\d{2}\b/.test(para.combinedText)) {
+                    // Reference entries typically have: a year, a period after the year, and length > 40 chars
+                    const hasYear = /\b(19|20)\d{2}\b/.test(para.combinedText);
+                    const hasRefStructure = para.combinedText.length > 40 && /\.\s/.test(para.combinedText);
+                    if (!hasYear || !hasRefStructure) {
                       continue; // Skip this, likely an in-text citation
                     }
                   }


### PR DESCRIPTION
- cleanDeletion: use returned `end` at both call sites so trailing space is consumed when citation is at text start
- citation-export: narrow bracket RENUMBER skip to ref-section entries only (require trailing space after [N]), preserve in-text bracket citation renumber changes
- citation-style: scope citation update to current documentId to prevent cross-document writes
- docx-processor: tighten reference-vs-citation discrimination to require both year pattern AND reference structure (length > 40, period + space), reducing false positives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved citation reordering logic to handle numbered citations more accurately
  * Fixed citation deletion handling to correctly position subsequent text
  * Prevented unintended cross-document citation updates
  * Enhanced reference entry detection in documents with stricter validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->