### PR TITLE
fix(epub): reclassify EPUB-STRUCT-004 as manual and fix landmark file targeting

### DIFF
--- a/src/constants/auto-fix-codes.ts
+++ b/src/constants/auto-fix-codes.ts
@@ -8,7 +8,8 @@ export const AUTO_FIXABLE_ISSUE_CODES = new Set([
   'EPUB-IMG-001',
   'EPUB-STRUCT-002',
   'EPUB-STRUCT-003',
-  'EPUB-STRUCT-004',
+  // EPUB-STRUCT-004 excluded: auto-fix targets alphabetically-first file (often cover page)
+  // which does not satisfy ACE validation — must be treated as manual
   'EPUB-NAV-001',
   'EPUB-FIG-001',
 ]);

--- a/src/constants/fix-classification.ts
+++ b/src/constants/fix-classification.ts
@@ -11,7 +11,8 @@ const BASE_AUTO_FIXABLE_CODES = new Set([
   'EPUB-SEM-001',
   'EPUB-SEM-002',
   'EPUB-STRUCT-003',
-  'EPUB-STRUCT-004',
+  // EPUB-STRUCT-004 excluded: landmark is unreliably placed on cover/front-matter pages
+  // and does not consistently satisfy ACE re-audit — classify as manual
   'EPUB-FIG-001',
   // ACE metadata codes - now auto-fixable
   'METADATA-ACCESSMODE',

--- a/src/services/epub/epub-modifier.service.ts
+++ b/src/services/epub/epub-modifier.service.ts
@@ -1198,6 +1198,18 @@ class EPUBModifierService {
       files = [...targetFiles, ...otherFiles];
     }
 
+    // Within the ordered list, push front-matter/cover pages to the end so the
+    // landmark lands on a real content page rather than the cover or title page.
+    // ACE validates that role="main" is in reading content, not front matter.
+    const isFrontMatter = (f: string): boolean => {
+      const name = (f.split('/').pop() ?? '').toLowerCase();
+      return /cover|title|front|copyright|dedication|colophon|halftitle|half[_-]title/.test(name)
+        || /^0+[_-]/.test(name); // e.g. 00_cover.xhtml, 000_title.xhtml
+    };
+    const contentFiles = files.filter(f => !isFrontMatter(f));
+    const frontMatterFiles = files.filter(f => isFrontMatter(f));
+    files = [...contentFiles, ...frontMatterFiles];
+
     // Track if we've added a main landmark anywhere
     let mainLandmarkExists = false;
 


### PR DESCRIPTION
## Problem

When a user ran auto-remediation on an EPUB with `EPUB-STRUCT-004` (Missing main landmark), the issues CSV showed it as **Auto-fixable**, the fix appeared to apply (comparison report showed a change), but **re-audit still flagged the issue**.

Two separate root causes were identified.

## Root Cause 1 — Classification mismatch

`EPUB-STRUCT-004` existed in both `AUTO_FIXABLE_ISSUE_CODES` (`auto-fix-codes.ts`) and `BASE_AUTO_FIXABLE_CODES` (`fix-classification.ts`), causing the issues export CSV and all `getFixType()` callers to label it **Auto-fixable**.

`batch.controller.ts` had already excluded it from `isAutoFixableCode()` (with comment: *"Could not add main landmark - no suitable element found"*) but the shared constants were never updated to match.

**Fix:** Removed `EPUB-STRUCT-004` from both constant sets. It now returns `'manual'` from `getFixType()`, so the CSV correctly shows **Manual** and the UI treats it accordingly.

## Root Cause 2 — Landmark placed on cover page

`addAriaLandmarks()` sorted all `.html`/`.xhtml` files **alphabetically**, so `00_cover.xhtml` was always the first candidate. If the cover had a `<section>` element, `role="main"` was added there. ACE rejects this because the main landmark must be in reading content, not front matter.

**Fix:** After the existing target-location prioritization, files are now partitioned so front-matter/cover pages (matched by name pattern: `cover`, `title`, `front`, `copyright`, `dedication`, `colophon`, `00_`, etc.) move to the end of the processing list. Content pages are tried first.

## Changes

| File | Change |
|---|---|
| `src/constants/auto-fix-codes.ts` | Removed `EPUB-STRUCT-004` from `AUTO_FIXABLE_ISSUE_CODES` |
| `src/constants/fix-classification.ts` | Removed `EPUB-STRUCT-004` from `BASE_AUTO_FIXABLE_CODES` |
| `src/services/epub/epub-modifier.service.ts` | Added front-matter detection + reordering in `addAriaLandmarks()` |

## Test plan
- [ ] Audit an EPUB with `EPUB-STRUCT-004` — issues CSV should show **Manual**, not Auto-fixable
- [ ] Run auto-remediation on an EPUB where `00_cover.xhtml` comes first alphabetically — landmark should land on a content page, not the cover
- [ ] Re-audit the remediated EPUB — ACE should not re-flag `EPUB-STRUCT-004`
- [ ] Verify other auto-fixable codes (`EPUB-META-*`, `EPUB-STRUCT-002`, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved landmark placement accuracy in EPUB files by adjusting file processing order to prioritize content pages.
  * EPUB-STRUCT-004 issues are now treated as manual fixes instead of automatic fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->