### PR TITLE
feat: per-page timing, phase detection, AI re-run page-range

### DIFF
--- a/src/routes/calibration.routes.ts
+++ b/src/routes/calibration.routes.ts
@@ -506,7 +506,16 @@ const aiAnnotateBodySchema = z.object({
   confidenceThreshold: z.number().min(0).max(1).optional(),
   model: z.string().optional(),
   dryRun: z.boolean().optional(),
-});
+  // Page-range re-processing: restrict to a page window, and optionally include zones that
+  // already have a decision so they can be re-classified under the current prompt version.
+  pageStart: z.number().int().positive().optional(),
+  pageEnd: z.number().int().positive().optional(),
+  includeDecided: z.boolean().optional(),
+  forceOverwriteHuman: z.boolean().optional(),
+}).refine(
+  (v) => v.pageStart === undefined || v.pageEnd === undefined || v.pageStart <= v.pageEnd,
+  { message: 'pageStart must be <= pageEnd', path: ['pageEnd'] },
+);
 
 // POST /api/v1/calibration/runs/:runId/ai-annotate
 // Returns 202 immediately; annotation runs in background.

--- a/src/services/calibration/ai-annotation.service.ts
+++ b/src/services/calibration/ai-annotation.service.ts
@@ -95,6 +95,21 @@ export interface AiAnnotationOptions {
   model?: string;               // model override
   dryRun?: boolean;             // if true, classify but don't persist
   aiRunId?: string;             // pre-created AiAnnotationRun ID (for async pattern)
+  /** Only annotate zones on pages >= pageStart (inclusive). */
+  pageStart?: number;
+  /** Only annotate zones on pages <= pageEnd (inclusive). */
+  pageEnd?: number;
+  /**
+   * If true, include zones that already have a decision (re-processing pass).
+   * AI fields are always overwritten; human decisions are only overwritten when the
+   * new confidence exceeds `confidenceThreshold`.
+   */
+  includeDecided?: boolean;
+  /**
+   * If true, allow auto-apply to overwrite zones that were last verified by a human
+   * (verifiedBy not starting with 'ai:'). Default false — human decisions are sticky.
+   */
+  forceOverwriteHuman?: boolean;
 }
 
 export interface AiAnnotationResult {
@@ -138,13 +153,27 @@ export async function runAiAnnotation(
       });
 
   try {
-    // 2. Fetch unreviewed zones (not yet decided by operator or auto-annotation)
+    // 2. Fetch zones to annotate. By default: unreviewed + not already AI-annotated + not ghost.
+    // When re-processing (includeDecided), skip the decision/aiDecision filters so already-seen
+    // zones can be re-classified under a new prompt version. Ghost zones are always skipped.
+    const pageFilter =
+      options.pageStart !== undefined || options.pageEnd !== undefined
+        ? {
+            pageNumber: {
+              ...(options.pageStart !== undefined ? { gte: options.pageStart } : {}),
+              ...(options.pageEnd !== undefined ? { lte: options.pageEnd } : {}),
+            },
+          }
+        : {};
+
     const zones = await prisma.zone.findMany({
       where: {
         calibrationRunId,
-        decision: null,        // only unreviewed zones
-        aiDecision: null,      // not already AI-annotated
-        isGhost: false,        // skip ghost zones
+        isGhost: false,
+        ...(options.includeDecided
+          ? {}
+          : { decision: null, aiDecision: null }),
+        ...pageFilter,
       },
       select: {
         id: true,
@@ -157,6 +186,12 @@ export async function runAiAnnotation(
         reconciliationBucket: true,
         doclingLabel: true,
         pdfxtLabel: true,
+        decision: true,
+        verifiedBy: true,
+        operatorVerified: true,
+        isArtefact: true,
+        operatorLabel: true,
+        correctionReason: true,
       },
     });
 
@@ -360,21 +395,47 @@ export async function runAiAnnotation(
               aiAnnotatedAt: new Date(),
             };
 
-            // Auto-apply if capped confidence >= threshold and not dry run
-            if (!options.dryRun && conf >= confThreshold) {
+            // Auto-apply if capped confidence >= threshold and not dry run.
+            // Human decisions are sticky: never overwrite a zone that was last verified by a
+            // human (verifiedBy not starting with 'ai:') unless forceOverwriteHuman is set.
+            const isHumanVerified =
+              !!zone.decision &&
+              !!zone.verifiedBy &&
+              !zone.verifiedBy.startsWith('ai:');
+            const canAutoApply =
+              !options.dryRun &&
+              conf >= confThreshold &&
+              (!isHumanVerified || options.forceOverwriteHuman === true);
+
+            if (canAutoApply) {
               if (classification.decision === 'REJECTED') {
                 updateData.decision = 'REJECTED';
                 updateData.isArtefact = true;
+                updateData.operatorLabel = null;
+                updateData.correctionReason = classification.reason ?? 'AI rejection';
                 updateData.verifiedBy = `ai:${effectiveModel}`;
+                updateData.verifiedAt = new Date();
               } else if (classification.decision === 'CORRECTED') {
                 updateData.decision = 'CORRECTED';
                 updateData.operatorLabel = classification.label;
-                updateData.verifiedBy = `ai:${effectiveModel}`;
+                updateData.isArtefact = false;
                 updateData.correctionReason = classification.reason ?? 'AI correction';
+                updateData.verifiedBy = `ai:${effectiveModel}`;
+                updateData.verifiedAt = new Date();
               } else {
                 updateData.decision = 'CONFIRMED';
+                updateData.operatorLabel = null;
+                updateData.correctionReason = null;
+                updateData.isArtefact = false;
                 updateData.verifiedBy = `ai:${effectiveModel}`;
+                updateData.verifiedAt = new Date();
               }
+            } else if (isHumanVerified && !options.dryRun && conf >= confThreshold) {
+              // Skipped auto-apply because the zone was human-verified — log for traceability
+              logger.info(
+                `[ai-annotation] Skipping auto-apply for human-verified zone ${classification.zoneId} ` +
+                `(verifiedBy=${zone.verifiedBy}); only AI fields will be persisted`,
+              );
             }
 
             await prisma.zone.update({

--- a/src/services/calibration/ai-annotation.service.ts
+++ b/src/services/calibration/ai-annotation.service.ts
@@ -398,10 +398,13 @@ export async function runAiAnnotation(
             // Auto-apply if capped confidence >= threshold and not dry run.
             // Human decisions are sticky: never overwrite a zone that was last verified by a
             // human (verifiedBy not starting with 'ai:') unless forceOverwriteHuman is set.
+            // 'auto-annotation' is the deterministic system verifier, not a human — exclude it
+            // so re-runs over auto-annotated pages can still be reclassified.
             const isHumanVerified =
               !!zone.decision &&
               !!zone.verifiedBy &&
-              !zone.verifiedBy.startsWith('ai:');
+              !zone.verifiedBy.startsWith('ai:') &&
+              zone.verifiedBy !== 'auto-annotation';
             const canAutoApply =
               !options.dryRun &&
               conf >= confThreshold &&

--- a/src/services/calibration/annotation-timesheet.service.ts
+++ b/src/services/calibration/annotation-timesheet.service.ts
@@ -298,55 +298,71 @@ class AnnotationTimesheetService {
       }
     }
 
-    // Apportionment pool: distribute the leftover active time across pages with no measured
-    // segments, weighted by *human* zone count. Use a largest-remainder (Hamilton) distribution
-    // so the per-page integers sum exactly to `unmeasuredActiveMs` instead of drifting due to
-    // independent rounding.
+    // Apportionment pool: distribute the leftover active time using a largest-remainder
+    // (Hamilton) split so per-page integers sum exactly to the pool. Three regimes:
+    //
+    //   1. Some pages have no measured segments at all → the leftover gets distributed across
+    //      those unmeasured pages (weighted by human zone count). Measured pages keep their
+    //      measured value untouched.
+    //   2. Every page has at least some measured time, but session time still includes
+    //      page-less segments (so `unmeasuredActiveMs > 0`). We add the leftover on top of the
+    //      measured values across ALL pages so totals reconcile to `totalActiveMs`.
+    //   3. Nothing measured anywhere → fall back to a pure proportional split.
     const unmeasuredActiveMs = Math.max(0, totalActiveMs - measuredTotalMs);
     const totalHumanZoneCount = [...pageMap.values()].reduce((sum, d) => sum + d.humanCount, 0);
     const unmeasuredPages = [...pageMap.entries()].filter(([page]) => !measuredMsByPage.has(page));
     const unmeasuredHumanZoneCount = unmeasuredPages.reduce((sum, [, d]) => sum + d.humanCount, 0);
 
-    const apportionedMs = new Map<number, number>();
-    if (unmeasuredHumanZoneCount > 0 && unmeasuredActiveMs > 0) {
-      // Largest-remainder method
-      const exact = unmeasuredPages.map(([page, d]) => ({
-        page,
-        exact: unmeasuredActiveMs * (d.humanCount / unmeasuredHumanZoneCount),
-      }));
+    /** Largest-remainder distribution helper. Returns map page→ms summing exactly to `pool`. */
+    const distribute = (
+      pool: number,
+      pages: { page: number; weight: number }[],
+    ): Map<number, number> => {
+      const result = new Map<number, number>();
+      const totalWeight = pages.reduce((s, p) => s + p.weight, 0);
+      if (pool <= 0 || totalWeight <= 0 || pages.length === 0) return result;
+      const exact = pages.map(p => ({ page: p.page, exact: pool * (p.weight / totalWeight) }));
       let assigned = 0;
       const withFloor = exact.map(e => {
         const floor = Math.floor(e.exact);
         assigned += floor;
         return { page: e.page, floor, remainder: e.exact - floor };
       });
-      let remainder = unmeasuredActiveMs - assigned;
+      let leftover = pool - assigned;
       withFloor.sort((a, b) => b.remainder - a.remainder);
       for (const row of withFloor) {
-        const bonus = remainder > 0 ? 1 : 0;
-        apportionedMs.set(row.page, row.floor + bonus);
-        if (remainder > 0) remainder--;
+        const bonus = leftover > 0 ? 1 : 0;
+        result.set(row.page, row.floor + bonus);
+        if (leftover > 0) leftover--;
       }
-    } else if (totalHumanZoneCount > 0 && totalActiveMs > 0) {
-      // No segments at all and no measurable split — fall back to a proportional split over all pages
-      const allPages = [...pageMap.entries()];
-      const exact = allPages.map(([page, d]) => ({
-        page,
-        exact: totalActiveMs * (d.humanCount / totalHumanZoneCount),
-      }));
-      let assigned = 0;
-      const withFloor = exact.map(e => {
-        const floor = Math.floor(e.exact);
-        assigned += floor;
-        return { page: e.page, floor, remainder: e.exact - floor };
-      });
-      let remainder = totalActiveMs - assigned;
-      withFloor.sort((a, b) => b.remainder - a.remainder);
-      for (const row of withFloor) {
-        const bonus = remainder > 0 ? 1 : 0;
-        apportionedMs.set(row.page, row.floor + bonus);
-        if (remainder > 0) remainder--;
+      return result;
+    };
+
+    const apportionedMs = new Map<number, number>();   // for pages with no measured time
+    const measuredTopUp = new Map<number, number>();   // extra ms added on top of measured pages
+
+    if (unmeasuredActiveMs > 0) {
+      if (unmeasuredHumanZoneCount > 0) {
+        // Regime 1: distribute leftover across pages with no measured segments
+        const split = distribute(
+          unmeasuredActiveMs,
+          unmeasuredPages.map(([page, d]) => ({ page, weight: d.humanCount })),
+        );
+        for (const [page, ms] of split) apportionedMs.set(page, ms);
+      } else if (totalHumanZoneCount > 0) {
+        // Regime 2: every page already has some measured time but page-less session segments
+        // remain — top up measured pages so totals reconcile
+        const measuredPagesWithHuman = [...pageMap.entries()]
+          .filter(([page]) => measuredMsByPage.has(page))
+          .map(([page, d]) => ({ page, weight: d.humanCount }));
+        const split = distribute(unmeasuredActiveMs, measuredPagesWithHuman);
+        for (const [page, ms] of split) measuredTopUp.set(page, ms);
       }
+    } else if (measuredTotalMs === 0 && totalHumanZoneCount > 0 && totalActiveMs > 0) {
+      // Regime 3: nothing measured anywhere — proportional split over all pages with human zones
+      const allPages = [...pageMap.entries()].map(([page, d]) => ({ page, weight: d.humanCount }));
+      const split = distribute(totalActiveMs, allPages);
+      for (const [page, ms] of split) apportionedMs.set(page, ms);
     }
 
     // Build the union of pages with zones AND pages with measured time only — a page may have
@@ -361,8 +377,12 @@ class AnnotationTimesheetService {
       let timingSource: 'measured' | 'derived' = 'derived';
       const measured = measuredMsByPage.get(page);
       if (measured !== undefined) {
-        timeSpentMs = Math.round(measured);
-        timingSource = 'measured';
+        // Measured page: start from the measured value and add any reconciliation top-up.
+        // The page is still considered 'measured' as long as the top-up is small relative
+        // to the measured value — otherwise mark it 'derived' so the UI can flag it.
+        const topUp = measuredTopUp.get(page) ?? 0;
+        timeSpentMs = Math.round(measured + topUp);
+        timingSource = topUp > measured ? 'derived' : 'measured';
       } else {
         timeSpentMs = apportionedMs.get(page) ?? 0;
       }

--- a/src/services/calibration/annotation-timesheet.service.ts
+++ b/src/services/calibration/annotation-timesheet.service.ts
@@ -22,6 +22,30 @@ export interface PageTimeRow {
   confirmed: number;
   corrected: number;
   rejected: number;
+  /** How timeSpentMs was computed: 'measured' from sessionLog page segments, or 'derived' by apportionment. */
+  timingSource: 'measured' | 'derived';
+  /** Review workflow mode inferred from decision pattern. */
+  reviewMode: 'deep' | 'sampling' | 'unreviewed';
+}
+
+export interface ZoneTypeRow {
+  zoneType: string;
+  total: number;
+  confirmed: number;
+  corrected: number;
+  rejected: number;
+  confirmPct: number | null;
+  correctPct: number | null;
+  rejectPct: number | null;
+}
+
+/** Single entry inside AnnotationSession.sessionLog when the frontend timer emits page-tagged segments. */
+interface SessionSegmentEntry {
+  openedAt?: string;
+  closedAt?: string;
+  activeMs?: number;
+  idleMs?: number;
+  pageNumber?: number | null;
 }
 
 export interface TimesheetReport {
@@ -52,6 +76,7 @@ export interface TimesheetReport {
   byOperator: (OperatorRow & { operator: string })[];
   pageBreakdown: PageTimeRow[];
   byPage: (PageTimeRow & { zones: number })[];
+  zoneTypeBreakdown: ZoneTypeRow[];
   efficiencyMetrics: {
     autoAnnotationSavingsMs: number;
     reviewQueueReductionPct: number | null;
@@ -138,6 +163,8 @@ class AnnotationTimesheetService {
           orderBy: [{ pageNumber: 'asc' }],
           select: {
             id: true,
+            type: true,
+            operatorLabel: true,
             pageNumber: true,
             decision: true,
             verifiedBy: true,
@@ -239,36 +266,190 @@ class AnnotationTimesheetService {
       };
     });
 
-    // Page breakdown — derive from zone decisions (no per-page timing from sessions yet)
-    const pageMap = new Map<number, { count: number; confirmed: number; corrected: number; rejected: number }>();
+    // Page breakdown — aggregate decisions per page.
+    // `pageMap` counts ALL zones for the visible page row; `humanPageMap` excludes zones
+    // that were applied by auto-annotation (so apportionment of human review time is not
+    // diluted by pages that the human never actually opened).
+    const pageMap = new Map<number, { count: number; humanCount: number; confirmed: number; corrected: number; rejected: number }>();
     for (const z of zones) {
-      const existing = pageMap.get(z.pageNumber) ?? { count: 0, confirmed: 0, corrected: 0, rejected: 0 };
+      const existing = pageMap.get(z.pageNumber) ?? { count: 0, humanCount: 0, confirmed: 0, corrected: 0, rejected: 0 };
       existing.count++;
+      if (z.verifiedBy !== 'auto-annotation') existing.humanCount++;
       if (z.decision === 'CONFIRMED') existing.confirmed++;
       if (z.decision === 'CORRECTED') existing.corrected++;
       if (z.decision === 'REJECTED') existing.rejected++;
       pageMap.set(z.pageNumber, existing);
     }
 
-    // Distribute total active time proportionally by zone count
-    const totalZoneCount = zones.length;
-    const pageBreakdown: PageTimeRow[] = [...pageMap.entries()]
-      .sort(([a], [b]) => a - b)
-      .map(([page, data]) => {
-        const timeSpentMs = totalZoneCount > 0
-          ? Math.round(totalActiveMs * (data.count / totalZoneCount))
-          : 0;
-        const mins = timeSpentMs / 60_000;
-        return {
-          pageNumber: page,
-          zoneCount: data.count,
-          timeSpentMs,
-          zonesPerMin: mins > 0 ? data.count / mins : null,
-          confirmed: data.confirmed,
-          corrected: data.corrected,
-          rejected: data.rejected,
-        };
+    // Measured per-page time: aggregate active time from sessionLog segments that carry pageNumber.
+    // Falls back to proportional apportionment for pages with no segments (older sessions or missing tags).
+    const measuredMsByPage = new Map<number, number>();
+    let measuredTotalMs = 0;
+    for (const sess of sessions) {
+      const log = sess.sessionLog as unknown;
+      if (!Array.isArray(log)) continue;
+      for (const entry of log as SessionSegmentEntry[]) {
+        if (!entry || typeof entry !== 'object') continue;
+        const page = entry.pageNumber;
+        const ms = entry.activeMs;
+        if (typeof page !== 'number' || typeof ms !== 'number' || ms <= 0) continue;
+        measuredMsByPage.set(page, (measuredMsByPage.get(page) ?? 0) + ms);
+        measuredTotalMs += ms;
+      }
+    }
+
+    // Apportionment pool: distribute the leftover active time across pages with no measured
+    // segments, weighted by *human* zone count. Use a largest-remainder (Hamilton) distribution
+    // so the per-page integers sum exactly to `unmeasuredActiveMs` instead of drifting due to
+    // independent rounding.
+    const unmeasuredActiveMs = Math.max(0, totalActiveMs - measuredTotalMs);
+    const totalHumanZoneCount = [...pageMap.values()].reduce((sum, d) => sum + d.humanCount, 0);
+    const unmeasuredPages = [...pageMap.entries()].filter(([page]) => !measuredMsByPage.has(page));
+    const unmeasuredHumanZoneCount = unmeasuredPages.reduce((sum, [, d]) => sum + d.humanCount, 0);
+
+    const apportionedMs = new Map<number, number>();
+    if (unmeasuredHumanZoneCount > 0 && unmeasuredActiveMs > 0) {
+      // Largest-remainder method
+      const exact = unmeasuredPages.map(([page, d]) => ({
+        page,
+        exact: unmeasuredActiveMs * (d.humanCount / unmeasuredHumanZoneCount),
+      }));
+      let assigned = 0;
+      const withFloor = exact.map(e => {
+        const floor = Math.floor(e.exact);
+        assigned += floor;
+        return { page: e.page, floor, remainder: e.exact - floor };
       });
+      let remainder = unmeasuredActiveMs - assigned;
+      withFloor.sort((a, b) => b.remainder - a.remainder);
+      for (const row of withFloor) {
+        const bonus = remainder > 0 ? 1 : 0;
+        apportionedMs.set(row.page, row.floor + bonus);
+        if (remainder > 0) remainder--;
+      }
+    } else if (totalHumanZoneCount > 0 && totalActiveMs > 0) {
+      // No segments at all and no measurable split — fall back to a proportional split over all pages
+      const allPages = [...pageMap.entries()];
+      const exact = allPages.map(([page, d]) => ({
+        page,
+        exact: totalActiveMs * (d.humanCount / totalHumanZoneCount),
+      }));
+      let assigned = 0;
+      const withFloor = exact.map(e => {
+        const floor = Math.floor(e.exact);
+        assigned += floor;
+        return { page: e.page, floor, remainder: e.exact - floor };
+      });
+      let remainder = totalActiveMs - assigned;
+      withFloor.sort((a, b) => b.remainder - a.remainder);
+      for (const row of withFloor) {
+        const bonus = remainder > 0 ? 1 : 0;
+        apportionedMs.set(row.page, row.floor + bonus);
+        if (remainder > 0) remainder--;
+      }
+    }
+
+    // Build the union of pages with zones AND pages with measured time only — a page may have
+    // recorded segments before any zone was decided, and we must not drop it from the report.
+    const allPageNumbers = new Set<number>([...pageMap.keys(), ...measuredMsByPage.keys()]);
+    const sortedPageNumbers = [...allPageNumbers].sort((a, b) => a - b);
+
+    // First pass: compute time + per-page rows without reviewMode
+    const preliminary = sortedPageNumbers.map(page => {
+      const data = pageMap.get(page) ?? { count: 0, humanCount: 0, confirmed: 0, corrected: 0, rejected: 0 };
+      let timeSpentMs = 0;
+      let timingSource: 'measured' | 'derived' = 'derived';
+      const measured = measuredMsByPage.get(page);
+      if (measured !== undefined) {
+        timeSpentMs = Math.round(measured);
+        timingSource = 'measured';
+      } else {
+        timeSpentMs = apportionedMs.get(page) ?? 0;
+      }
+      const mins = timeSpentMs / 60_000;
+      return {
+        pageNumber: page,
+        zoneCount: data.count,
+        timeSpentMs,
+        zonesPerMin: mins > 0 ? data.count / mins : null,
+        confirmed: data.confirmed,
+        corrected: data.corrected,
+        rejected: data.rejected,
+        timingSource,
+      };
+    });
+
+    // Phase detection: classify each page as 'deep', 'sampling', or 'unreviewed'.
+    // - unreviewed: no decisions recorded on a page that has zones
+    // - sampling:  the page belongs to a run of >= 3 consecutive pages where confirmed <= 3 on pages with > 10 zones
+    //              (matches the pattern seen in Phase B of cmnmw6d4 where triage replaced deep review)
+    // - deep:      everything else (the default quality tier)
+    const SAMPLING_MIN_RUN = 3;
+    const SAMPLING_ZONE_THRESHOLD = 10;
+    const SAMPLING_CONFIRMED_CAP = 3;
+
+    const baseMode: ('deep' | 'sampling' | 'unreviewed')[] = preliminary.map(p => {
+      if (p.confirmed === 0 && p.corrected === 0 && p.rejected === 0) return 'unreviewed';
+      return 'deep';
+    });
+
+    // Walk runs of pages looking for sampling patterns. A run must be both consecutive
+    // *by page number* (no gaps in the page sequence) and meet the sampling heuristic
+    // — otherwise reports with sparse page coverage would falsely group unrelated pages.
+    let runStart = -1;
+    let prevPageNumber = -Infinity;
+    for (let i = 0; i <= preliminary.length; i++) {
+      const p = preliminary[i];
+      const isContiguous = p !== undefined && p.pageNumber === prevPageNumber + 1;
+      const isSamplingCandidate =
+        p !== undefined &&
+        p.zoneCount > SAMPLING_ZONE_THRESHOLD &&
+        p.confirmed <= SAMPLING_CONFIRMED_CAP &&
+        baseMode[i] !== 'unreviewed';
+
+      if (isSamplingCandidate && (runStart === -1 || isContiguous)) {
+        if (runStart === -1) runStart = i;
+      } else {
+        if (runStart !== -1 && i - runStart >= SAMPLING_MIN_RUN) {
+          for (let j = runStart; j < i; j++) baseMode[j] = 'sampling';
+        }
+        // If the current page is itself a candidate but broke the run because of a page gap,
+        // start a fresh run from this index.
+        runStart = isSamplingCandidate ? i : -1;
+      }
+
+      if (p !== undefined) prevPageNumber = p.pageNumber;
+    }
+
+    const pageBreakdown: PageTimeRow[] = preliminary.map((p, i) => ({
+      ...p,
+      reviewMode: baseMode[i],
+    }));
+
+    // Zone type breakdown — correction rates by zone.type (or operatorLabel if corrected)
+    const typeMap = new Map<string, { total: number; confirmed: number; corrected: number; rejected: number }>();
+    for (const z of zones) {
+      if (!z.decision) continue;
+      const key = z.type || 'unknown';
+      const existing = typeMap.get(key) ?? { total: 0, confirmed: 0, corrected: 0, rejected: 0 };
+      existing.total++;
+      if (z.decision === 'CONFIRMED') existing.confirmed++;
+      else if (z.decision === 'CORRECTED') existing.corrected++;
+      else if (z.decision === 'REJECTED') existing.rejected++;
+      typeMap.set(key, existing);
+    }
+    const zoneTypeBreakdown: ZoneTypeRow[] = [...typeMap.entries()]
+      .sort(([, a], [, b]) => b.total - a.total)
+      .map(([zoneType, d]) => ({
+        zoneType,
+        total: d.total,
+        confirmed: d.confirmed,
+        corrected: d.corrected,
+        rejected: d.rejected,
+        confirmPct: d.total > 0 ? d.confirmed / d.total : null,
+        correctPct: d.total > 0 ? d.corrected / d.total : null,
+        rejectPct: d.total > 0 ? d.rejected / d.total : null,
+      }));
 
     // Efficiency metrics
     const avgSecsPerZoneSafe = avgSecsPerZone ?? 6.4; // default estimate
@@ -329,6 +510,7 @@ class AnnotationTimesheetService {
         ...p,
         zones: p.zoneCount,
       })),
+      zoneTypeBreakdown,
       efficiencyMetrics: {
         autoAnnotationSavingsMs,
         reviewQueueReductionPct,
@@ -367,11 +549,23 @@ class AnnotationTimesheetService {
     ].map(escape).join(','));
 
     // Section 2: Page breakdown
-    const pgHeaders = ['Page', 'Zones', 'TimeSpentMs', 'ZonesPerMin', 'Confirmed', 'Corrected', 'Rejected'];
+    const pgHeaders = [
+      'Page', 'Zones', 'TimeSpentMs', 'ZonesPerMin',
+      'Confirmed', 'Corrected', 'Rejected', 'ReviewMode', 'TimingSource',
+    ];
     const pgRows = report.pageBreakdown.map(r => [
       r.pageNumber, r.zoneCount, r.timeSpentMs,
       r.zonesPerMin !== null ? r.zonesPerMin.toFixed(1) : '',
-      r.confirmed, r.corrected, r.rejected,
+      r.confirmed, r.corrected, r.rejected, r.reviewMode, r.timingSource,
+    ].map(escape).join(','));
+
+    // Section 3: Zone type breakdown
+    const ztHeaders = ['ZoneType', 'Total', 'Confirmed', 'Corrected', 'Rejected', 'Confirm%', 'Correct%', 'Reject%'];
+    const ztRows = report.zoneTypeBreakdown.map(r => [
+      r.zoneType, r.total, r.confirmed, r.corrected, r.rejected,
+      r.confirmPct !== null ? (r.confirmPct * 100).toFixed(1) : '',
+      r.correctPct !== null ? (r.correctPct * 100).toFixed(1) : '',
+      r.rejectPct !== null ? (r.rejectPct * 100).toFixed(1) : '',
     ].map(escape).join(','));
 
     return [
@@ -382,6 +576,10 @@ class AnnotationTimesheetService {
       '# Page Breakdown',
       pgHeaders.join(','),
       ...pgRows,
+      '',
+      '# Zone Type Breakdown',
+      ztHeaders.join(','),
+      ...ztRows,
     ].join('\n');
   }
 


### PR DESCRIPTION
## Summary
Per-page timing aggregation, phase-shift detection, and a page-range re-run option for AI annotation — driven by the timesheet analysis of run `cmnmw6d4` which surfaced a constant `ZonesPerMin` (derived, not measured) and an unflagged shift from deep review to triage in Phase B.

### Service: `annotation-timesheet.service.ts`
- **Per-page timing** — aggregates `activeMs` from `sessionLog` segments tagged with `pageNumber`. Returns `timingSource: 'measured' | 'derived'` per row.
- **Apportionment** — leftover unmeasured time is distributed only over pages with *human* zones (excludes `verifiedBy === 'auto-annotation'`) using a largest-remainder (Hamilton) split, so per-page integers sum exactly to the unmeasured pool.
- **Pages with measured time only** — preliminary list is the union of `pageMap` and `measuredMsByPage`, so segments recorded before any decision still appear.
- **Sampling-run detection** — labels each page `deep | sampling | unreviewed`. A sampling run requires ≥3 *page-number contiguous* pages with `confirmed ≤ 3` and `zoneCount > 10`. Page-number gaps now break runs.
- **Zone-type breakdown** — new `zoneTypeBreakdown[]` with confirm/correct/reject percentages by `zone.type`.
- CSV export gains `ReviewMode`, `TimingSource` columns plus a Zone Type Breakdown section.

### Service: `ai-annotation.service.ts`
- New `pageStart` / `pageEnd` / `includeDecided` options on `runAiAnnotation()` so a re-run can target a single page window and optionally re-classify already-decided zones under the current prompt version.
- New `forceOverwriteHuman` option (default `false`) — auto-apply now treats human-verified zones as sticky and only writes AI fields unless this flag is set.
- Auto-apply branches normalize stale fields to prevent inconsistent state:
  - `CONFIRMED` → clears `operatorLabel`, `correctionReason`, `isArtefact`
  - `CORRECTED` → sets `operatorLabel`, clears `isArtefact`
  - `REJECTED` → clears `operatorLabel`, sets `isArtefact = true`
- All branches stamp `verifiedAt`.

### Route: `calibration.routes.ts`
- `aiAnnotateBodySchema` accepts `pageStart`, `pageEnd`, `includeDecided`, `forceOverwriteHuman` with a `pageStart <= pageEnd` refinement.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/services/calibration src/routes/calibration.routes.ts --max-warnings 0` clean
- [x] `npx vitest run tests/unit/services/calibration` — 32 passed
- [ ] Smoke test the timesheet endpoint on staging against an existing run (`cmnmw6d4`) to confirm per-page timing now varies and the sampling phase is flagged
- [ ] Smoke test `POST /runs/:runId/ai-annotate` with a page-range payload to confirm only the targeted window is processed

## Notes
Frontend companion PR: s4cindia/ninja-frontend (`feat/timesheet-per-page-instrumentation`) — adds `setCurrentPage` to the timer hook so the segments this PR consumes actually carry `pageNumber`.

Adversarially reviewed by Codex; all 6 findings (2 CRITICAL, 3 HIGH, 1 MEDIUM) were addressed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional page-range controls to re-run AI annotation for selected pages.
  * Introduced re-processing flags to include already-decided zones and to force-overwrite human-verified decisions.
  * AI auto-apply now respects human verification by default; can be overridden with a force option.
  * Extended timesheet reports: measured vs. derived timing, per-page review mode (deep/sampling/unreviewed), zone-type breakdowns, and updated CSV export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->