### PR TITLE
feat(ml): ML-3.3 zone correction write-back API + training export

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -41,6 +41,8 @@ import pacReportRoutes from "./pac-report.routes";
 import zonesRoutes from "./zones.routes";
 import zoneExtractorRoutes from "./zone-extractor.routes";
 import calibrationRoutes from "./calibration.routes";
+import zoneCorrectionRoutes from "./zone-correction.routes";
+import trainingRoutes from "./training.routes";
 import mlMetricsRoutes from "./ml-metrics.routes";
 
 const router = Router();
@@ -142,6 +144,8 @@ router.use("/pdf", pacReportRoutes);
 router.use("/zones", zonesRoutes);
 router.use("/zone-extractor", zoneExtractorRoutes);
 router.use("/calibration", calibrationRoutes);
+router.use("/calibration", zoneCorrectionRoutes);
+router.use("/training", trainingRoutes);
 router.use("/ml-metrics", mlMetricsRoutes);
 
 export default router;

--- a/src/routes/training.routes.ts
+++ b/src/routes/training.routes.ts
@@ -1,0 +1,110 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { authenticate } from '../middleware/auth.middleware';
+import prisma from '../lib/prisma';
+
+const router = Router();
+
+const groundTruthQuerySchema = z.object({
+  runId: z.string().min(1),
+});
+
+// GET /api/v1/training/ground-truth
+router.get('/ground-truth', authenticate, async (req: Request, res: Response) => {
+  try {
+    const parsed = groundTruthQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(422).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Query validation failed',
+          details: parsed.error.issues,
+        },
+      });
+    }
+
+    const { runId } = parsed.data;
+
+    const zones = await prisma.zone.findMany({
+      where: {
+        calibrationRunId: runId,
+        operatorVerified: true,
+        isArtefact: false,
+      },
+    });
+
+    const mappedZones = zones.map((zone) => ({
+      pageNumber: zone.pageNumber,
+      bbox: zone.bounds,
+      label: zone.operatorLabel ?? zone.type,
+      confidence: 1.0,
+      source: 'operator' as const,
+    }));
+
+    return res.json({
+      success: true,
+      data: { zones: mappedZones, total: mappedZones.length },
+    });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
+// GET /api/v1/training/ground-truth/stats
+router.get('/ground-truth/stats', authenticate, async (req: Request, res: Response) => {
+  try {
+    const confirmedZones = await prisma.zone.findMany({
+      where: { operatorVerified: true, isArtefact: false },
+      select: { operatorLabel: true, type: true, calibrationRunId: true },
+    });
+
+    const totalConfirmed = confirmedZones.length;
+
+    // Group by zone type
+    const byZoneType: Record<string, number> = {};
+    for (const zone of confirmedZones) {
+      const label = zone.operatorLabel ?? zone.type;
+      byZoneType[label] = (byZoneType[label] ?? 0) + 1;
+    }
+
+    // Group by publisher via CalibrationRun → CorpusDocument
+    const runIds = [...new Set(confirmedZones.map((z) => z.calibrationRunId).filter(Boolean))] as string[];
+    const byPublisher: Record<string, number> = {};
+
+    if (runIds.length > 0) {
+      const runs = await prisma.calibrationRun.findMany({
+        where: { id: { in: runIds } },
+        select: { id: true, corpusDocument: { select: { publisher: true } } },
+      });
+
+      const runPublisherMap = new Map<string, string | null>();
+      for (const run of runs) {
+        runPublisherMap.set(run.id, run.corpusDocument.publisher);
+      }
+
+      for (const zone of confirmedZones) {
+        if (!zone.calibrationRunId) continue;
+        const publisher = runPublisherMap.get(zone.calibrationRunId);
+        if (publisher != null) {
+          byPublisher[publisher] = (byPublisher[publisher] ?? 0) + 1;
+        }
+      }
+    }
+
+    return res.json({
+      success: true,
+      data: { totalConfirmed, byZoneType, byPublisher },
+    });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
+export default router;

--- a/src/routes/zone-correction.routes.ts
+++ b/src/routes/zone-correction.routes.ts
@@ -1,0 +1,162 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { authenticate } from '../middleware/auth.middleware';
+import prisma, { Prisma } from '../lib/prisma';
+
+const router = Router();
+
+// POST /api/v1/calibration/zones/:zoneId/confirm
+router.post('/zones/:zoneId/confirm', authenticate, async (req: Request, res: Response) => {
+  try {
+    const { zoneId } = req.params;
+    const operatorId = req.user!.id;
+
+    const zone = await prisma.zone.findUnique({ where: { id: zoneId } });
+    if (!zone) {
+      return res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Zone not found' },
+      });
+    }
+
+    const updated = await prisma.zone.update({
+      where: { id: zoneId },
+      data: {
+        operatorVerified: true,
+        operatorLabel: zone.operatorLabel ?? zone.type,
+        verifiedAt: new Date(),
+        verifiedBy: operatorId,
+      },
+    });
+
+    return res.json({ success: true, data: updated });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
+const correctBodySchema = z.object({
+  newLabel: z.string().min(1),
+  bbox: z.object({
+    x: z.number(),
+    y: z.number(),
+    w: z.number(),
+    h: z.number(),
+  }).optional(),
+});
+
+// POST /api/v1/calibration/zones/:zoneId/correct
+router.post('/zones/:zoneId/correct', authenticate, async (req: Request, res: Response) => {
+  try {
+    const { zoneId } = req.params;
+    const operatorId = req.user!.id;
+
+    const parsed = correctBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(422).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Request validation failed',
+          details: parsed.error.issues,
+        },
+      });
+    }
+
+    const { newLabel, bbox } = parsed.data;
+
+    const zone = await prisma.zone.findUnique({ where: { id: zoneId } });
+    if (!zone) {
+      return res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Zone not found' },
+      });
+    }
+
+    const updated = await prisma.zone.update({
+      where: { id: zoneId },
+      data: {
+        operatorVerified: true,
+        operatorLabel: newLabel,
+        operatorBbox: bbox ?? Prisma.DbNull,
+        verifiedAt: new Date(),
+        verifiedBy: operatorId,
+      },
+    });
+
+    return res.json({ success: true, data: updated });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
+// POST /api/v1/calibration/zones/:zoneId/reject
+router.post('/zones/:zoneId/reject', authenticate, async (req: Request, res: Response) => {
+  try {
+    const { zoneId } = req.params;
+    const operatorId = req.user!.id;
+
+    const zone = await prisma.zone.findUnique({ where: { id: zoneId } });
+    if (!zone) {
+      return res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Zone not found' },
+      });
+    }
+
+    const updated = await prisma.zone.update({
+      where: { id: zoneId },
+      data: {
+        isArtefact: true,
+        verifiedAt: new Date(),
+        verifiedBy: operatorId,
+      },
+    });
+
+    return res.json({ success: true, data: updated });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
+// POST /api/v1/calibration/runs/:runId/confirm-all-green
+// Approach: updateMany for boolean/datetime fields.
+// operatorLabel is not set per-zone — at display time the frontend
+// falls back to zone.type when operatorLabel is null.
+router.post('/runs/:runId/confirm-all-green', authenticate, async (req: Request, res: Response) => {
+  try {
+    const { runId } = req.params;
+    const operatorId = req.user!.id;
+
+    const result = await prisma.zone.updateMany({
+      where: {
+        calibrationRunId: runId,
+        reconciliationBucket: 'GREEN',
+        operatorVerified: false,
+      },
+      data: {
+        operatorVerified: true,
+        verifiedAt: new Date(),
+        verifiedBy: operatorId,
+      },
+    });
+
+    return res.json({ success: true, data: { confirmedCount: result.count } });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
+export default router;

--- a/tests/unit/routes/training.routes.test.ts
+++ b/tests/unit/routes/training.routes.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mockZoneFindMany = vi.fn();
+const mockZoneCount = vi.fn();
+const mockCalibrationRunFindMany = vi.fn();
+
+vi.mock('../../../src/lib/prisma', () => ({
+  default: {
+    zone: {
+      findMany: (...args: unknown[]) => mockZoneFindMany(...args),
+      count: (...args: unknown[]) => mockZoneCount(...args),
+    },
+    calibrationRun: {
+      findMany: (...args: unknown[]) => mockCalibrationRunFindMany(...args),
+    },
+  },
+}));
+
+vi.mock('../../../src/middleware/auth.middleware', () => ({
+  authenticate: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: 'operator-test-id', tenantId: 'tenant-1' } as never;
+    next();
+  },
+}));
+
+import trainingRoutes from '../../../src/routes/training.routes';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/training', trainingRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /training/ground-truth', () => {
+  it('returns only operatorVerified=true, isArtefact=false zones in YOLO format', async () => {
+    mockZoneFindMany.mockResolvedValue([
+      {
+        pageNumber: 1,
+        bounds: { x: 10, y: 20, w: 100, h: 50 },
+        type: 'paragraph',
+        operatorLabel: 'section-header',
+      },
+    ]);
+
+    const app = buildApp();
+    const res = await request(app).get('/training/ground-truth?runId=run-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.zones).toHaveLength(1);
+    expect(res.body.data.total).toBe(1);
+
+    // Verify the where clause
+    expect(mockZoneFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          calibrationRunId: 'run-1',
+          operatorVerified: true,
+          isArtefact: false,
+        },
+      }),
+    );
+  });
+
+  it('returns confidence=1.0 and source=operator', async () => {
+    mockZoneFindMany.mockResolvedValue([
+      {
+        pageNumber: 1,
+        bounds: { x: 0, y: 0, w: 10, h: 10 },
+        type: 'table',
+        operatorLabel: 'table',
+      },
+    ]);
+
+    const app = buildApp();
+    const res = await request(app).get('/training/ground-truth?runId=run-1');
+
+    const zone = res.body.data.zones[0];
+    expect(zone.confidence).toBe(1.0);
+    expect(zone.source).toBe('operator');
+  });
+
+  it('uses operatorLabel when present, falls back to type', async () => {
+    mockZoneFindMany.mockResolvedValue([
+      {
+        pageNumber: 1,
+        bounds: { x: 0, y: 0, w: 10, h: 10 },
+        type: 'paragraph',
+        operatorLabel: 'caption',
+      },
+      {
+        pageNumber: 2,
+        bounds: { x: 0, y: 0, w: 10, h: 10 },
+        type: 'figure',
+        operatorLabel: null,
+      },
+    ]);
+
+    const app = buildApp();
+    const res = await request(app).get('/training/ground-truth?runId=run-1');
+
+    expect(res.body.data.zones[0].label).toBe('caption');
+    expect(res.body.data.zones[1].label).toBe('figure');
+  });
+
+  it('returns 422 when runId is missing', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/training/ground-truth');
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('GET /training/ground-truth/stats', () => {
+  it('totalConfirmed count correct', async () => {
+    mockZoneFindMany.mockResolvedValue([
+      { operatorLabel: 'paragraph', type: 'paragraph', calibrationRunId: null },
+      { operatorLabel: null, type: 'table', calibrationRunId: null },
+      { operatorLabel: 'figure', type: 'figure', calibrationRunId: null },
+    ]);
+    mockCalibrationRunFindMany.mockResolvedValue([]);
+
+    const app = buildApp();
+    const res = await request(app).get('/training/ground-truth/stats');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.totalConfirmed).toBe(3);
+  });
+
+  it('byZoneType groups correctly', async () => {
+    mockZoneFindMany.mockResolvedValue([
+      { operatorLabel: 'paragraph', type: 'paragraph', calibrationRunId: null },
+      { operatorLabel: 'paragraph', type: 'paragraph', calibrationRunId: null },
+      { operatorLabel: null, type: 'table', calibrationRunId: null },
+    ]);
+    mockCalibrationRunFindMany.mockResolvedValue([]);
+
+    const app = buildApp();
+    const res = await request(app).get('/training/ground-truth/stats');
+
+    expect(res.body.data.byZoneType).toEqual({
+      paragraph: 2,
+      table: 1,
+    });
+  });
+});

--- a/tests/unit/routes/zone-correction.routes.test.ts
+++ b/tests/unit/routes/zone-correction.routes.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mockZoneFindUnique = vi.fn();
+const mockZoneUpdate = vi.fn();
+const mockZoneUpdateMany = vi.fn();
+
+vi.mock('../../../src/lib/prisma', () => ({
+  default: {
+    zone: {
+      findUnique: (...args: unknown[]) => mockZoneFindUnique(...args),
+      update: (...args: unknown[]) => mockZoneUpdate(...args),
+      updateMany: (...args: unknown[]) => mockZoneUpdateMany(...args),
+    },
+  },
+  Prisma: {
+    DbNull: 'DbNull',
+  },
+}));
+
+vi.mock('../../../src/middleware/auth.middleware', () => ({
+  authenticate: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: 'operator-test-id', tenantId: 'tenant-1' } as never;
+    next();
+  },
+}));
+
+import zoneCorrectionRoutes from '../../../src/routes/zone-correction.routes';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/calibration', zoneCorrectionRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /calibration/zones/:zoneId/confirm', () => {
+  it('sets operatorVerified=true and verifiedBy', async () => {
+    const zone = { id: 'z1', type: 'paragraph', operatorLabel: null };
+    mockZoneFindUnique.mockResolvedValue(zone);
+    mockZoneUpdate.mockResolvedValue({
+      ...zone,
+      operatorVerified: true,
+      operatorLabel: 'paragraph',
+      verifiedBy: 'operator-test-id',
+    });
+
+    const app = buildApp();
+    const res = await request(app).post('/calibration/zones/z1/confirm');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.operatorVerified).toBe(true);
+    expect(res.body.data.verifiedBy).toBe('operator-test-id');
+    expect(mockZoneUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'z1' },
+        data: expect.objectContaining({
+          operatorVerified: true,
+          operatorLabel: 'paragraph',
+          verifiedBy: 'operator-test-id',
+        }),
+      }),
+    );
+  });
+
+  it('returns 404 when zone not found', async () => {
+    mockZoneFindUnique.mockResolvedValue(null);
+
+    const app = buildApp();
+    const res = await request(app).post('/calibration/zones/missing/confirm');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+});
+
+describe('POST /calibration/zones/:zoneId/correct', () => {
+  it('updates operatorLabel, preserves doclingLabel', async () => {
+    const zone = { id: 'z1', type: 'paragraph', doclingLabel: 'Text', operatorLabel: null };
+    mockZoneFindUnique.mockResolvedValue(zone);
+    mockZoneUpdate.mockResolvedValue({
+      ...zone,
+      operatorVerified: true,
+      operatorLabel: 'section-header',
+      doclingLabel: 'Text',
+      verifiedBy: 'operator-test-id',
+    });
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/calibration/zones/z1/correct')
+      .send({ newLabel: 'section-header' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.operatorLabel).toBe('section-header');
+    expect(res.body.data.doclingLabel).toBe('Text');
+    expect(mockZoneUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          operatorVerified: true,
+          operatorLabel: 'section-header',
+        }),
+      }),
+    );
+    // Verify doclingLabel is NOT in the update data
+    const updateCall = mockZoneUpdate.mock.calls[0][0];
+    expect(updateCall.data).not.toHaveProperty('doclingLabel');
+    expect(updateCall.data).not.toHaveProperty('pdfxtLabel');
+  });
+
+  it('returns 422 for missing newLabel', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/calibration/zones/z1/correct')
+      .send({});
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('POST /calibration/zones/:zoneId/reject', () => {
+  it('sets isArtefact=true and verifiedBy', async () => {
+    const zone = { id: 'z1', type: 'paragraph' };
+    mockZoneFindUnique.mockResolvedValue(zone);
+    mockZoneUpdate.mockResolvedValue({
+      ...zone,
+      isArtefact: true,
+      verifiedBy: 'operator-test-id',
+    });
+
+    const app = buildApp();
+    const res = await request(app).post('/calibration/zones/z1/reject');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.isArtefact).toBe(true);
+    expect(res.body.data.verifiedBy).toBe('operator-test-id');
+  });
+
+  it('returns 404 when zone not found', async () => {
+    mockZoneFindUnique.mockResolvedValue(null);
+
+    const app = buildApp();
+    const res = await request(app).post('/calibration/zones/missing/reject');
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /calibration/runs/:runId/confirm-all-green', () => {
+  it('confirms all GREEN unverified zones', async () => {
+    mockZoneUpdateMany.mockResolvedValue({ count: 3 });
+
+    const app = buildApp();
+    const res = await request(app).post('/calibration/runs/run-1/confirm-all-green');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.confirmedCount).toBe(3);
+    expect(mockZoneUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          calibrationRunId: 'run-1',
+          reconciliationBucket: 'GREEN',
+          operatorVerified: false,
+        },
+      }),
+    );
+  });
+
+  it('excludes already verified zones', async () => {
+    mockZoneUpdateMany.mockResolvedValue({ count: 0 });
+
+    const app = buildApp();
+    const res = await request(app).post('/calibration/runs/run-1/confirm-all-green');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.confirmedCount).toBe(0);
+    // Verify operatorVerified: false is in the where clause
+    expect(mockZoneUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ operatorVerified: false }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- POST `/calibration/zones/:zoneId/confirm` — operator confirms a zone prediction
- POST `/calibration/zones/:zoneId/correct` — operator corrects zone label/bbox
- POST `/calibration/zones/:zoneId/reject` — marks zone as artefact
- POST `/calibration/runs/:runId/confirm-all-green` — bulk confirm GREEN zones
- GET `/training/ground-truth?runId=` — YOLO-format training export (confidence=1.0, source=operator)
- GET `/training/ground-truth/stats` — confirmed zone stats by type/publisher

## Test plan
- [ ] 8 unit tests in `tests/unit/routes/zone-correction.routes.test.ts`
- [ ] 6 unit tests in `tests/unit/routes/training.routes.test.ts`
- [ ] Verify confirm/correct/reject mutations update DB correctly
- [ ] Verify training export returns YOLO-format with operator labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added training endpoints for retrieving ground truth zones and computing zone statistics.
  * Added zone correction endpoints for confirming, correcting, and rejecting individual zones, plus bulk confirmation capability.

* **Tests**
  * Added comprehensive unit tests for training and zone correction routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->