### PR TITLE
feat(ml): ML-2.5 mAP@0.5 calculation service

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -41,6 +41,7 @@ import pacReportRoutes from "./pac-report.routes";
 import zonesRoutes from "./zones.routes";
 import zoneExtractorRoutes from "./zone-extractor.routes";
 import calibrationRoutes from "./calibration.routes";
+import mlMetricsRoutes from "./ml-metrics.routes";
 
 const router = Router();
 
@@ -141,5 +142,6 @@ router.use("/pdf", pacReportRoutes);
 router.use("/zones", zonesRoutes);
 router.use("/zone-extractor", zoneExtractorRoutes);
 router.use("/calibration", calibrationRoutes);
+router.use("/ml-metrics", mlMetricsRoutes);
 
 export default router;

--- a/src/routes/ml-metrics.routes.ts
+++ b/src/routes/ml-metrics.routes.ts
@@ -1,0 +1,187 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { authenticate } from '../middleware/auth.middleware';
+import prisma from '../lib/prisma';
+import { calculateMAP } from '../services/metrics/map.service';
+import {
+  saveMapSnapshot,
+  getMapSnapshot,
+  getMapHistory,
+} from '../services/metrics/map-persistence';
+import type { AnnotatedZone, PredictedZone } from '../services/metrics/ml-metrics.types';
+import type { BBox } from '../services/calibration/iou';
+import type { CanonicalZoneType } from '../services/zone-extractor/types';
+
+const router = Router();
+
+router.use(authenticate);
+
+const runMapSchema = z.object({
+  runId: z.string().min(1),
+});
+
+// POST /api/v1/ml-metrics/map
+router.post('/map', async (req: Request, res: Response) => {
+  try {
+    const parsed = runMapSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(422).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Request validation failed',
+          details: parsed.error.issues,
+        },
+      });
+    }
+
+    const { runId } = parsed.data;
+
+    // Verify run exists
+    const run = await prisma.calibrationRun.findUnique({
+      where: { id: runId },
+    });
+    if (!run) {
+      return res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: `CalibrationRun ${runId} not found` },
+      });
+    }
+
+    // Fetch operator-verified zones as ground truth
+    const gtZones = await prisma.zone.findMany({
+      where: {
+        calibrationRunId: runId,
+        operatorVerified: true,
+        isArtefact: false,
+      },
+    });
+
+    const groundTruth: AnnotatedZone[] = gtZones.map((z) => ({
+      pageNumber: z.pageNumber,
+      bbox: z.bounds as unknown as BBox,
+      zoneType: (z.operatorLabel ?? z.type) as CanonicalZoneType,
+    }));
+
+    // Fetch docling predictions
+    const predZones = await prisma.zone.findMany({
+      where: {
+        calibrationRunId: runId,
+        source: 'docling',
+      },
+    });
+
+    const predictions: PredictedZone[] = predZones.map((z) => ({
+      pageNumber: z.pageNumber,
+      bbox: z.bounds as unknown as BBox,
+      zoneType: z.type as CanonicalZoneType,
+      confidence: z.doclingConfidence ?? 0.5,
+    }));
+
+    const result = calculateMAP(groundTruth, predictions);
+    await saveMapSnapshot(runId, result);
+
+    return res.json({ success: true, data: result });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
+// GET /api/v1/ml-metrics/map/:runId
+router.get('/map/:runId', async (req: Request, res: Response) => {
+  try {
+    const { runId } = req.params;
+    const result = await getMapSnapshot(runId);
+
+    if (!result) {
+      return res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: `mAP snapshot for run ${runId} not found` },
+      });
+    }
+
+    return res.json({ success: true, data: result });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
+// GET /api/v1/ml-metrics/map/history
+// NOTE: must be before /map/:runId but Express will match 'history' as :runId
+// So we register this route specifically
+router.get('/map-history', async (req: Request, res: Response) => {
+  try {
+    const { fromDate, toDate } = req.query;
+    const from = fromDate && typeof fromDate === 'string' ? new Date(fromDate) : undefined;
+    const to = toDate && typeof toDate === 'string' ? new Date(toDate) : undefined;
+
+    const snapshots = await getMapHistory(from, to);
+    return res.json({ success: true, data: snapshots });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
+// GET /api/v1/ml-metrics/phase-gate
+router.get('/phase-gate', async (_req: Request, res: Response) => {
+  return res.json({
+    success: true,
+    data: {
+      criteria: [
+        {
+          id: 'C1',
+          label: 'Overall mAP ≥75%',
+          status: 'AMBER',
+          currentValue: 'pending',
+          threshold: '75%',
+          tooltip: 'Run POST /ml-metrics/map to compute',
+        },
+        {
+          id: 'C2',
+          label: 'All 8 zone types ≥30 instances',
+          status: 'AMBER',
+          currentValue: 'pending',
+          threshold: '30 per type',
+          tooltip: 'Requires 300+ annotated pages',
+        },
+        {
+          id: 'C3',
+          label: 'Publisher diversity ≥3',
+          status: 'AMBER',
+          currentValue: 'pending',
+          threshold: '3 publishers',
+          tooltip: 'Pending corpus',
+        },
+        {
+          id: 'C4',
+          label: 'Content type diversity ≥3',
+          status: 'AMBER',
+          currentValue: 'pending',
+          threshold: '3 content types',
+          tooltip: 'Pending corpus',
+        },
+        {
+          id: 'C5',
+          label: 'Write quality pass rate ≥95%',
+          status: 'AMBER',
+          currentValue: 'pending',
+          threshold: '95% PAC 2024',
+          tooltip: 'Pending pikepdf spike (ML-3.8)',
+        },
+      ],
+      overallStatus: 'AMBER',
+      readyForPhase2: false,
+    },
+  });
+});
+
+export default router;

--- a/src/services/metrics/map-persistence.ts
+++ b/src/services/metrics/map-persistence.ts
@@ -1,0 +1,71 @@
+import prisma, { Prisma } from '../../lib/prisma';
+import type { MAPResult } from './ml-metrics.types';
+
+export interface MAPSnapshot {
+  runId: string;
+  runDate: Date;
+  overallMAP: number;
+  perClass: object;
+}
+
+export async function saveMapSnapshot(
+  calibrationRunId: string,
+  result: MAPResult,
+): Promise<void> {
+  await prisma.calibrationRun.update({
+    where: { id: calibrationRunId },
+    data: {
+      mapSnapshot: result as unknown as Prisma.InputJsonValue,
+    },
+  });
+}
+
+export async function getMapHistory(
+  fromDate?: Date,
+  toDate?: Date,
+): Promise<MAPSnapshot[]> {
+  const where: Prisma.CalibrationRunWhereInput = {
+    mapSnapshot: { not: Prisma.DbNull },
+  };
+
+  if (fromDate || toDate) {
+    where.completedAt = {};
+    if (fromDate) (where.completedAt as Prisma.DateTimeNullableFilter).gte = fromDate;
+    if (toDate) (where.completedAt as Prisma.DateTimeNullableFilter).lte = toDate;
+  }
+
+  const runs = await prisma.calibrationRun.findMany({
+    where,
+    select: {
+      id: true,
+      runDate: true,
+      mapSnapshot: true,
+    },
+    orderBy: { completedAt: 'asc' },
+  });
+
+  return runs
+    .filter((r) => r.mapSnapshot !== null)
+    .map((r) => {
+      const snapshot = r.mapSnapshot as unknown as MAPResult;
+      return {
+        runId: r.id,
+        runDate: r.runDate,
+        overallMAP: snapshot.overallMAP,
+        perClass: snapshot.perClass,
+      };
+    });
+}
+
+export async function getMapSnapshot(
+  calibrationRunId: string,
+): Promise<MAPResult | null> {
+  const run = await prisma.calibrationRun.findUnique({
+    where: { id: calibrationRunId },
+    select: { mapSnapshot: true },
+  });
+
+  if (!run || run.mapSnapshot === null) return null;
+
+  return run.mapSnapshot as unknown as MAPResult;
+}

--- a/src/services/metrics/map.service.ts
+++ b/src/services/metrics/map.service.ts
@@ -1,0 +1,90 @@
+import {
+  calculatePrecisionRecall,
+  MIN_INSTANCES,
+} from './precision-recall';
+import type {
+  AnnotatedZone,
+  PredictedZone,
+  MAPResult,
+  ClassAPResult,
+} from './ml-metrics.types';
+import type { CanonicalZoneType } from '../zone-extractor/types';
+
+const ALL_ZONE_TYPES: CanonicalZoneType[] = [
+  'paragraph',
+  'section-header',
+  'table',
+  'figure',
+  'caption',
+  'footnote',
+  'header',
+  'footer',
+];
+
+export function calculateMAP(
+  groundTruth: AnnotatedZone[],
+  predictions: PredictedZone[],
+): MAPResult {
+  // Group by zoneType
+  const gtByType = new Map<CanonicalZoneType, AnnotatedZone[]>();
+  for (const gt of groundTruth) {
+    const arr = gtByType.get(gt.zoneType) ?? [];
+    arr.push(gt);
+    gtByType.set(gt.zoneType, arr);
+  }
+
+  const predByType = new Map<CanonicalZoneType, PredictedZone[]>();
+  for (const pred of predictions) {
+    const arr = predByType.get(pred.zoneType) ?? [];
+    arr.push(pred);
+    predByType.set(pred.zoneType, arr);
+  }
+
+  const perClass: ClassAPResult[] = [];
+  const insufficientDataWarnings: string[] = [];
+
+  for (const zoneType of ALL_ZONE_TYPES) {
+    const gtForType = gtByType.get(zoneType) ?? [];
+    const predForType = predByType.get(zoneType) ?? [];
+    const insufficientData = gtForType.length < MIN_INSTANCES;
+
+    let ap: number;
+    if (insufficientData) {
+      ap = 0;
+      if (gtForType.length > 0 || predForType.length > 0) {
+        insufficientDataWarnings.push(
+          `${zoneType}: only ${gtForType.length} ground truth instances (minimum ${MIN_INSTANCES} required)`,
+        );
+      }
+    } else {
+      const curve = calculatePrecisionRecall(gtForType, predForType);
+      ap = curve.ap;
+    }
+
+    perClass.push({
+      zoneType,
+      ap,
+      groundTruthCount: gtForType.length,
+      predictionCount: predForType.length,
+      insufficientData,
+    });
+  }
+
+  const validClasses = perClass.filter((c) => !c.insufficientData);
+  let overallMAP: number;
+  if (validClasses.length === 0) {
+    overallMAP = 0;
+  } else {
+    overallMAP =
+      validClasses.reduce((sum, c) => sum + c.ap, 0) / validClasses.length;
+  }
+  overallMAP = Math.round(overallMAP * 10000) / 10000;
+
+  return {
+    overallMAP,
+    perClass,
+    insufficientDataWarnings,
+    groundTruthTotal: groundTruth.length,
+    predictionTotal: predictions.length,
+  };
+}

--- a/src/services/metrics/ml-metrics.types.ts
+++ b/src/services/metrics/ml-metrics.types.ts
@@ -1,0 +1,41 @@
+import type { BBox } from '../calibration/iou';
+import type { CanonicalZoneType } from '../zone-extractor/types';
+
+export interface AnnotatedZone {
+  pageNumber: number;
+  bbox: BBox;
+  zoneType: CanonicalZoneType;
+}
+
+export interface PredictedZone {
+  pageNumber: number;
+  bbox: BBox;
+  zoneType: CanonicalZoneType;
+  confidence: number;
+}
+
+export interface ClassAPResult {
+  zoneType: CanonicalZoneType;
+  ap: number;
+  groundTruthCount: number;
+  predictionCount: number;
+  insufficientData: boolean;
+}
+
+export interface MAPResult {
+  overallMAP: number;
+  perClass: ClassAPResult[];
+  insufficientDataWarnings: string[];
+  groundTruthTotal: number;
+  predictionTotal: number;
+}
+
+export interface PRPoint {
+  precision: number;
+  recall: number;
+}
+
+export interface PRCurve {
+  points: PRPoint[];
+  ap: number;
+}

--- a/src/services/metrics/precision-recall.ts
+++ b/src/services/metrics/precision-recall.ts
@@ -1,0 +1,84 @@
+import { calculateIoU } from '../calibration/iou';
+import type { AnnotatedZone, PredictedZone, PRCurve } from './ml-metrics.types';
+
+export const IOU_THRESHOLD = 0.5;
+export const MIN_INSTANCES = 5;
+
+export function calculatePrecisionRecall(
+  groundTruth: AnnotatedZone[],
+  predictions: PredictedZone[],
+  iouThreshold = IOU_THRESHOLD,
+): PRCurve {
+  if (groundTruth.length === 0) {
+    return { points: [], ap: 0 };
+  }
+
+  // Sort predictions by confidence descending
+  const sorted = [...predictions].sort(
+    (a, b) => b.confidence - a.confidence,
+  );
+
+  const matchedGT = new Set<number>();
+  let tp = 0;
+  let fp = 0;
+  const tpCumulative: number[] = [];
+  const fpCumulative: number[] = [];
+
+  for (const pred of sorted) {
+    let bestIoU = 0;
+    let bestGTIdx = -1;
+
+    for (let gi = 0; gi < groundTruth.length; gi++) {
+      if (matchedGT.has(gi)) continue;
+      const gt = groundTruth[gi];
+      if (gt.pageNumber !== pred.pageNumber) continue;
+      if (gt.zoneType !== pred.zoneType) continue;
+
+      const iou = calculateIoU(gt.bbox, pred.bbox);
+      if (iou > bestIoU) {
+        bestIoU = iou;
+        bestGTIdx = gi;
+      }
+    }
+
+    if (bestIoU >= iouThreshold && bestGTIdx !== -1) {
+      matchedGT.add(bestGTIdx);
+      tp++;
+    } else {
+      fp++;
+    }
+
+    tpCumulative.push(tp);
+    fpCumulative.push(fp);
+  }
+
+  const total = groundTruth.length;
+  const points = tpCumulative.map((tpVal, i) => ({
+    precision: tpVal / (tpVal + fpCumulative[i]),
+    recall: tpVal / total,
+  }));
+
+  // Compute AP via trapezoidal integration
+  // Prepend origin (recall=0, precision=first point's precision)
+  // to capture area from recall=0 to the first recall value.
+  let ap: number;
+  if (points.length === 0) {
+    ap = 0;
+  } else {
+    const sortedPoints = [...points].sort((a, b) => a.recall - b.recall);
+    // Add origin point to capture the full area under the curve
+    const withOrigin = [
+      { precision: sortedPoints[0].precision, recall: 0 },
+      ...sortedPoints,
+    ];
+    ap = 0;
+    for (let i = 1; i < withOrigin.length; i++) {
+      const deltaRecall = withOrigin[i].recall - withOrigin[i - 1].recall;
+      const avgPrecision =
+        (withOrigin[i].precision + withOrigin[i - 1].precision) / 2;
+      ap += deltaRecall * avgPrecision;
+    }
+  }
+
+  return { points, ap: Math.min(1, Math.max(0, ap)) };
+}

--- a/tests/unit/services/metrics/map-persistence.test.ts
+++ b/tests/unit/services/metrics/map-persistence.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockUpdate = vi.fn();
+const mockFindUnique = vi.fn();
+const mockFindMany = vi.fn();
+
+vi.mock('../../../../src/lib/prisma', () => ({
+  default: {
+    calibrationRun: {
+      update: (...args: unknown[]) => mockUpdate(...args),
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+    },
+  },
+  Prisma: {
+    DbNull: 'DbNull',
+  },
+}));
+
+import {
+  saveMapSnapshot,
+  getMapSnapshot,
+  getMapHistory,
+} from '../../../../src/services/metrics/map-persistence';
+import type { MAPResult } from '../../../../src/services/metrics/ml-metrics.types';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const sampleResult: MAPResult = {
+  overallMAP: 0.85,
+  perClass: [],
+  insufficientDataWarnings: [],
+  groundTruthTotal: 40,
+  predictionTotal: 42,
+};
+
+describe('saveMapSnapshot', () => {
+  it('calls prisma.calibrationRun.update with correct args', async () => {
+    mockUpdate.mockResolvedValue({});
+    await saveMapSnapshot('run-1', sampleResult);
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'run-1' },
+      data: { mapSnapshot: sampleResult },
+    });
+  });
+});
+
+describe('getMapSnapshot', () => {
+  it('returns null when run not found', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    const result = await getMapSnapshot('missing-id');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when mapSnapshot is null', async () => {
+    mockFindUnique.mockResolvedValue({ mapSnapshot: null });
+    const result = await getMapSnapshot('run-1');
+    expect(result).toBeNull();
+  });
+});
+
+describe('getMapHistory', () => {
+  it('returns results ordered by completedAt asc', async () => {
+    const runs = [
+      { id: 'r1', runDate: new Date('2026-01-01'), mapSnapshot: { overallMAP: 0.7, perClass: [] } },
+      { id: 'r2', runDate: new Date('2026-02-01'), mapSnapshot: { overallMAP: 0.8, perClass: [] } },
+    ];
+    mockFindMany.mockResolvedValue(runs);
+
+    const result = await getMapHistory();
+    expect(result).toHaveLength(2);
+    expect(result[0].runId).toBe('r1');
+    expect(result[1].runId).toBe('r2');
+  });
+
+  it('filters by fromDate correctly', async () => {
+    const runs = [
+      { id: 'r2', runDate: new Date('2026-02-01'), mapSnapshot: { overallMAP: 0.8, perClass: [] } },
+      { id: 'r3', runDate: new Date('2026-03-01'), mapSnapshot: { overallMAP: 0.9, perClass: [] } },
+    ];
+    mockFindMany.mockResolvedValue(runs);
+
+    const from = new Date('2026-01-15');
+    const result = await getMapHistory(from);
+    expect(result).toHaveLength(2);
+    // Verify the findMany was called with gte filter
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          completedAt: expect.objectContaining({ gte: from }),
+        }),
+      }),
+    );
+  });
+});

--- a/tests/unit/services/metrics/map.service.test.ts
+++ b/tests/unit/services/metrics/map.service.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { calculateMAP } from '../../../../src/services/metrics/map.service';
+import type {
+  AnnotatedZone,
+  PredictedZone,
+} from '../../../../src/services/metrics/ml-metrics.types';
+import type { CanonicalZoneType } from '../../../../src/services/zone-extractor/types';
+
+const ALL_TYPES: CanonicalZoneType[] = [
+  'paragraph', 'section-header', 'table', 'figure',
+  'caption', 'footnote', 'header', 'footer',
+];
+
+function makeGT(zoneType: CanonicalZoneType, idx: number): AnnotatedZone {
+  return {
+    pageNumber: 1,
+    bbox: { x: idx * 20, y: 0, w: 10, h: 10 },
+    zoneType,
+  };
+}
+
+function makePred(zoneType: CanonicalZoneType, idx: number, confidence = 0.9): PredictedZone {
+  return {
+    pageNumber: 1,
+    bbox: { x: idx * 20, y: 0, w: 10, h: 10 },
+    zoneType,
+    confidence,
+  };
+}
+
+describe('calculateMAP', () => {
+  it('all types with sufficient data → overallMAP close to 1.0', () => {
+    const gt: AnnotatedZone[] = [];
+    const pred: PredictedZone[] = [];
+
+    for (const type of ALL_TYPES) {
+      for (let i = 0; i < 5; i++) {
+        gt.push(makeGT(type, i + ALL_TYPES.indexOf(type) * 10));
+        pred.push(makePred(type, i + ALL_TYPES.indexOf(type) * 10));
+      }
+    }
+
+    const result = calculateMAP(gt, pred);
+    expect(result.overallMAP).toBeCloseTo(1.0, 1);
+    expect(result.insufficientDataWarnings).toHaveLength(0);
+    expect(result.perClass).toHaveLength(8);
+    expect(result.perClass.every((c) => !c.insufficientData)).toBe(true);
+  });
+
+  it('insufficient data warning for footnote', () => {
+    const gt: AnnotatedZone[] = [];
+    const pred: PredictedZone[] = [];
+
+    for (const type of ALL_TYPES) {
+      const count = type === 'footnote' ? 3 : 5;
+      for (let i = 0; i < count; i++) {
+        gt.push(makeGT(type, i + ALL_TYPES.indexOf(type) * 10));
+        pred.push(makePred(type, i + ALL_TYPES.indexOf(type) * 10));
+      }
+    }
+
+    const result = calculateMAP(gt, pred);
+    const footnoteClass = result.perClass.find((c) => c.zoneType === 'footnote')!;
+    expect(footnoteClass.insufficientData).toBe(true);
+    expect(footnoteClass.ap).toBe(0);
+    expect(
+      result.insufficientDataWarnings.some((w) => w.includes('footnote')),
+    ).toBe(true);
+    // overallMAP should exclude footnote — still close to 1.0
+    expect(result.overallMAP).toBeGreaterThan(0.9);
+  });
+
+  it('all types insufficient → overallMAP = 0', () => {
+    const gt: AnnotatedZone[] = [];
+    const pred: PredictedZone[] = [];
+
+    for (const type of ALL_TYPES) {
+      for (let i = 0; i < 2; i++) {
+        gt.push(makeGT(type, i));
+        pred.push(makePred(type, i));
+      }
+    }
+
+    const result = calculateMAP(gt, pred);
+    expect(result.overallMAP).toBe(0);
+    expect(result.perClass.every((c) => c.insufficientData)).toBe(true);
+    expect(result.insufficientDataWarnings).toHaveLength(8);
+  });
+
+  it('zero ground truth → overallMAP = 0', () => {
+    const result = calculateMAP([], []);
+    expect(result.overallMAP).toBe(0);
+    expect(result.perClass.every((c) => c.insufficientData)).toBe(true);
+  });
+
+  it('determinism: same inputs → identical results', () => {
+    const gt = ALL_TYPES.flatMap((type) =>
+      Array.from({ length: 5 }, (_, i) => makeGT(type, i + ALL_TYPES.indexOf(type) * 10)),
+    );
+    const pred = ALL_TYPES.flatMap((type) =>
+      Array.from({ length: 5 }, (_, i) => makePred(type, i + ALL_TYPES.indexOf(type) * 10)),
+    );
+
+    const r1 = calculateMAP(gt, pred);
+    const r2 = calculateMAP(gt, pred);
+    expect(r1).toEqual(r2);
+  });
+
+  it('overallMAP rounded to 4 decimal places', () => {
+    // Use mismatched counts to produce a non-round number
+    const gt: AnnotatedZone[] = [];
+    const pred: PredictedZone[] = [];
+
+    // Only paragraph with 7 GT, 5 matching preds + 2 wrong type
+    for (let i = 0; i < 7; i++) {
+      gt.push(makeGT('paragraph', i));
+    }
+    for (let i = 0; i < 5; i++) {
+      pred.push(makePred('paragraph', i, 0.9 - i * 0.1));
+    }
+    pred.push(makePred('paragraph', 100, 0.3)); // no matching GT
+    pred.push(makePred('paragraph', 101, 0.2)); // no matching GT
+
+    const result = calculateMAP(gt, pred);
+    const str = result.overallMAP.toString();
+    const decimals = str.includes('.') ? str.split('.')[1].length : 0;
+    expect(decimals).toBeLessThanOrEqual(4);
+  });
+});

--- a/tests/unit/services/metrics/precision-recall.test.ts
+++ b/tests/unit/services/metrics/precision-recall.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { calculatePrecisionRecall } from '../../../../src/services/metrics/precision-recall';
+import type {
+  AnnotatedZone,
+  PredictedZone,
+} from '../../../../src/services/metrics/ml-metrics.types';
+
+function makeGT(
+  zoneType: AnnotatedZone['zoneType'] = 'paragraph',
+  bbox = { x: 0, y: 0, w: 10, h: 10 },
+  pageNumber = 1,
+): AnnotatedZone {
+  return { pageNumber, bbox, zoneType };
+}
+
+function makePred(
+  zoneType: PredictedZone['zoneType'] = 'paragraph',
+  bbox = { x: 0, y: 0, w: 10, h: 10 },
+  confidence = 0.9,
+  pageNumber = 1,
+): PredictedZone {
+  return { pageNumber, bbox, zoneType, confidence };
+}
+
+describe('calculatePrecisionRecall', () => {
+  it('perfect detection → ap = 1.0', () => {
+    const gt = [makeGT()];
+    const pred = [makePred()];
+    const result = calculatePrecisionRecall(gt, pred);
+    expect(result.ap).toBe(1.0);
+    expect(result.points).toHaveLength(1);
+    expect(result.points[0].precision).toBe(1);
+    expect(result.points[0].recall).toBe(1);
+  });
+
+  it('zero precision: wrong type → ap = 0', () => {
+    const gt = [makeGT('paragraph')];
+    const pred = [makePred('table')];
+    const result = calculatePrecisionRecall(gt, pred);
+    expect(result.ap).toBe(0);
+  });
+
+  it('50% recall: 2 GT, 1 matching prediction', () => {
+    const gt = [
+      makeGT('paragraph', { x: 0, y: 0, w: 10, h: 10 }),
+      makeGT('paragraph', { x: 20, y: 0, w: 10, h: 10 }),
+    ];
+    const pred = [makePred('paragraph', { x: 0, y: 0, w: 10, h: 10 }, 0.9)];
+    const result = calculatePrecisionRecall(gt, pred);
+    expect(result.ap).toBeGreaterThan(0);
+    expect(result.ap).toBeLessThan(1);
+    // Max recall is 0.5
+    const maxRecall = Math.max(...result.points.map((p) => p.recall));
+    expect(maxRecall).toBe(0.5);
+  });
+
+  it('confidence ordering: both match → ap = 1.0', () => {
+    const gt = [
+      makeGT('paragraph', { x: 0, y: 0, w: 10, h: 10 }),
+      makeGT('paragraph', { x: 20, y: 0, w: 10, h: 10 }),
+    ];
+    const pred = [
+      makePred('paragraph', { x: 0, y: 0, w: 10, h: 10 }, 0.6),
+      makePred('paragraph', { x: 20, y: 0, w: 10, h: 10 }, 0.9),
+    ];
+    const result = calculatePrecisionRecall(gt, pred);
+    expect(result.ap).toBe(1.0);
+  });
+
+  it('no ground truth → ap = 0, empty points', () => {
+    const pred = [makePred()];
+    const result = calculatePrecisionRecall([], pred);
+    expect(result.ap).toBe(0);
+    expect(result.points).toEqual([]);
+  });
+
+  it('no predictions → ap = 0', () => {
+    const gt = [makeGT(), makeGT('paragraph', { x: 20, y: 0, w: 10, h: 10 })];
+    const result = calculatePrecisionRecall(gt, []);
+    expect(result.ap).toBe(0);
+  });
+
+  it('page number isolation: different pages → no match', () => {
+    const gt = [makeGT('paragraph', { x: 0, y: 0, w: 10, h: 10 }, 1)];
+    const pred = [makePred('paragraph', { x: 0, y: 0, w: 10, h: 10 }, 0.9, 2)];
+    const result = calculatePrecisionRecall(gt, pred);
+    expect(result.ap).toBe(0);
+  });
+
+  it('AP clamped to [0, 1]', () => {
+    const gt = [makeGT()];
+    const pred = [makePred()];
+    const result = calculatePrecisionRecall(gt, pred);
+    expect(result.ap).toBeGreaterThanOrEqual(0);
+    expect(result.ap).toBeLessThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Sprint ML-2: Story ML-2.5

### mAP@0.5 metrics
- `src/services/metrics/ml-metrics.types.ts` — AnnotatedZone, PredictedZone, ClassAPResult, MAPResult, PRCurve, PRPoint
- `src/services/metrics/precision-recall.ts` — PASCAL VOC AP calculation, trapezoidal integration with origin point, page-scoped matching, confidence-ordered sorting
- `src/services/metrics/map.service.ts` — calculateMAP() across all 8 zone types, insufficient data detection (< 5 instances), overallMAP excluding flagged classes, 4dp rounding
- `src/services/metrics/map-persistence.ts` — saveMapSnapshot(), getMapSnapshot(), getMapHistory() with date range filtering
- `src/routes/ml-metrics.routes.ts` — POST /ml-metrics/map, GET /ml-metrics/map/:runId, GET /ml-metrics/map-history, GET /ml-metrics/phase-gate (static thresholds)
- Registered at `/ml-metrics` in routes/index.ts

### Tests
- precision-recall.test.ts (8), map.service.test.ts (6), map-persistence.test.ts (5) = **19 tests**

**Depends on: PR #255 (feature/ml-docling-integration)**

Tests: 19/19 passing | TypeScript: 0 errors
Phase-gate endpoint: static (live queries in ML-3.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoints for calculating and retrieving Mean Average Precision (MAP) metrics
  * Added capability to view historical mAP snapshots with optional date filtering
  * Added phase-gate status endpoint with predefined criteria

* **Tests**
  * Added comprehensive unit test coverage for metrics calculation and persistence services
<!-- end of auto-generated comment: release notes by coderabbit.ai -->