### PR TITLE
feat(ml): ML-3.7 live phase gate endpoint

### DIFF
--- a/src/routes/ml-metrics.routes.ts
+++ b/src/routes/ml-metrics.routes.ts
@@ -8,6 +8,7 @@ import {
   getMapSnapshot,
   getMapHistory,
 } from '../services/metrics/map-persistence';
+import { getPhaseGateStatus } from '../services/metrics/phase-gate.service';
 import type { AnnotatedZone, PredictedZone } from '../services/metrics/ml-metrics.types';
 import type { BBox } from '../services/calibration/iou';
 import type { CanonicalZoneType } from '../services/zone-extractor/types';
@@ -133,55 +134,15 @@ router.get('/map-history', async (req: Request, res: Response) => {
 
 // GET /api/v1/ml-metrics/phase-gate
 router.get('/phase-gate', async (_req: Request, res: Response) => {
-  return res.json({
-    success: true,
-    data: {
-      criteria: [
-        {
-          id: 'C1',
-          label: 'Overall mAP ≥75%',
-          status: 'AMBER',
-          currentValue: 'pending',
-          threshold: '75%',
-          tooltip: 'Run POST /ml-metrics/map to compute',
-        },
-        {
-          id: 'C2',
-          label: 'All 8 zone types ≥30 instances',
-          status: 'AMBER',
-          currentValue: 'pending',
-          threshold: '30 per type',
-          tooltip: 'Requires 300+ annotated pages',
-        },
-        {
-          id: 'C3',
-          label: 'Publisher diversity ≥3',
-          status: 'AMBER',
-          currentValue: 'pending',
-          threshold: '3 publishers',
-          tooltip: 'Pending corpus',
-        },
-        {
-          id: 'C4',
-          label: 'Content type diversity ≥3',
-          status: 'AMBER',
-          currentValue: 'pending',
-          threshold: '3 content types',
-          tooltip: 'Pending corpus',
-        },
-        {
-          id: 'C5',
-          label: 'Write quality pass rate ≥95%',
-          status: 'AMBER',
-          currentValue: 'pending',
-          threshold: '95% PAC 2024',
-          tooltip: 'Pending pikepdf spike (ML-3.8)',
-        },
-      ],
-      overallStatus: 'AMBER',
-      readyForPhase2: false,
-    },
-  });
+  try {
+    const status = await getPhaseGateStatus();
+    return res.json({ success: true, data: status });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
 });
 
 export default router;

--- a/src/services/metrics/phase-gate.service.ts
+++ b/src/services/metrics/phase-gate.service.ts
@@ -1,0 +1,160 @@
+import prisma, { Prisma } from '../../lib/prisma';
+
+export type CriterionStatus = 'GREEN' | 'AMBER' | 'RED';
+
+export interface PhaseCriterion {
+  id: string;
+  label: string;
+  status: CriterionStatus;
+  currentValue: string;
+  threshold: string;
+  tooltip: string;
+}
+
+export interface PhaseGateStatus {
+  criteria: PhaseCriterion[];
+  overallStatus: CriterionStatus;
+  readyForPhase2: boolean;
+}
+
+const ALL_ZONE_TYPES = [
+  'paragraph', 'section-header', 'table', 'figure',
+  'caption', 'footnote', 'header', 'footer',
+];
+
+export async function getPhaseGateStatus(): Promise<PhaseGateStatus> {
+  const [latestMapRun, zoneCounts, publishers, contentTypes, spikeRun] =
+    await Promise.all([
+      // C1: latest CalibrationRun with mapSnapshot
+      prisma.calibrationRun.findFirst({
+        where: { mapSnapshot: { not: Prisma.DbNull } },
+        orderBy: { completedAt: 'desc' },
+        select: { mapSnapshot: true },
+      }),
+      // C2: confirmed zone counts by type
+      prisma.zone.groupBy({
+        by: ['type'],
+        where: { operatorVerified: true, isArtefact: false },
+        _count: { id: true },
+      }),
+      // C3: distinct publishers
+      prisma.corpusDocument.findMany({
+        select: { publisher: true },
+        distinct: ['publisher'],
+        where: { publisher: { not: null } },
+      }),
+      // C4: distinct content types
+      prisma.corpusDocument.findMany({
+        select: { contentType: true },
+        distinct: ['contentType'],
+        where: { contentType: { not: null } },
+      }),
+      // C5: latest pikepdf spike run
+      prisma.calibrationRun.findFirst({
+        where: { type: 'PIKE_PDF_SPIKE' },
+        orderBy: { completedAt: 'desc' },
+        select: { summary: true },
+      }),
+    ]);
+
+  // --- C1: Overall mAP ≥75% ---
+  let c1Status: CriterionStatus = 'RED';
+  let c1Value = 'Not yet computed';
+  const mapSnapshot = latestMapRun?.mapSnapshot as Record<string, unknown> | null;
+  const overallMAP = typeof mapSnapshot?.overallMAP === 'number' ? mapSnapshot.overallMAP : null;
+  if (overallMAP !== null) {
+    c1Value = `${(overallMAP * 100).toFixed(1)}%`;
+    if (overallMAP >= 0.75) c1Status = 'GREEN';
+    else if (overallMAP >= 0.70) c1Status = 'AMBER';
+  }
+
+  // --- C2: All 8 zone types ≥30 confirmed instances ---
+  const countMap = new Map<string, number>();
+  for (const row of zoneCounts) {
+    countMap.set(row.type, row._count.id);
+  }
+  const counts = ALL_ZONE_TYPES.map((t) => countMap.get(t) ?? 0);
+  const minCount = Math.min(...counts);
+  const typesAbove30 = counts.filter((c) => c >= 30).length;
+  let c2Status: CriterionStatus = 'RED';
+  if (minCount >= 30) c2Status = 'GREEN';
+  else if (minCount >= 15) c2Status = 'AMBER';
+
+  // --- C3: Publisher diversity ≥3 ---
+  const publisherCount = publishers.length;
+  let c3Status: CriterionStatus = 'RED';
+  if (publisherCount >= 3) c3Status = 'GREEN';
+  else if (publisherCount === 2) c3Status = 'AMBER';
+
+  // --- C4: Content type diversity ≥3 ---
+  const contentTypeCount = contentTypes.length;
+  let c4Status: CriterionStatus = 'RED';
+  if (contentTypeCount >= 3) c4Status = 'GREEN';
+  else if (contentTypeCount === 2) c4Status = 'AMBER';
+
+  // --- C5: Write quality pass rate ≥95% ---
+  let c5Status: CriterionStatus = 'AMBER';
+  let c5Value = 'Spike not yet run';
+  let c5Tooltip = 'Run the pikepdf write spike (ML-3.8)';
+  const spikeSummary = spikeRun?.summary as Record<string, unknown> | null;
+  const passRate = typeof spikeSummary?.passRate === 'number' ? spikeSummary.passRate : null;
+  if (passRate !== null) {
+    c5Value = `${(passRate * 100).toFixed(1)}% pass rate`;
+    if (passRate >= 0.95) {
+      c5Status = 'GREEN';
+      c5Tooltip = 'pikepdf write spike passed — ready for Phase 2';
+    } else {
+      c5Status = 'RED';
+      c5Tooltip = 'pikepdf spike failed — review failure report';
+    }
+  }
+
+  const criteria: PhaseCriterion[] = [
+    {
+      id: 'C1',
+      label: 'Overall mAP ≥75%',
+      status: c1Status,
+      currentValue: c1Value,
+      threshold: '75%',
+      tooltip: 'Run POST /ml-metrics/metrics/map on a calibration run to compute mAP',
+    },
+    {
+      id: 'C2',
+      label: 'All 8 zone types ≥30 instances',
+      status: c2Status,
+      currentValue: `Min: ${minCount} instances (${typesAbove30}/8 types at target)`,
+      threshold: '30 per zone type',
+      tooltip: 'Requires operator annotation of 300+ pages',
+    },
+    {
+      id: 'C3',
+      label: 'Publisher diversity ≥3',
+      status: c3Status,
+      currentValue: `${publisherCount} publisher(s)`,
+      threshold: '3 publishers',
+      tooltip: 'Source documents from at least 3 publishers',
+    },
+    {
+      id: 'C4',
+      label: 'Content type diversity ≥3',
+      status: c4Status,
+      currentValue: `${contentTypeCount} content type(s)`,
+      threshold: '3 content types',
+      tooltip: 'Include table-heavy, figure-heavy, and text-dominant documents',
+    },
+    {
+      id: 'C5',
+      label: 'Write quality pass rate ≥95%',
+      status: c5Status,
+      currentValue: c5Value,
+      threshold: '95% PAC 2024 pass rate',
+      tooltip: c5Tooltip,
+    },
+  ];
+
+  const allGreen = criteria.every((c) => c.status === 'GREEN');
+  const anyRed = criteria.some((c) => c.status === 'RED');
+  const overallStatus: CriterionStatus = allGreen ? 'GREEN' : anyRed ? 'RED' : 'AMBER';
+
+  return { criteria, overallStatus, readyForPhase2: allGreen };
+}

--- a/tests/unit/services/metrics/phase-gate.service.test.ts
+++ b/tests/unit/services/metrics/phase-gate.service.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockCalibrationRunFindFirst = vi.fn();
+const mockZoneGroupBy = vi.fn();
+const mockCorpusDocumentFindMany = vi.fn();
+
+vi.mock('../../../../src/lib/prisma', () => ({
+  default: {
+    calibrationRun: {
+      findFirst: (...args: unknown[]) => mockCalibrationRunFindFirst(...args),
+    },
+    zone: {
+      groupBy: (...args: unknown[]) => mockZoneGroupBy(...args),
+    },
+    corpusDocument: {
+      findMany: (...args: unknown[]) => mockCorpusDocumentFindMany(...args),
+    },
+  },
+  Prisma: {
+    DbNull: 'DbNull',
+  },
+}));
+
+import { getPhaseGateStatus } from '../../../../src/services/metrics/phase-gate.service';
+
+const ALL_TYPES = [
+  'paragraph', 'section-header', 'table', 'figure',
+  'caption', 'footnote', 'header', 'footer',
+];
+
+function makeZoneCounts(countPerType: number | Record<string, number>) {
+  return ALL_TYPES.map((type) => ({
+    type,
+    _count: {
+      id: typeof countPerType === 'number' ? countPerType : (countPerType[type] ?? 0),
+    },
+  }));
+}
+
+interface SetupOptions {
+  mapSnapshot?: Record<string, unknown> | null;
+  zoneCounts?: number | Record<string, number>;
+  publishers?: string[];
+  contentTypes?: string[];
+  spikeRun?: { summary: Record<string, unknown> } | null;
+}
+
+function setup(overrides: SetupOptions = {}) {
+  const {
+    mapSnapshot = null,
+    zoneCounts = 20,
+    publishers = ['Pub1', 'Pub2'],
+    contentTypes = ['mixed', 'table-heavy'],
+    spikeRun = null,
+  } = overrides;
+
+  // findFirst is called twice: once for mapSnapshot (C1), once for spike (C5)
+  mockCalibrationRunFindFirst
+    .mockResolvedValueOnce(mapSnapshot !== null ? { mapSnapshot } : null)
+    .mockResolvedValueOnce(spikeRun);
+
+  mockZoneGroupBy.mockResolvedValue(makeZoneCounts(zoneCounts));
+
+  // findMany is called twice: once for publishers (C3), once for contentTypes (C4)
+  mockCorpusDocumentFindMany
+    .mockResolvedValueOnce(publishers.map((p) => ({ publisher: p })))
+    .mockResolvedValueOnce(contentTypes.map((c) => ({ contentType: c })));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getPhaseGateStatus', () => {
+  it('all GREEN when all criteria met', async () => {
+    setup({
+      mapSnapshot: { overallMAP: 0.80 },
+      zoneCounts: 35,
+      publishers: ['Pearson', 'Wiley', 'OUP'],
+      contentTypes: ['table-heavy', 'figure-heavy', 'mixed'],
+      spikeRun: { summary: { passRate: 0.97 } },
+    });
+
+    const result = await getPhaseGateStatus();
+    expect(result.overallStatus).toBe('GREEN');
+    expect(result.readyForPhase2).toBe(true);
+    expect(result.criteria.every((c) => c.status === 'GREEN')).toBe(true);
+  });
+
+  it('C1 AMBER when mAP is 72%', async () => {
+    setup({ mapSnapshot: { overallMAP: 0.72 } });
+
+    const result = await getPhaseGateStatus();
+    const c1 = result.criteria.find((c) => c.id === 'C1')!;
+    expect(c1.status).toBe('AMBER');
+    expect(c1.currentValue).toBe('72.0%');
+  });
+
+  it('C1 RED when no mapSnapshot exists', async () => {
+    setup({ mapSnapshot: null });
+
+    const result = await getPhaseGateStatus();
+    const c1 = result.criteria.find((c) => c.id === 'C1')!;
+    expect(c1.status).toBe('RED');
+    expect(c1.currentValue).toBe('Not yet computed');
+  });
+
+  it('C2 AMBER when some types below 30', async () => {
+    const counts: Record<string, number> = {};
+    for (const t of ALL_TYPES) counts[t] = 35;
+    counts['footnote'] = 20;
+    counts['caption'] = 20;
+    setup({ zoneCounts: counts });
+
+    const result = await getPhaseGateStatus();
+    const c2 = result.criteria.find((c) => c.id === 'C2')!;
+    expect(c2.status).toBe('AMBER');
+    expect(c2.currentValue).toContain('Min: 20');
+  });
+
+  it('C2 RED when some types below 15', async () => {
+    const counts: Record<string, number> = {};
+    for (const t of ALL_TYPES) counts[t] = 35;
+    counts['footnote'] = 3;
+    setup({ zoneCounts: counts });
+
+    const result = await getPhaseGateStatus();
+    const c2 = result.criteria.find((c) => c.id === 'C2')!;
+    expect(c2.status).toBe('RED');
+  });
+
+  it('C3 RED when only 1 publisher', async () => {
+    setup({ publishers: ['Solo'] });
+
+    const result = await getPhaseGateStatus();
+    const c3 = result.criteria.find((c) => c.id === 'C3')!;
+    expect(c3.status).toBe('RED');
+  });
+
+  it('C5 AMBER when no spike run exists', async () => {
+    setup({ spikeRun: null });
+
+    const result = await getPhaseGateStatus();
+    const c5 = result.criteria.find((c) => c.id === 'C5')!;
+    expect(c5.status).toBe('AMBER');
+    expect(c5.currentValue).toBe('Spike not yet run');
+  });
+
+  it('C5 RED when spike failed (passRate 0.88)', async () => {
+    setup({ spikeRun: { summary: { passRate: 0.88 } } });
+
+    const result = await getPhaseGateStatus();
+    const c5 = result.criteria.find((c) => c.id === 'C5')!;
+    expect(c5.status).toBe('RED');
+    expect(c5.currentValue).toBe('88.0% pass rate');
+  });
+
+  it('overallStatus RED when any criterion is RED', async () => {
+    const counts: Record<string, number> = {};
+    for (const t of ALL_TYPES) counts[t] = 3;
+    setup({
+      mapSnapshot: { overallMAP: 0.80 },
+      zoneCounts: counts,
+      publishers: ['Pearson', 'Wiley', 'OUP'],
+      contentTypes: ['table-heavy', 'figure-heavy', 'mixed'],
+      spikeRun: { summary: { passRate: 0.97 } },
+    });
+
+    const result = await getPhaseGateStatus();
+    expect(result.overallStatus).toBe('RED');
+    expect(result.readyForPhase2).toBe(false);
+  });
+
+  it('overallStatus AMBER when mix of GREEN and AMBER', async () => {
+    setup({
+      mapSnapshot: { overallMAP: 0.80 },
+      zoneCounts: 35,
+      publishers: ['Pearson', 'Wiley', 'OUP'],
+      contentTypes: ['table-heavy', 'figure-heavy', 'mixed'],
+      spikeRun: null, // C5 = AMBER
+    });
+
+    const result = await getPhaseGateStatus();
+    expect(result.overallStatus).toBe('AMBER');
+    expect(result.readyForPhase2).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace static phase gate stub with live database queries
- 5 criteria evaluated from CalibrationRun, Zone, CorpusDocument data:
  - C1: Overall mAP from latest run's mapSnapshot
  - C2: Min zone count across 8 required types
  - C3: Distinct publisher count
  - C4: Distinct content type count
  - C5: pikepdf spike pass rate
- Each criterion returns GREEN/AMBER/RED with value + threshold

## Test plan
- [ ] 10 unit tests in `tests/unit/services/metrics/phase-gate.service.test.ts`
- [ ] Verify all 5 criteria compute correct status from mock data
- [ ] Verify empty DB returns all RED status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase-gate status endpoint now returns live, computed phase-gate evaluations and ready-for-phase-2 indication.

* **Improvements**
  * Dynamic multi-criteria assessment with clearer status (GREEN/AMBER/RED) aggregation and improved error handling for failures.

* **Tests**
  * Added comprehensive unit tests covering green/amber/red scenarios and overall readiness outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->