### PR TITLE
feat: auto-reject header/footer zones and heading offset detection

### DIFF
--- a/src/services/ai/prompts/zone-classification.prompts.ts
+++ b/src/services/ai/prompts/zone-classification.prompts.ts
@@ -108,7 +108,7 @@ Deepest heading level used so far: h${headingContext.maxDepth}
 Recent headings (most recent last):
 ${headingContext.stack.slice(-10).map(h => `- h${h.level}: "${h.text}" (page ${h.page})`).join('\n')}
 ${headingContext.extractorOffset ? `
-**CRITICAL — Heading Offset Detected**: The PDF tag tree in this document uses heading levels that are ${headingContext.extractorOffset} level(s) too high. The extractor labels do NOT reflect the correct semantic hierarchy. Always subtract ${headingContext.extractorOffset} from the extractor heading level:
+**CRITICAL — Heading Offset Detected**: The PDF tag tree in this document uses heading levels that are ${headingContext.extractorOffset} level(s) too shallow. The extractor labels do NOT reflect the correct semantic hierarchy. Shift each extractor heading level down by ${headingContext.extractorOffset} (add ${headingContext.extractorOffset} to the level number):
 - Extractor H1 → use h${1 + headingContext.extractorOffset}
 - Extractor H2 → use h${2 + headingContext.extractorOffset}
 - Extractor H3 → use h${3 + headingContext.extractorOffset}
@@ -116,7 +116,7 @@ Do NOT confirm extractor heading levels at face value — apply the offset corre
 **Important**: Match heading levels to the established hierarchy above. Do not assign a heading level that contradicts the document structure.`}
 ` : `${headingContext?.extractorOffset ? `
 ## Heading Offset Detected
-The PDF tag tree in this document uses heading levels that are ${headingContext.extractorOffset} level(s) too high. When classifying heading zones on this page, subtract ${headingContext.extractorOffset} from the extractor heading level:
+The PDF tag tree in this document uses heading levels that are ${headingContext.extractorOffset} level(s) too shallow. Shift each extractor heading level down by ${headingContext.extractorOffset} (add ${headingContext.extractorOffset} to the level number):
 - Extractor H1 → use h${1 + headingContext.extractorOffset}
 - Extractor H2 → use h${2 + headingContext.extractorOffset}
 - Extractor H3 → use h${3 + headingContext.extractorOffset}

--- a/src/services/ai/prompts/zone-classification.prompts.ts
+++ b/src/services/ai/prompts/zone-classification.prompts.ts
@@ -29,6 +29,12 @@ export interface HeadingContext {
   stack: { level: number; text: string; page: number }[];
   /** The deepest heading level used so far in the document */
   maxDepth: number;
+  /**
+   * Document-level heading offset detected from extractor data.
+   * e.g., 1 means extractors report heading levels 1 higher than semantic reality
+   * (H1 in PDF tag tree = h2 semantically). 0 or undefined = no offset.
+   */
+  extractorOffset?: number;
 }
 
 export interface ZoneClassification {
@@ -101,9 +107,20 @@ Deepest heading level used so far: h${headingContext.maxDepth}
 
 Recent headings (most recent last):
 ${headingContext.stack.slice(-10).map(h => `- h${h.level}: "${h.text}" (page ${h.page})`).join('\n')}
-
-**Important**: If the document uses h2 for chapter titles and h3 for sections, continue that pattern. Do not assign h3 to a chapter title because you see h3 elsewhere.
-` : ''}
+${headingContext.extractorOffset ? `
+**CRITICAL — Heading Offset Detected**: The PDF tag tree in this document uses heading levels that are ${headingContext.extractorOffset} level(s) too high. The extractor labels do NOT reflect the correct semantic hierarchy. Always subtract ${headingContext.extractorOffset} from the extractor heading level:
+- Extractor H1 → use h${1 + headingContext.extractorOffset}
+- Extractor H2 → use h${2 + headingContext.extractorOffset}
+- Extractor H3 → use h${3 + headingContext.extractorOffset}
+Do NOT confirm extractor heading levels at face value — apply the offset correction.` : `
+**Important**: Match heading levels to the established hierarchy above. Do not assign a heading level that contradicts the document structure.`}
+` : `${headingContext?.extractorOffset ? `
+## Heading Offset Detected
+The PDF tag tree in this document uses heading levels that are ${headingContext.extractorOffset} level(s) too high. When classifying heading zones on this page, subtract ${headingContext.extractorOffset} from the extractor heading level:
+- Extractor H1 → use h${1 + headingContext.extractorOffset}
+- Extractor H2 → use h${2 + headingContext.extractorOffset}
+- Extractor H3 → use h${3 + headingContext.extractorOffset}
+` : ''}`}
 ## Zones to Classify
 \`\`\`json
 ${JSON.stringify(zonesJson, null, 2)}

--- a/src/services/calibration/ai-annotation.service.ts
+++ b/src/services/calibration/ai-annotation.service.ts
@@ -90,6 +90,30 @@ async function classifyPageWithFallback(
   };
 }
 
+/**
+ * Detect if the PDF tag tree uses heading levels that are systematically too high.
+ * Heuristic: if H1-level tags (from pdfxtLabel) appear on more than 2 distinct pages,
+ * they are likely chapter headings rather than the document title → offset = 1.
+ */
+function detectExtractorHeadingOffset(
+  zones: Array<{ pageNumber: number; pdfxtLabel: string | null }>,
+): number {
+  const pdfxtHeadingPattern = /^H(\d)$/i;
+  const h1Pages = new Set<number>();
+
+  for (const z of zones) {
+    if (!z.pdfxtLabel) continue;
+    const match = pdfxtHeadingPattern.exec(z.pdfxtLabel.trim());
+    if (match && parseInt(match[1], 10) === 1) {
+      h1Pages.add(z.pageNumber);
+    }
+  }
+
+  // H1 on >2 distinct pages → chapter-level headings, not document title
+  if (h1Pages.size > 2) return 1;
+  return 0;
+}
+
 export interface AiAnnotationOptions {
   confidenceThreshold?: number; // minimum confidence to auto-apply (default 0.97)
   model?: string;               // model override
@@ -260,6 +284,11 @@ export async function runAiAnnotation(
     // maintain consistent heading hierarchy throughout the document
     const headingContext: HeadingContext = { stack: [], maxDepth: 0 };
     const HEADING_PATTERN = /^h([1-6])$/;
+
+    // Detect heading offset from extractor labels before classification begins.
+    // If the PDF tag tree uses H1 for chapter headings (instead of document title),
+    // the AI should subtract 1 from every extractor heading level.
+    headingContext.extractorOffset = detectExtractorHeadingOffset(zones);
 
     const sortedPages = [...byPage.keys()].sort((a, b) => a - b);
     const pagesWithZones = sortedPages.length;

--- a/src/services/calibration/ai-annotation.service.ts
+++ b/src/services/calibration/ai-annotation.service.ts
@@ -285,10 +285,16 @@ export async function runAiAnnotation(
     const headingContext: HeadingContext = { stack: [], maxDepth: 0 };
     const HEADING_PATTERN = /^h([1-6])$/;
 
-    // Detect heading offset from extractor labels before classification begins.
-    // If the PDF tag tree uses H1 for chapter headings (instead of document title),
-    // the AI should subtract 1 from every extractor heading level.
-    headingContext.extractorOffset = detectExtractorHeadingOffset(zones);
+    // Detect heading offset from extractor labels across the FULL document,
+    // not just the current page range. On partial re-runs (pageStart/pageEnd),
+    // using only the filtered zones would undercount H1 pages and miss the offset.
+    const allZonesForOffset = (options.pageStart !== undefined || options.pageEnd !== undefined)
+      ? await prisma.zone.findMany({
+          where: { calibrationRunId, isGhost: false },
+          select: { pageNumber: true, pdfxtLabel: true },
+        })
+      : zones;
+    headingContext.extractorOffset = detectExtractorHeadingOffset(allZonesForOffset);
 
     const sortedPages = [...byPage.keys()].sort((a, b) => a - b);
     const pagesWithZones = sortedPages.length;

--- a/src/services/calibration/annotation-analysis.service.ts
+++ b/src/services/calibration/annotation-analysis.service.ts
@@ -351,10 +351,17 @@ ${slowestPage ? `- Slowest page: p${slowestPage.pageNumber} (${slowestPage.zones
 - Zones with AI annotation: ${la.aiCoverage.withAi} (${fmtPct(la.aiCoverage.withAi, s.totalZones)})
 - Zones without AI: ${la.aiCoverage.withoutAi} (${fmtPct(la.aiCoverage.withoutAi, s.totalZones)})
 - AI model: ${la.aiCoverage.model ?? 'none'}
-- AI decisions: CONFIRMED=${la.aiDecisionDist.confirmed}, CORRECTED=${la.aiDecisionDist.corrected}, REJECTED=${la.aiDecisionDist.rejected}
+### AI Decision Distribution
+| Decision | Count | % of AI-Annotated |
+|---|---|---|
+| CONFIRMED | ${la.aiDecisionDist.confirmed} | ${fmtPct(la.aiDecisionDist.confirmed, la.aiCoverage.withAi)} |
+| CORRECTED | ${la.aiDecisionDist.corrected} | ${fmtPct(la.aiDecisionDist.corrected, la.aiCoverage.withAi)} |
+| REJECTED | ${la.aiDecisionDist.rejected} | ${fmtPct(la.aiDecisionDist.rejected, la.aiCoverage.withAi)} |
 
 ## AI Confidence Distribution
-${la.confidenceDist.map(d => `  ${d.confidence}: ${d.count} zones`).join('\n')}
+| Confidence | Count | % of AI-Annotated |
+|---|---|---|
+${la.confidenceDist.map(d => `| ${d.confidence.toFixed(2)} | ${d.count} | ${fmtPct(d.count, la.aiCoverage.withAi)} |`).join('\n')}
 
 ## AI vs Human Agreement (${la.agreement.sameDecisionAndLabel + la.agreement.sameDecisionDiffLabel + la.agreement.differentDecision} zones with both)
 - Same decision AND label: ${la.agreement.sameDecisionAndLabel} (${fmtPct(la.agreement.sameDecisionAndLabel, la.agreement.sameDecisionAndLabel + la.agreement.sameDecisionDiffLabel + la.agreement.differentDecision)})
@@ -388,7 +395,9 @@ ${Object.entries(la.perBucket).map(([b, s]) =>
 ${q.mostCorrectedPage ? `- Most corrected page: p${q.mostCorrectedPage.page} (${q.mostCorrectedPage.corrections} corrections)` : ''}
 
 ## Zone Type Correction Rates
-${ztb.map(z => `  ${z.zoneType}: ${z.total} total, confirm ${z.confirmPct != null ? (z.confirmPct * 100).toFixed(1) + '%' : '—'}, correct ${z.correctPct != null ? (z.correctPct * 100).toFixed(1) + '%' : '—'}, reject ${z.rejectPct != null ? (z.rejectPct * 100).toFixed(1) + '%' : '—'}`).join('\n')}
+| Zone Type | Total | Confirm% | Correct% | Reject% |
+|---|---|---|---|---|
+${ztb.map(z => `| ${z.zoneType} | ${z.total} | ${z.confirmPct != null ? (z.confirmPct * 100).toFixed(1) + '%' : '—'} | ${z.correctPct != null ? (z.correctPct * 100).toFixed(1) + '%' : '—'} | ${z.rejectPct != null ? (z.rejectPct * 100).toFixed(1) + '%' : '—'} |`).join('\n')}
 
 ## Efficiency
 - Auto-annotation savings: ${fmtMs(eff.autoAnnotationSavingsMs)}

--- a/src/services/calibration/auto-annotation.service.ts
+++ b/src/services/calibration/auto-annotation.service.ts
@@ -14,6 +14,8 @@
  *   6. GREEN Bucket Confirm — both extractors agree on canonical type
  *   7. Figure Cross-Validation — either extractor identifies figure/picture
  *   8. Section-Header Resolution — resolve section-header to h-level by bbox height
+ *   9. Footer Artefact Rejection — reject all footer zones (running page footers)
+ *  10. Header Artefact Rejection — reject RED-bucket header zones (single-extractor page headers)
  */
 import prisma from '../../lib/prisma';
 import { logger } from '../../lib/logger';
@@ -679,6 +681,82 @@ async function applySectionHeaderResolution(zones: ZoneRow[]): Promise<PatternRe
   return result;
 }
 
+// ── Pattern 9: Footer Artefact Rejection ──────────────────────────
+
+async function applyFooterArtefactRejection(zones: ZoneRow[]): Promise<PatternResult> {
+  const result: PatternResult = {
+    pattern: 'footer-artefact-rejection',
+    description: 'Reject all footer zones (running page footers are non-semantic)',
+    confirmed: 0, corrected: 0, rejected: 0, skipped: 0, details: [],
+  };
+
+  const footerZones = zones.filter(
+    (z) => !z.operatorVerified && !z.isArtefact && !z.decision &&
+      z.type === 'footer',
+  );
+
+  if (footerZones.length === 0) return result;
+
+  const ids = footerZones.map(z => z.id);
+  await prisma.zone.updateMany({
+    where: { id: { in: ids } },
+    data: {
+      isArtefact: true,
+      operatorVerified: true,
+      decision: 'REJECTED',
+      correctionReason: 'Auto-annotation: running footer artefact',
+      verifiedAt: new Date(),
+      verifiedBy: SYSTEM_OPERATOR,
+    },
+  });
+  result.rejected = ids.length;
+
+  const pageSet = new Set(footerZones.map(z => z.pageNumber));
+  result.details.push(`${ids.length} footer zones rejected across ${pageSet.size} pages`);
+
+  return result;
+}
+
+// ── Pattern 10: Header Artefact Rejection (RED bucket) ────────────
+
+async function applyHeaderArtefactRejection(zones: ZoneRow[]): Promise<PatternResult> {
+  const result: PatternResult = {
+    pattern: 'header-artefact-rejection',
+    description: 'Reject RED-bucket header zones (single-extractor running headers)',
+    confirmed: 0, corrected: 0, rejected: 0, skipped: 0, details: [],
+  };
+
+  // Only reject headers in the RED bucket (single-extractor, low confidence).
+  // GREEN-bucket headers where both extractors agree are left for human review
+  // since ~10% of those are legitimate content headers (e.g., page 1 title).
+  const headerZones = zones.filter(
+    (z) => !z.operatorVerified && !z.isArtefact && !z.decision &&
+      z.type === 'header' &&
+      z.reconciliationBucket === 'RED',
+  );
+
+  if (headerZones.length === 0) return result;
+
+  const ids = headerZones.map(z => z.id);
+  await prisma.zone.updateMany({
+    where: { id: { in: ids } },
+    data: {
+      isArtefact: true,
+      operatorVerified: true,
+      decision: 'REJECTED',
+      correctionReason: 'Auto-annotation: RED-bucket running header artefact',
+      verifiedAt: new Date(),
+      verifiedBy: SYSTEM_OPERATOR,
+    },
+  });
+  result.rejected = ids.length;
+
+  const pageSet = new Set(headerZones.map(z => z.pageNumber));
+  result.details.push(`${ids.length} RED-bucket header zones rejected across ${pageSet.size} pages`);
+
+  return result;
+}
+
 // ── Main Orchestrator ───────────────────────────────────────────────
 
 export async function runAutoAnnotation(
@@ -722,6 +800,8 @@ export async function runAutoAnnotation(
     { name: 'duplicate-fig-rejection', fn: applyDuplicateFigRejection },
     { name: 'figure-cross-validation', fn: applyFigureCrossValidation },
     { name: 'section-header-resolution', fn: applySectionHeaderResolution },
+    { name: 'footer-artefact-rejection', fn: applyFooterArtefactRejection },
+    { name: 'header-artefact-rejection', fn: applyHeaderArtefactRejection },
     { name: 'green-bucket-confirm', fn: applyGreenBucketConfirm },
   ];
 

--- a/src/services/calibration/auto-annotation.service.ts
+++ b/src/services/calibration/auto-annotation.service.ts
@@ -5,17 +5,17 @@
  * review effort. Each pattern targets a specific class of zones that
  * can be reliably confirmed, corrected, or rejected without human review.
  *
- * Patterns:
+ * Patterns (execution order):
  *   1. Ghost Zone Rejection — isGhost=true or zero-area bbox
  *   2. TOCI Bulk Confirm — all TOCI zones from pdfxt
- *   3. Running Header Auto-Classification — H on page>1 with header content
- *   4. List Item Sequence Confirm — ≥3 consecutive LI zones on a page
- *   5. Duplicate FIG Rejection — overlapping FIG zones, keep higher confidence
- *   6. GREEN Bucket Confirm — both extractors agree on canonical type
- *   7. Figure Cross-Validation — either extractor identifies figure/picture
- *   8. Section-Header Resolution — resolve section-header to h-level by bbox height
- *   9. Footer Artefact Rejection — reject all footer zones (running page footers)
- *  10. Header Artefact Rejection — reject RED-bucket header zones (single-extractor page headers)
+ *   3. Footer Artefact Rejection — reject all footer zones (running page footers)
+ *   4. Header Artefact Rejection — reject RED-bucket header zones (single-extractor page headers)
+ *   5. Running Header Classification — reclassify running headers from H to HDR
+ *   6. List-Item Sequence Confirm — ≥3 consecutive LI zones on a page
+ *   7. Duplicate Figure Rejection — overlapping FIG zones, keep higher confidence
+ *   8. Figure Cross-Validation — either extractor identifies figure/picture
+ *   9. Section-Header Resolution — resolve section-header to h-level by bbox height
+ *  10. GREEN Bucket Confirm — both extractors agree on canonical type
  */
 import prisma from '../../lib/prisma';
 import { logger } from '../../lib/logger';
@@ -795,13 +795,13 @@ export async function runAutoAnnotation(
   const allPatterns = [
     { name: 'ghost-zone-rejection', fn: applyGhostZoneRejection },
     { name: 'toci-bulk-confirm', fn: applyTociBulkConfirm },
+    { name: 'footer-artefact-rejection', fn: applyFooterArtefactRejection },
+    { name: 'header-artefact-rejection', fn: applyHeaderArtefactRejection },
     { name: 'running-header-classification', fn: applyRunningHeaderClassification },
     { name: 'list-item-sequence-confirm', fn: applyListItemSequenceConfirm },
     { name: 'duplicate-fig-rejection', fn: applyDuplicateFigRejection },
     { name: 'figure-cross-validation', fn: applyFigureCrossValidation },
     { name: 'section-header-resolution', fn: applySectionHeaderResolution },
-    { name: 'footer-artefact-rejection', fn: applyFooterArtefactRejection },
-    { name: 'header-artefact-rejection', fn: applyHeaderArtefactRejection },
     { name: 'green-bucket-confirm', fn: applyGreenBucketConfirm },
   ];
 


### PR DESCRIPTION
## Summary
- **Heading offset detection**: Detects when PDF tag tree heading levels are systematically 1 level too high (H1 on >2 pages = chapter headings, not document title). Injects correction bias into AI classification prompt so it outputs h2/h3/h4 instead of h1/h2/h3. Targets ~120 heading corrections per document.
- **Auto-reject footer zones** (Pattern 9): All footer zones are rejected automatically — 100% rejection rate in annotator data across both analyzed documents.
- **Auto-reject RED-bucket header zones** (Pattern 10): Single-extractor page headers rejected automatically — 89.7% rejection rate. GREEN-bucket headers (both extractors agree) kept for human review since ~10% are legitimate content headers.
- **Pattern ordering fix**: Rejection patterns now run before green-bucket-confirm to prevent GREEN-bucket footers from being incorrectly confirmed.
- **Analysis report formatting**: AI decision distribution and zone type tables now render as markdown tables.

## Context
Based on timesheet analysis of documents cmnpdryw (Nambi T) and cmnmw6d4 (Poornakala U), which both showed:
- Systematic heading off-by-1 error (11% of all zones)
- 91.2% rejection rate for header/footer zones (135 manual rejections per document)
- Identical ~47% session correction rate across annotators, confirming these are document-level patterns, not annotator-specific

## Test plan
- [ ] Typecheck passes (`npx tsc --noEmit`)
- [ ] Existing tests pass (889/896, 7 pre-existing failures in workflow-config integration)
- [ ] Re-run AI annotation on a heading-heavy document and verify heading levels shift down by 1
- [ ] Run auto-annotation on a document with footer/header zones and verify they are auto-rejected
- [ ] Verify GREEN-bucket headers are NOT rejected (only RED-bucket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter detection of heading-level offsets to improve document heading classification accuracy.
  * Automated bulk rejection of header and footer artefacts during annotation runs.
  * Richer annotation reports with tables showing AI decision distribution, confidence breakdowns, and zone correction rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->