### PR TITLE
fix: add GET /calibration/corpus-docs endpoint

### DIFF
--- a/src/routes/calibration.routes.ts
+++ b/src/routes/calibration.routes.ts
@@ -222,6 +222,66 @@ router.get('/runs/:runId/zones', authenticate, async (req: Request, res: Respons
   }
 });
 
+const corpusDocsQuerySchema = z.object({
+  limit: z.coerce.number().default(20),
+  cursor: z.string().optional(),
+  publisher: z.string().optional(),
+  contentType: z.string().optional(),
+});
+
+// GET /api/v1/calibration/corpus-docs
+router.get('/corpus-docs', authenticate, async (req: Request, res: Response) => {
+  try {
+    const parsed = corpusDocsQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(422).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Query validation failed',
+          details: parsed.error.issues,
+        },
+      });
+    }
+
+    const { limit, cursor, publisher, contentType } = parsed.data;
+    const take = Math.min(limit, 100);
+
+    const where: Record<string, unknown> = {};
+    if (publisher) where.publisher = publisher;
+    if (contentType) where.contentType = contentType;
+
+    const documents = await prisma.corpusDocument.findMany({
+      where,
+      take: take + 1,
+      ...(cursor && { cursor: { id: cursor }, skip: 1 }),
+      orderBy: { uploadedAt: 'desc' },
+      include: {
+        bootstrapJobs: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+        },
+      },
+    });
+
+    let nextCursor: string | null = null;
+    if (documents.length > take) {
+      const extra = documents.pop()!;
+      nextCursor = extra.id;
+    }
+
+    return res.json({
+      success: true,
+      data: { documents, nextCursor },
+    });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
 // GET /api/v1/calibration/corpus-stats
 router.get('/corpus-stats', authenticate, async (_req: Request, res: Response) => {
   try {

--- a/tests/unit/routes/corpus-docs.test.ts
+++ b/tests/unit/routes/corpus-docs.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mockCorpusDocFindMany = vi.fn();
+
+vi.mock('../../../src/lib/prisma', () => ({
+  default: {
+    corpusDocument: {
+      findMany: (...args: unknown[]) => mockCorpusDocFindMany(...args),
+    },
+    calibrationRun: { findMany: vi.fn().mockResolvedValue([]) },
+    zone: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+vi.mock('../../../src/middleware/auth.middleware', () => ({
+  authenticate: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = { id: 'user-1', tenantId: 'tenant-1' } as never;
+    next();
+  },
+}));
+
+vi.mock('../../../src/queues', () => ({
+  getCalibrationQueue: vi.fn(),
+}));
+
+vi.mock('../../../src/services/calibration/corpus-stats.service', () => ({
+  getCorpusStats: vi.fn().mockResolvedValue({}),
+}));
+
+import calibrationRoutes from '../../../src/routes/calibration.routes';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/calibration', calibrationRoutes);
+  return app;
+}
+
+describe('GET /calibration/corpus-docs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns paginated documents with 200', async () => {
+    const docs = [
+      {
+        id: 'doc-1',
+        filename: 'test.pdf',
+        publisher: 'Pearson',
+        contentType: 'mixed',
+        uploadedAt: new Date(),
+        bootstrapJobs: [{ id: 'job-1', status: 'COMPLETE' }],
+      },
+      {
+        id: 'doc-2',
+        filename: 'test2.pdf',
+        publisher: 'Wiley',
+        contentType: 'text-dominant',
+        uploadedAt: new Date(),
+        bootstrapJobs: [],
+      },
+    ];
+    mockCorpusDocFindMany.mockResolvedValue(docs);
+
+    const app = buildApp();
+    const res = await request(app).get('/calibration/corpus-docs');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.documents).toHaveLength(2);
+    expect(res.body.data.nextCursor).toBeNull();
+  });
+
+  it('filters by publisher', async () => {
+    mockCorpusDocFindMany.mockResolvedValue([]);
+
+    const app = buildApp();
+    await request(app).get('/calibration/corpus-docs?publisher=Pearson');
+
+    expect(mockCorpusDocFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ publisher: 'Pearson' }),
+      }),
+    );
+  });
+
+  it('returns empty result with nextCursor null', async () => {
+    mockCorpusDocFindMany.mockResolvedValue([]);
+
+    const app = buildApp();
+    const res = await request(app).get('/calibration/corpus-docs');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ documents: [], nextCursor: null });
+  });
+});


### PR DESCRIPTION
## Summary
- Add missing `GET /calibration/corpus-docs` endpoint called by DocumentQueueView frontend
- Paginated with cursor, filterable by publisher and contentType
- Includes latest ZoneBootstrapJob for frontend status computation

## Test plan
- [x] 3 unit tests passing (paginated response, publisher filter, empty result)
- [ ] Verify staging 404 resolved after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for retrieving corpus documents with pagination support, including limit capping and cursor-based navigation.
  * Filtering capabilities by publisher and content type parameters.
  * Request validation and standard error handling.

* **Tests**
  * Added unit tests validating pagination, filtering, and response structures for the new endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->