### PR TITLE
feat: corpus summary v2 — cross-title lineage & timesheet aggregations

### DIFF
--- a/src/controllers/annotation-report.controller.ts
+++ b/src/controllers/annotation-report.controller.ts
@@ -319,7 +319,11 @@ class AnnotationReportController {
         });
         return;
       }
-      const range = resolveCorpusRange(parsed.data);
+      // Legacy contract: when no from/to is supplied, return the full
+      // history (not a synthesized last-30-days window). Only narrow the
+      // result when the caller explicitly asked for a range.
+      const hasRange = parsed.data.from !== undefined || parsed.data.to !== undefined;
+      const range = hasRange ? resolveCorpusRange(parsed.data) : undefined;
       const result = await generateCorpusSummary(range);
       res.json({ success: true, data: result });
     } catch (err) {

--- a/src/controllers/annotation-report.controller.ts
+++ b/src/controllers/annotation-report.controller.ts
@@ -8,7 +8,16 @@ import {
   generateCorpusSummary,
   type MarkCompleteInput,
 } from '../services/calibration/annotation-analysis.service';
+import {
+  getLineageSummary,
+  getTimesheetSummary,
+  exportLineageSummaryCsv,
+  exportTimesheetPerOperatorCsv,
+  exportTimesheetPerTitleCsv,
+  exportTimesheetSummaryPdf,
+} from '../services/calibration/corpus-summary.service';
 import { markCompleteBodySchema } from '../schemas/mark-complete.schema';
+import { corpusRangeQuerySchema, resolveCorpusRange } from '../schemas/corpus-summary.schema';
 import prisma from '../lib/prisma';
 import { logger } from '../lib/logger';
 
@@ -292,12 +301,158 @@ class AnnotationReportController {
   }
 
   /** GET /calibration/corpus/analysis-summary — Cross-title corpus summary */
-  async getCorpusSummary(_req: Request, res: Response, _next: NextFunction): Promise<void> {
+  async getCorpusSummary(req: Request, res: Response, _next: NextFunction): Promise<void> {
     try {
-      const result = await generateCorpusSummary();
+      const parsed = corpusRangeQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.status(422).json({
+          success: false,
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid range parameters',
+            details: parsed.error.issues,
+          },
+        });
+        return;
+      }
+      const range = resolveCorpusRange(parsed.data);
+      const result = await generateCorpusSummary(range);
       res.json({ success: true, data: result });
     } catch (err) {
       serverError(res, err, 'CORPUS_SUMMARY_FAILED');
+    }
+  }
+
+  // ── Corpus Summary v2 (Backend PR #2) ─────────────────────────────────
+
+  /**
+   * Shared range-query parser. Returns `null` and writes a 422 response when
+   * parsing fails so callers can simply `if (!range) return;` and stay terse.
+   */
+  private parseCorpusRange(
+    req: Request,
+    res: Response,
+  ): { from: Date; to: Date } | null {
+    const parsed = corpusRangeQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(422).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid range parameters',
+          details: parsed.error.issues,
+        },
+      });
+      return null;
+    }
+    return resolveCorpusRange(parsed.data);
+  }
+
+  /** GET /calibration/corpus/lineage-summary */
+  async getCorpusLineageSummary(req: Request, res: Response, _next: NextFunction): Promise<void> {
+    try {
+      const range = this.parseCorpusRange(req, res);
+      if (!range) return;
+      const result = await getLineageSummary(range);
+      res.json({ success: true, data: result });
+    } catch (err) {
+      serverError(res, err, 'CORPUS_LINEAGE_SUMMARY_FAILED');
+    }
+  }
+
+  /** GET /calibration/corpus/timesheet-summary */
+  async getCorpusTimesheetSummary(req: Request, res: Response, _next: NextFunction): Promise<void> {
+    try {
+      const range = this.parseCorpusRange(req, res);
+      if (!range) return;
+      const result = await getTimesheetSummary(range);
+      res.json({ success: true, data: result });
+    } catch (err) {
+      serverError(res, err, 'CORPUS_TIMESHEET_SUMMARY_FAILED');
+    }
+  }
+
+  /** GET /calibration/corpus/lineage-summary/export/csv */
+  async exportCorpusLineageCsv(req: Request, res: Response, _next: NextFunction): Promise<void> {
+    try {
+      const range = this.parseCorpusRange(req, res);
+      if (!range) return;
+      const csv = await exportLineageSummaryCsv(range);
+      const fromStr = range.from.toISOString().slice(0, 10).replace(/-/g, '');
+      const toStr = range.to.toISOString().slice(0, 10).replace(/-/g, '');
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="corpus-lineage-summary-${fromStr}-${toStr}.csv"`,
+      );
+      res.send(csv);
+    } catch (err) {
+      serverError(res, err, 'EXPORT_CORPUS_LINEAGE_CSV_FAILED');
+    }
+  }
+
+  /** GET /calibration/corpus/timesheet-summary/export/per-operator-csv */
+  async exportCorpusTimesheetPerOperatorCsv(
+    req: Request,
+    res: Response,
+    _next: NextFunction,
+  ): Promise<void> {
+    try {
+      const range = this.parseCorpusRange(req, res);
+      if (!range) return;
+      const csv = await exportTimesheetPerOperatorCsv(range);
+      const fromStr = range.from.toISOString().slice(0, 10).replace(/-/g, '');
+      const toStr = range.to.toISOString().slice(0, 10).replace(/-/g, '');
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="corpus-timesheet-per-operator-${fromStr}-${toStr}.csv"`,
+      );
+      res.send(csv);
+    } catch (err) {
+      serverError(res, err, 'EXPORT_CORPUS_TIMESHEET_PER_OPERATOR_CSV_FAILED');
+    }
+  }
+
+  /** GET /calibration/corpus/timesheet-summary/export/per-title-csv */
+  async exportCorpusTimesheetPerTitleCsv(
+    req: Request,
+    res: Response,
+    _next: NextFunction,
+  ): Promise<void> {
+    try {
+      const range = this.parseCorpusRange(req, res);
+      if (!range) return;
+      const csv = await exportTimesheetPerTitleCsv(range);
+      const fromStr = range.from.toISOString().slice(0, 10).replace(/-/g, '');
+      const toStr = range.to.toISOString().slice(0, 10).replace(/-/g, '');
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="corpus-timesheet-per-title-${fromStr}-${toStr}.csv"`,
+      );
+      res.send(csv);
+    } catch (err) {
+      serverError(res, err, 'EXPORT_CORPUS_TIMESHEET_PER_TITLE_CSV_FAILED');
+    }
+  }
+
+  /** GET /calibration/corpus/timesheet-summary/export/pdf */
+  async exportCorpusTimesheetPdf(req: Request, res: Response, _next: NextFunction): Promise<void> {
+    try {
+      const range = this.parseCorpusRange(req, res);
+      if (!range) return;
+      const pdfBuffer = await exportTimesheetSummaryPdf(range);
+      const fromStr = range.from.toISOString().slice(0, 10).replace(/-/g, '');
+      const toStr = range.to.toISOString().slice(0, 10).replace(/-/g, '');
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="corpus-timesheet-summary-${fromStr}-${toStr}.pdf"`,
+      );
+      res.send(pdfBuffer);
+    } catch (err) {
+      serverError(res, err, 'EXPORT_CORPUS_TIMESHEET_PDF_FAILED');
     }
   }
 }

--- a/src/controllers/annotation-report.controller.ts
+++ b/src/controllers/annotation-report.controller.ts
@@ -22,12 +22,16 @@ import prisma from '../lib/prisma';
 import { logger } from '../lib/logger';
 
 function serverError(res: Response, err: unknown, code: string) {
+  // Full error + stack goes to the server log for operators, but the
+  // client response only carries a stable error code + generic message.
+  // Returning `err.message` leaks internal details (Prisma constraint
+  // names, file paths, query fragments) to whoever can hit the endpoint.
   logger.error(`[AnnotationReportController] ${code}`, err);
   return res.status(500).json({
     success: false,
     error: {
       code,
-      message: err instanceof Error ? err.message : 'Internal server error',
+      message: 'Internal server error',
     },
   });
 }

--- a/src/routes/annotation-report.routes.ts
+++ b/src/routes/annotation-report.routes.ts
@@ -6,7 +6,33 @@ const router = Router();
 
 router.use(authenticate);
 
-// Corpus-level (static route before parameterized)
+// Corpus-level (static routes before parameterized). Order matters — more
+// specific export paths must come before their parent summary routes so the
+// router matches them first.
+router.get(
+  '/corpus/lineage-summary/export/csv',
+  annotationReportController.exportCorpusLineageCsv.bind(annotationReportController),
+);
+router.get(
+  '/corpus/timesheet-summary/export/per-operator-csv',
+  annotationReportController.exportCorpusTimesheetPerOperatorCsv.bind(annotationReportController),
+);
+router.get(
+  '/corpus/timesheet-summary/export/per-title-csv',
+  annotationReportController.exportCorpusTimesheetPerTitleCsv.bind(annotationReportController),
+);
+router.get(
+  '/corpus/timesheet-summary/export/pdf',
+  annotationReportController.exportCorpusTimesheetPdf.bind(annotationReportController),
+);
+router.get(
+  '/corpus/lineage-summary',
+  annotationReportController.getCorpusLineageSummary.bind(annotationReportController),
+);
+router.get(
+  '/corpus/timesheet-summary',
+  annotationReportController.getCorpusTimesheetSummary.bind(annotationReportController),
+);
 router.get('/corpus/analysis-summary', annotationReportController.getCorpusSummary.bind(annotationReportController));
 
 // Annotation analysis

--- a/src/schemas/corpus-summary.schema.ts
+++ b/src/schemas/corpus-summary.schema.ts
@@ -3,36 +3,80 @@ import { z } from 'zod';
 /**
  * Query-param schema for corpus-summary v2 endpoints.
  *
- * Both params are optional ISO-8601 strings. Defaults applied by the caller
- * (NOT here) so we can distinguish "caller omitted" from "caller sent nothing"
- * cleanly when merging with feature-flag defaults.
+ * Both params are optional ISO-8601 strings. The spec calls out "ISO date"
+ * (e.g. `2026-04-01`), but we also accept full ISO datetimes with offsets
+ * (e.g. `2026-04-01T12:00:00Z`) so callers can express sub-day precision
+ * when needed. Defaults applied by `resolveCorpusRange` below.
  *
  * Validation rules:
- * - `from` and `to` must be parseable ISO-8601 dates if present
- * - When both are provided, `from <= to`
+ * - `from` / `to` must match YYYY-MM-DD OR a valid ISO-8601 datetime with offset.
+ * - When both are provided, `from <= to` (enforced after normalization).
  */
+const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+const isoDateOrDatetime = (fieldName: 'from' | 'to') =>
+  z
+    .string()
+    .refine(
+      (v) => {
+        if (ISO_DATE_ONLY.test(v)) {
+          // Validate it's a real calendar date. Date.parse rolls 2026-02-31
+          // over to 2026-03-03, so we have to round-trip and compare.
+          const [y, m, d] = v.split('-').map(Number);
+          const parsed = new Date(Date.UTC(y!, (m ?? 0) - 1, d ?? 0));
+          return (
+            parsed.getUTCFullYear() === y &&
+            parsed.getUTCMonth() === (m ?? 0) - 1 &&
+            parsed.getUTCDate() === d
+          );
+        }
+        // Fall back to strict datetime with timezone offset.
+        return (
+          /T/.test(v) &&
+          /(Z|[+-]\d{2}:?\d{2})$/.test(v) &&
+          Number.isFinite(Date.parse(v))
+        );
+      },
+      { message: `${fieldName} must be an ISO-8601 date (YYYY-MM-DD) or datetime with offset` },
+    )
+    .optional();
+
 export const corpusRangeQuerySchema = z
   .object({
-    from: z
-      .string()
-      .datetime({ offset: true, message: 'from must be an ISO-8601 datetime' })
-      .optional(),
-    to: z
-      .string()
-      .datetime({ offset: true, message: 'to must be an ISO-8601 datetime' })
-      .optional(),
+    from: isoDateOrDatetime('from'),
+    to: isoDateOrDatetime('to'),
   })
   .superRefine((val, ctx) => {
-    if (val.from && val.to && new Date(val.from).getTime() > new Date(val.to).getTime()) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['from'],
-        message: 'from must be on or before to',
-      });
+    if (val.from && val.to) {
+      // Compare after normalizing both ends — date-only `from` parses as 00:00Z
+      // and date-only `to` parses as 23:59Z, so same-day from=to is valid.
+      const fromMs = normalizeRangeBound(val.from, 'from').getTime();
+      const toMs = normalizeRangeBound(val.to, 'to').getTime();
+      if (fromMs > toMs) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['from'],
+          message: 'from must be on or before to',
+        });
+      }
     }
   });
 
 export type CorpusRangeQuery = z.infer<typeof corpusRangeQuerySchema>;
+
+/**
+ * Normalize a validated range bound to a Date.
+ * - `YYYY-MM-DD` as `from` → start of UTC day (00:00:00.000Z)
+ * - `YYYY-MM-DD` as `to`   → end of UTC day   (23:59:59.999Z)
+ * - Full datetime          → parsed as-is
+ */
+function normalizeRangeBound(value: string, which: 'from' | 'to'): Date {
+  if (ISO_DATE_ONLY.test(value)) {
+    const suffix = which === 'from' ? 'T00:00:00.000Z' : 'T23:59:59.999Z';
+    return new Date(`${value}${suffix}`);
+  }
+  return new Date(value);
+}
 
 /**
  * Default window — last 30 days ending "now" — applied when a caller omits
@@ -41,7 +85,9 @@ export type CorpusRangeQuery = z.infer<typeof corpusRangeQuerySchema>;
  */
 export function resolveCorpusRange(query: CorpusRangeQuery): { from: Date; to: Date } {
   const now = new Date();
-  const to = query.to ? new Date(query.to) : now;
-  const from = query.from ? new Date(query.from) : new Date(to.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const to = query.to ? normalizeRangeBound(query.to, 'to') : now;
+  const from = query.from
+    ? normalizeRangeBound(query.from, 'from')
+    : new Date(to.getTime() - 30 * 24 * 60 * 60 * 1000);
   return { from, to };
 }

--- a/src/schemas/corpus-summary.schema.ts
+++ b/src/schemas/corpus-summary.schema.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+/**
+ * Query-param schema for corpus-summary v2 endpoints.
+ *
+ * Both params are optional ISO-8601 strings. Defaults applied by the caller
+ * (NOT here) so we can distinguish "caller omitted" from "caller sent nothing"
+ * cleanly when merging with feature-flag defaults.
+ *
+ * Validation rules:
+ * - `from` and `to` must be parseable ISO-8601 dates if present
+ * - When both are provided, `from <= to`
+ */
+export const corpusRangeQuerySchema = z
+  .object({
+    from: z
+      .string()
+      .datetime({ offset: true, message: 'from must be an ISO-8601 datetime' })
+      .optional(),
+    to: z
+      .string()
+      .datetime({ offset: true, message: 'to must be an ISO-8601 datetime' })
+      .optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.from && val.to && new Date(val.from).getTime() > new Date(val.to).getTime()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['from'],
+        message: 'from must be on or before to',
+      });
+    }
+  });
+
+export type CorpusRangeQuery = z.infer<typeof corpusRangeQuerySchema>;
+
+/**
+ * Default window — last 30 days ending "now" — applied when a caller omits
+ * either end. Returned alongside the resolved Dates so handlers can echo the
+ * range back in the response envelope.
+ */
+export function resolveCorpusRange(query: CorpusRangeQuery): { from: Date; to: Date } {
+  const now = new Date();
+  const to = query.to ? new Date(query.to) : now;
+  const from = query.from ? new Date(query.from) : new Date(to.getTime() - 30 * 24 * 60 * 60 * 1000);
+  return { from, to };
+}

--- a/src/services/calibration/annotation-analysis.service.ts
+++ b/src/services/calibration/annotation-analysis.service.ts
@@ -52,6 +52,7 @@ export interface MarkCompleteInput {
 
 export interface CorpusSummaryResult {
   summaryReport: AnalysisReport;
+  range?: { from: string; to: string };
   costSummary: {
     titles: Array<{
       documentName: string;
@@ -62,6 +63,10 @@ export interface CorpusSummaryResult {
       aiReportCostInr: number;
       annotatorCostInr: number;
       totalCostInr: number;
+      // NEW in PR #2 — feeds the corpus-summary tabs on the frontend so they
+      // can filter/sort by completion time and surface operator issue counts.
+      completedAt: string | null;
+      issuesCount: number;
     }>;
     totals: {
       documents: number;
@@ -839,17 +844,35 @@ export async function getStoredAnalysis(runId: string): Promise<PerTitleAnalysis
   };
 }
 
-export async function generateCorpusSummary(): Promise<CorpusSummaryResult> {
-  // 1. Fetch all completed runs with stored analysis
+/**
+ * Cross-title corpus summary. Now accepts an optional `[from, to]` window
+ * (spec §Backend PR #2, §4 cost-summary additions). When no range is given,
+ * returns *all* completed runs (historical behavior preserved for legacy
+ * callers).
+ *
+ * An empty range returns a valid, zeroed response — never throws. That
+ * matches the spec's empty-range rules for the sibling lineage/timesheet
+ * endpoints so all three feel consistent.
+ */
+export async function generateCorpusSummary(
+  range?: { from: Date; to: Date },
+): Promise<CorpusSummaryResult> {
+  // 1. Fetch all completed runs with stored analysis within the window
   const completedRuns = await prisma.calibrationRun.findMany({
-    where: { completedAt: { not: null } },
+    where: {
+      completedAt: range
+        ? { gte: range.from, lte: range.to, not: null }
+        : { not: null },
+    },
     select: {
       id: true,
+      completedAt: true,
       summary: true,
       corpusDocument: { select: { filename: true, pageCount: true } },
       zones: { select: { decision: true }, where: { decision: { not: null } } },
       annotationSessions: { select: { activeMs: true, operatorId: true, zonesReviewed: true } },
       aiAnnotationRuns: { where: { status: 'COMPLETED' }, select: { estimatedCostUsd: true } },
+      _count: { select: { issues: true } },
     },
     orderBy: { completedAt: 'asc' },
   });
@@ -858,7 +881,33 @@ export async function generateCorpusSummary(): Promise<CorpusSummaryResult> {
   const analyzedRuns = completedRuns.filter(run => run.zones.length > 0);
 
   if (analyzedRuns.length === 0) {
-    throw new Error('No completed annotation runs with reviewed zones found');
+    // Spec: empty range returns a valid, zeroed response — not a throw.
+    // For legacy callers (no range supplied) we preserve the old behavior
+    // and throw so callers/tests that relied on the error keep working.
+    if (!range) {
+      throw new Error('No completed annotation runs with reviewed zones found');
+    }
+    return {
+      summaryReport: {
+        markdown: '_No completed annotation runs in the selected range._',
+        generatedAt: new Date().toISOString(),
+        model: 'claude-haiku-4.5',
+        tokenUsage: { promptTokens: 0, completionTokens: 0 },
+      },
+      range: { from: range.from.toISOString(), to: range.to.toISOString() },
+      costSummary: {
+        titles: [],
+        totals: {
+          documents: 0,
+          pages: 0,
+          zones: 0,
+          aiAnnotationCostInr: 0,
+          aiReportCostInr: 0,
+          annotatorCostInr: 0,
+          totalCostInr: 0,
+        },
+      },
+    };
   }
 
   // 2. Build per-title summaries
@@ -897,6 +946,8 @@ export async function generateCorpusSummary(): Promise<CorpusSummaryResult> {
       agreementRate: (sum.agreementRate as number | undefined) ?? null,
       aiAgreementRate: null as number | null,
       costBreakdown,
+      completedAt: run.completedAt ? run.completedAt.toISOString() : null,
+      issuesCount: run._count.issues,
     };
   });
 
@@ -927,6 +978,8 @@ export async function generateCorpusSummary(): Promise<CorpusSummaryResult> {
     aiReportCostInr: r.costBreakdown.aiReportCostUsd * USD_TO_INR,
     annotatorCostInr: r.costBreakdown.annotatorCostInr,
     totalCostInr: r.costBreakdown.totalCostInr,
+    completedAt: r.completedAt,
+    issuesCount: r.issuesCount,
   }));
 
   const totals = {
@@ -946,6 +999,9 @@ export async function generateCorpusSummary(): Promise<CorpusSummaryResult> {
       model: 'claude-haiku-4.5',
       tokenUsage,
     },
+    ...(range
+      ? { range: { from: range.from.toISOString(), to: range.to.toISOString() } }
+      : {}),
     costSummary: { titles: costTitles, totals },
   };
 }

--- a/src/services/calibration/annotation-analysis.service.ts
+++ b/src/services/calibration/annotation-analysis.service.ts
@@ -816,6 +816,9 @@ export async function getStoredAnalysis(runId: string): Promise<PerTitleAnalysis
       completionNotes: true,
       // Stable ordering (see note in generateAnnotationAnalysis above).
       issues: { orderBy: [{ createdAt: 'asc' }, { id: 'asc' }] },
+      // Needed to recompute annotatorCostInr from the live session source of
+      // truth — see cost-parity note below.
+      annotationSessions: { select: { activeMs: true } },
     },
   });
 
@@ -835,9 +838,31 @@ export async function getStoredAnalysis(runId: string): Promise<PerTitleAnalysis
     createdAt: iss.createdAt.toISOString(),
   }));
 
+  // Cost-parity invariant: annotatorCostInr is ALWAYS recomputed from the
+  // live session data at read time, never returned from the persisted
+  // summary. `computeCost()` rounds to 2 decimals when it writes the
+  // breakdown, so the persisted number drifts from the unrounded
+  // corpus-timesheet total by up to ₹0.01 per run. AI cost fields are
+  // allowed to be reused because they derive from AI run logs, not
+  // annotator session time.
+  const persistedCost = analysisReports.costBreakdown;
+  const totalActiveMs = run.annotationSessions.reduce((s, sess) => s + sess.activeMs, 0);
+  const annotatorActiveHours = totalActiveMs / 3_600_000;
+  const annotatorCostInr = annotatorActiveHours * ANNOTATOR_RATE_INR_PER_HOUR;
+  const recomputedCost: CostBreakdown = {
+    aiAnnotationCostUsd: persistedCost.aiAnnotationCostUsd,
+    aiReportCostUsd: persistedCost.aiReportCostUsd,
+    annotatorActiveHours,
+    annotatorCostInr,
+    totalCostInr:
+      persistedCost.aiAnnotationCostUsd * USD_TO_INR +
+      persistedCost.aiReportCostUsd * USD_TO_INR +
+      annotatorCostInr,
+  };
+
   return {
     report: analysisReports.report,
-    costBreakdown: analysisReports.costBreakdown,
+    costBreakdown: recomputedCost,
     pagesReviewed: run.pagesReviewed ?? null,
     completionNotes: run.completionNotes ?? null,
     issues,

--- a/src/services/calibration/annotation-analysis.service.ts
+++ b/src/services/calibration/annotation-analysis.service.ts
@@ -924,12 +924,26 @@ export async function generateCorpusSummary(
     const operatorIds = [...new Set(run.annotationSessions.map(s => s.operatorId))];
     const aiCostUsd = run.aiAnnotationRuns.reduce((s, r) => s + (r.estimatedCostUsd ?? 0), 0);
 
-    const costBreakdown: CostBreakdown = analysisReports?.costBreakdown ?? {
-      aiAnnotationCostUsd: aiCostUsd,
-      aiReportCostUsd: 0,
+    // Cost-parity invariant (see corpus-summary.service.ts):
+    // Annotator cost MUST be recomputed from the live `annotationSessions.activeMs`
+    // every time — never reused from the persisted `analysisReports.costBreakdown`,
+    // because computeCost() rounds that value to 2 decimal places and the rounded
+    // number then diverges from the unrounded corpus-timesheet total. The AI cost
+    // fields are still allowed to be reused from the persisted breakdown since
+    // they are derived from the AI run logs, not from annotator session time.
+    const persistedAi = analysisReports?.costBreakdown;
+    const aiAnnotationCostUsd = persistedAi?.aiAnnotationCostUsd ?? aiCostUsd;
+    const aiReportCostUsd = persistedAi?.aiReportCostUsd ?? 0;
+    const annotatorCostInrRecomputed = totalHours * ANNOTATOR_RATE_INR_PER_HOUR;
+    const costBreakdown: CostBreakdown = {
+      aiAnnotationCostUsd,
+      aiReportCostUsd,
       annotatorActiveHours: totalHours,
-      annotatorCostInr: totalHours * ANNOTATOR_RATE_INR_PER_HOUR,
-      totalCostInr: aiCostUsd * USD_TO_INR + totalHours * ANNOTATOR_RATE_INR_PER_HOUR,
+      annotatorCostInr: annotatorCostInrRecomputed,
+      totalCostInr:
+        aiAnnotationCostUsd * USD_TO_INR +
+        aiReportCostUsd * USD_TO_INR +
+        annotatorCostInrRecomputed,
     };
 
     return {

--- a/src/services/calibration/corpus-summary.service.ts
+++ b/src/services/calibration/corpus-summary.service.ts
@@ -552,26 +552,32 @@ export async function getTimesheetSummary(range: DateRange): Promise<TimesheetSu
   if (runs.length === 0) return emptyTimesheetSummary(range);
 
   // ── Totals ────────────────────────────────────────────────────────────
+  // wallClockMs is the SUM of per-session durations, never `max(endedAt)
+  // − min(startedAt)`. Spanning the entire range counts gaps between
+  // unrelated sessions as work time: two one-hour sessions on consecutive
+  // days would report ~25 wall-clock hours, which badly inflates the
+  // totals card and the PDF export. For in-progress sessions (endedAt
+  // null) we fall back to activeMs + idleMs as a best-effort duration.
   let totalActiveMs = 0;
   let totalIdleMs = 0;
+  let totalWallClockMs = 0;
   let totalZonesReviewed = 0;
-  let earliestStart: Date | null = null;
-  let latestEnd: Date | null = null;
   for (const run of runs) {
     for (const sess of run.annotationSessions) {
       totalActiveMs += sess.activeMs;
       totalIdleMs += sess.idleMs;
       totalZonesReviewed += sess.zonesReviewed;
-      if (!earliestStart || sess.startedAt < earliestStart) earliestStart = sess.startedAt;
-      if (sess.endedAt && (!latestEnd || sess.endedAt > latestEnd)) latestEnd = sess.endedAt;
+      if (sess.endedAt) {
+        totalWallClockMs += sess.endedAt.getTime() - sess.startedAt.getTime();
+      } else {
+        // Session in flight — best-effort fallback keeps totals non-negative.
+        totalWallClockMs += sess.activeMs + sess.idleMs;
+      }
     }
   }
   const totalActiveHours = totalActiveMs / 3_600_000;
   const totalIdleHours = totalIdleMs / 3_600_000;
-  const totalWallClockHours =
-    earliestStart && latestEnd
-      ? (latestEnd.getTime() - earliestStart.getTime()) / 3_600_000
-      : totalActiveHours + totalIdleHours;
+  const totalWallClockHours = totalWallClockMs / 3_600_000;
   const totalZonesPerHour = totalActiveHours > 0 ? totalZonesReviewed / totalActiveHours : 0;
   const totalCostInr = totalActiveHours * ANNOTATOR_RATE_INR_PER_HOUR;
 
@@ -648,24 +654,37 @@ export async function getTimesheetSummary(range: DateRange): Promise<TimesheetSu
   });
 
   // ── Per zone type (avg seconds per zone) ──────────────────────────────
-  // Apportion totalActiveMs across zone types proportional to each type's
+  // Apportion active time across zone types proportional to each type's
   // share of reviewed zones. This matches the per-run approach of treating
   // operator time as uniformly distributed over the zones actually decided.
+  //
+  // IMPORTANT: only count active time from runs that actually contributed
+  // at least one human-decided zone. Otherwise a completed but abandoned
+  // run (annotation time, zero decided zones) would still bleed its hours
+  // into every other run's averages and inflate every avgSecondsPerZone.
   const typeCounts = new Map<string, number>();
   let decidedZoneCount = 0;
+  let decidedRunActiveMs = 0;
   for (const run of runs) {
+    let runDecidedInThisLoop = 0;
     for (const z of run.zones) {
       if (!z.decision) continue;
       if (z.verifiedBy === 'auto-annotation') continue;
+      runDecidedInThisLoop++;
       decidedZoneCount++;
       const key = z.type || 'unknown';
       typeCounts.set(key, (typeCounts.get(key) ?? 0) + 1);
+    }
+    if (runDecidedInThisLoop > 0) {
+      for (const sess of run.annotationSessions) {
+        decidedRunActiveMs += sess.activeMs;
+      }
     }
   }
   const perZoneType = [...typeCounts.entries()]
     .sort(([, a], [, b]) => b - a)
     .map(([zoneType, count]) => {
-      const shareMs = decidedZoneCount > 0 ? totalActiveMs * (count / decidedZoneCount) : 0;
+      const shareMs = decidedZoneCount > 0 ? decidedRunActiveMs * (count / decidedZoneCount) : 0;
       return {
         zoneType,
         totalZones: count,

--- a/src/services/calibration/corpus-summary.service.ts
+++ b/src/services/calibration/corpus-summary.service.ts
@@ -519,6 +519,9 @@ export async function getTimesheetSummary(range: DateRange): Promise<TimesheetSu
         },
       },
       annotationSessions: {
+        // NOTE: don't select sessionLog — it's a potentially-large JSONB blob
+        // and this aggregation never reads it. Including it multiplied the
+        // payload size on corpus-wide ranges for no benefit.
         select: {
           operatorId: true,
           startedAt: true,
@@ -529,7 +532,6 @@ export async function getTimesheetSummary(range: DateRange): Promise<TimesheetSu
           zonesConfirmed: true,
           zonesCorrected: true,
           zonesRejected: true,
-          sessionLog: true,
         },
       },
       _count: { select: { issues: true } },
@@ -717,8 +719,14 @@ export async function getTimesheetSummary(range: DateRange): Promise<TimesheetSu
 // ── CSV helpers ─────────────────────────────────────────────────────────
 
 function csvEscape(v: unknown): string {
-  const s = v === null || v === undefined ? '' : String(v);
-  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  const raw = v === null || v === undefined ? '' : String(v);
+  // CSV-formula-injection guard: cells starting with =, +, -, or @ are
+  // interpreted as formulas in Excel / Google Sheets. Prepend a single quote
+  // so the cell renders as text when opened in a spreadsheet tool. This is
+  // particularly important for operator-entered fields like documentName and
+  // issue descriptions that flow into lineage/timesheet CSV exports.
+  const safe = /^[=+\-@]/.test(raw) ? `'${raw}` : raw;
+  return /[",\n\r]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe;
 }
 
 function csvRow(values: unknown[]): string {

--- a/src/services/calibration/corpus-summary.service.ts
+++ b/src/services/calibration/corpus-summary.service.ts
@@ -1,0 +1,971 @@
+/**
+ * Corpus Summary v2 — cross-title lineage & timesheet aggregations with
+ * time-range filtering.
+ *
+ * Scope (Backend PR #2 of BACKEND_SPEC_MARK_COMPLETE_AND_CORPUS_SUMMARY.md):
+ * - GET /calibration/corpus/lineage-summary
+ * - GET /calibration/corpus/timesheet-summary
+ * - CSV exports (flat per-zone lineage, per-operator, per-title)
+ * - PDF export (timesheet)
+ *
+ * Correctness notes:
+ * - Only includes runs with `completedAt` inside [from, to].
+ * - Empty ranges return a valid, zeroed response — never a 404 or throw.
+ * - Cost is computed through the SAME formula as the per-run path:
+ *     annotatorActiveHours = sum(session.activeMs) / 3_600_000
+ *     annotatorCostInr     = annotatorActiveHours * ANNOTATOR_RATE_INR_PER_HOUR
+ *   (see annotation-analysis.service.ts — we import the constant to prevent drift)
+ */
+
+import prisma from '../../lib/prisma';
+import type { RunIssueCategory } from '@prisma/client';
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+
+// ── Constants (kept in sync with annotation-analysis.service.ts) ────────
+// These must match the per-run cost-computation path. If
+// annotation-analysis.service.ts ever changes its rate, update this value and
+// the cost-parity test will immediately catch the drift.
+export const ANNOTATOR_RATE_INR_PER_HOUR = 400;
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+export interface DateRange {
+  from: Date;
+  to: Date;
+}
+
+export interface LineageSummaryResult {
+  range: { from: string; to: string };
+  runsIncluded: number;
+  headline: {
+    totalZones: number;
+    aiAgreementRate: number;
+    humanCorrectionRate: number;
+    humanRejectionRate: number;
+  };
+  confusionMatrix: {
+    labels: string[];
+    cells: number[][];
+  };
+  perZoneType: Array<{
+    zoneType: string;
+    totalZones: number;
+    aiConfirmPct: number;
+    aiCorrectionPct: number;
+    aiRejectionPct: number;
+    topCorrectedTo: string | null;
+  }>;
+  bucketFlow: {
+    green: BucketRow;
+    amber: BucketRow;
+    red: BucketRow;
+  };
+  issuesLog: Array<{
+    category: RunIssueCategory;
+    titleCount: number;
+    totalPagesAffected: number;
+    blockingCount: number;
+    titles: Array<{
+      runId: string;
+      documentName: string;
+      completedAt: string;
+      pagesAffected: number | null;
+      description: string;
+      blocking: boolean;
+    }>;
+  }>;
+  extractorDisagreement: Array<{
+    finalLabel: string;
+    totalZones: number;
+    disagreementPct: number;
+  }>;
+}
+
+interface BucketRow {
+  total: number;
+  humanConfirmed: number;
+  humanCorrected: number;
+  humanRejected: number;
+}
+
+export interface TimesheetSummaryResult {
+  range: { from: string; to: string };
+  runsIncluded: number;
+  totals: {
+    wallClockHours: number;
+    activeHours: number;
+    idleHours: number;
+    zonesReviewed: number;
+    zonesPerHour: number;
+    annotatorCostInr: number;
+  };
+  perOperator: Array<{
+    operator: string;
+    activeHours: number;
+    zonesReviewed: number;
+    zonesPerHour: number;
+    confirmPct: number;
+    correctPct: number;
+    rejectPct: number;
+    runsContributedTo: number;
+    costInr: number;
+  }>;
+  perTitle: Array<{
+    runId: string;
+    documentName: string;
+    pages: number;
+    activeHours: number;
+    zonesReviewed: number;
+    zonesPerHour: number;
+    costInr: number;
+    issuesCount: number;
+    completedAt: string;
+  }>;
+  perZoneType: Array<{
+    zoneType: string;
+    totalZones: number;
+    avgSecondsPerZone: number;
+  }>;
+  throughputTrend: Array<{
+    date: string;
+    zonesReviewed: number;
+    activeHours: number;
+    zonesPerHour: number;
+    operatorsActive: number;
+  }>;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+const SYSTEM_OPERATOR_IDS = new Set(['auto-annotation', 'unknown']);
+
+/** Resolve operator UUIDs to human-readable display names. */
+async function resolveOperatorNames(ids: string[]): Promise<Map<string, string>> {
+  const userIds = ids.filter(id => id && !SYSTEM_OPERATOR_IDS.has(id));
+  const map = new Map<string, string>();
+  if (userIds.length === 0) return map;
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, firstName: true, lastName: true, email: true },
+  });
+  for (const u of users) {
+    const name = [u.firstName, u.lastName].filter(Boolean).join(' ') || u.email || u.id;
+    map.set(u.id, name);
+  }
+  return map;
+}
+
+/**
+ * Determine the "final" (human-verified) label for a zone. The confusion matrix
+ * and CSV exports both rely on this, so we centralize it here.
+ *
+ * - CONFIRMED → the zone's current `type` (AI/extractor label the operator accepted)
+ * - CORRECTED → the `operatorLabel` the operator chose instead
+ * - REJECTED or null → null (no final label)
+ */
+function finalLabelOf(zone: {
+  decision: string | null;
+  type: string;
+  operatorLabel: string | null;
+}): string | null {
+  if (zone.decision === 'CONFIRMED') return zone.type;
+  if (zone.decision === 'CORRECTED') return zone.operatorLabel ?? zone.type;
+  return null;
+}
+
+/** Return a new Date set to the start of the UTC day containing `d`. */
+function startOfUtcDay(d: Date): Date {
+  const copy = new Date(d);
+  copy.setUTCHours(0, 0, 0, 0);
+  return copy;
+}
+
+/** YYYY-MM-DD in UTC. */
+function ymd(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** Enumerate UTC day boundaries inclusive on both ends. */
+function enumerateDays(from: Date, to: Date): Date[] {
+  const days: Date[] = [];
+  const start = startOfUtcDay(from);
+  const end = startOfUtcDay(to);
+  for (let d = new Date(start); d.getTime() <= end.getTime(); d.setUTCDate(d.getUTCDate() + 1)) {
+    days.push(new Date(d));
+  }
+  return days;
+}
+
+/**
+ * Standard empty-range envelopes. Spec §"Aggregation rules" — MUST return
+ * valid zeroed responses, never 404.
+ */
+function emptyLineageSummary(range: DateRange): LineageSummaryResult {
+  return {
+    range: { from: range.from.toISOString(), to: range.to.toISOString() },
+    runsIncluded: 0,
+    headline: {
+      totalZones: 0,
+      aiAgreementRate: 0,
+      humanCorrectionRate: 0,
+      humanRejectionRate: 0,
+    },
+    confusionMatrix: { labels: [], cells: [] },
+    perZoneType: [],
+    bucketFlow: {
+      green: { total: 0, humanConfirmed: 0, humanCorrected: 0, humanRejected: 0 },
+      amber: { total: 0, humanConfirmed: 0, humanCorrected: 0, humanRejected: 0 },
+      red: { total: 0, humanConfirmed: 0, humanCorrected: 0, humanRejected: 0 },
+    },
+    issuesLog: [],
+    extractorDisagreement: [],
+  };
+}
+
+function emptyTimesheetSummary(range: DateRange): TimesheetSummaryResult {
+  return {
+    range: { from: range.from.toISOString(), to: range.to.toISOString() },
+    runsIncluded: 0,
+    totals: {
+      wallClockHours: 0,
+      activeHours: 0,
+      idleHours: 0,
+      zonesReviewed: 0,
+      zonesPerHour: 0,
+      annotatorCostInr: 0,
+    },
+    perOperator: [],
+    perTitle: [],
+    perZoneType: [],
+    // Throughput trend still emits one entry per day, even when empty.
+    throughputTrend: enumerateDays(range.from, range.to).map(d => ({
+      date: ymd(d),
+      zonesReviewed: 0,
+      activeHours: 0,
+      zonesPerHour: 0,
+      operatorsActive: 0,
+    })),
+  };
+}
+
+// ── Lineage summary ─────────────────────────────────────────────────────
+
+export async function getLineageSummary(range: DateRange): Promise<LineageSummaryResult> {
+  const runs = await prisma.calibrationRun.findMany({
+    where: {
+      completedAt: { gte: range.from, lte: range.to, not: null },
+    },
+    select: {
+      id: true,
+      completedAt: true,
+      corpusDocument: { select: { filename: true } },
+      zones: {
+        select: {
+          type: true,
+          operatorLabel: true,
+          decision: true,
+          aiLabel: true,
+          aiDecision: true,
+          reconciliationBucket: true,
+          doclingLabel: true,
+          pdfxtLabel: true,
+        },
+      },
+      issues: {
+        select: {
+          category: true,
+          pagesAffected: true,
+          description: true,
+          blocking: true,
+        },
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+    orderBy: { completedAt: 'asc' },
+  });
+
+  if (runs.length === 0) return emptyLineageSummary(range);
+
+  // ── Section 1: headline ───────────────────────────────────────────────
+  const allZones = runs.flatMap(r =>
+    r.zones.map(z => ({ ...z, runId: r.id, documentName: r.corpusDocument.filename, completedAt: r.completedAt })),
+  );
+  const totalZones = allZones.length;
+
+  // aiAgreementRate — of zones that have both an AI label AND a final label,
+  // how many match. Zones without either are excluded from the denominator so
+  // unreviewed / AI-untouched zones don't artificially deflate the rate.
+  let aiAgreementDenominator = 0;
+  let aiAgreementNumerator = 0;
+  for (const z of allZones) {
+    const final = finalLabelOf(z);
+    if (z.aiLabel && final) {
+      aiAgreementDenominator++;
+      if (z.aiLabel === final) aiAgreementNumerator++;
+    }
+  }
+  const aiAgreementRate = aiAgreementDenominator > 0 ? aiAgreementNumerator / aiAgreementDenominator : 0;
+
+  // humanCorrection/Rejection — denominator is zones with ANY human decision.
+  const humanDecided = allZones.filter(z => z.decision != null);
+  const humanCorrectedCount = humanDecided.filter(z => z.decision === 'CORRECTED').length;
+  const humanRejectedCount = humanDecided.filter(z => z.decision === 'REJECTED').length;
+  const humanCorrectionRate = humanDecided.length > 0 ? humanCorrectedCount / humanDecided.length : 0;
+  const humanRejectionRate = humanDecided.length > 0 ? humanRejectedCount / humanDecided.length : 0;
+
+  // ── Section 2: confusion matrix (AI × final) ──────────────────────────
+  // Only include labels that actually appear. Sorted alphabetically so the
+  // frontend receives a deterministic order.
+  const labelSet = new Set<string>();
+  const pairs: Array<{ ai: string; final: string }> = [];
+  for (const z of allZones) {
+    const final = finalLabelOf(z);
+    if (!z.aiLabel || !final) continue;
+    labelSet.add(z.aiLabel);
+    labelSet.add(final);
+    pairs.push({ ai: z.aiLabel, final });
+  }
+  const labels = [...labelSet].sort();
+  const labelIdx = new Map(labels.map((l, i) => [l, i] as const));
+  const cells: number[][] = labels.map(() => labels.map(() => 0));
+  for (const p of pairs) {
+    const r = labelIdx.get(p.ai);
+    const c = labelIdx.get(p.final);
+    if (r !== undefined && c !== undefined) cells[r]![c]!++;
+  }
+
+  // ── Section 3: per-zone-type performance ──────────────────────────────
+  // Group by the zone's `type`. For each type compute AI confirm/correction/
+  // rejection rates based on `aiDecision`. "topCorrectedTo" is the most common
+  // operatorLabel seen among zones where decision === 'CORRECTED'.
+  const zoneTypeMap = new Map<
+    string,
+    { total: number; aiConfirm: number; aiCorrect: number; aiReject: number; correctionCounts: Map<string, number> }
+  >();
+  for (const z of allZones) {
+    const key = z.type || 'unknown';
+    const existing = zoneTypeMap.get(key) ?? {
+      total: 0,
+      aiConfirm: 0,
+      aiCorrect: 0,
+      aiReject: 0,
+      correctionCounts: new Map<string, number>(),
+    };
+    existing.total++;
+    if (z.aiDecision === 'CONFIRMED') existing.aiConfirm++;
+    else if (z.aiDecision === 'CORRECTED') existing.aiCorrect++;
+    else if (z.aiDecision === 'REJECTED') existing.aiReject++;
+    if (z.decision === 'CORRECTED' && z.operatorLabel) {
+      existing.correctionCounts.set(z.operatorLabel, (existing.correctionCounts.get(z.operatorLabel) ?? 0) + 1);
+    }
+    zoneTypeMap.set(key, existing);
+  }
+  const perZoneType = [...zoneTypeMap.entries()]
+    .sort(([, a], [, b]) => b.total - a.total)
+    .map(([zoneType, d]) => {
+      let topCorrectedTo: string | null = null;
+      let topCount = 0;
+      for (const [label, cnt] of d.correctionCounts) {
+        if (cnt > topCount) {
+          topCorrectedTo = label;
+          topCount = cnt;
+        }
+      }
+      return {
+        zoneType,
+        totalZones: d.total,
+        aiConfirmPct: d.total > 0 ? (d.aiConfirm / d.total) * 100 : 0,
+        aiCorrectionPct: d.total > 0 ? (d.aiCorrect / d.total) * 100 : 0,
+        aiRejectionPct: d.total > 0 ? (d.aiReject / d.total) * 100 : 0,
+        topCorrectedTo,
+      };
+    });
+
+  // ── Section 4: bucket flow ────────────────────────────────────────────
+  const emptyBucket = (): BucketRow => ({ total: 0, humanConfirmed: 0, humanCorrected: 0, humanRejected: 0 });
+  const bucketFlow = {
+    green: emptyBucket(),
+    amber: emptyBucket(),
+    red: emptyBucket(),
+  };
+  for (const z of allZones) {
+    const bucket = z.reconciliationBucket;
+    let row: BucketRow | null = null;
+    if (bucket === 'GREEN') row = bucketFlow.green;
+    else if (bucket === 'AMBER') row = bucketFlow.amber;
+    else if (bucket === 'RED') row = bucketFlow.red;
+    if (!row) continue;
+    row.total++;
+    if (z.decision === 'CONFIRMED') row.humanConfirmed++;
+    else if (z.decision === 'CORRECTED') row.humanCorrected++;
+    else if (z.decision === 'REJECTED') row.humanRejected++;
+  }
+
+  // ── Section 5: issues log ─────────────────────────────────────────────
+  // Group all issues across runs by category, preserving per-title detail.
+  const issuesByCategory = new Map<
+    RunIssueCategory,
+    {
+      titleCount: Set<string>;
+      totalPagesAffected: number;
+      blockingCount: number;
+      titles: Array<{
+        runId: string;
+        documentName: string;
+        completedAt: string;
+        pagesAffected: number | null;
+        description: string;
+        blocking: boolean;
+      }>;
+    }
+  >();
+  for (const run of runs) {
+    if (!run.completedAt) continue;
+    for (const iss of run.issues) {
+      const entry =
+        issuesByCategory.get(iss.category) ??
+        {
+          titleCount: new Set<string>(),
+          totalPagesAffected: 0,
+          blockingCount: 0,
+          titles: [] as Array<{
+            runId: string;
+            documentName: string;
+            completedAt: string;
+            pagesAffected: number | null;
+            description: string;
+            blocking: boolean;
+          }>,
+        };
+      entry.titleCount.add(run.id);
+      entry.totalPagesAffected += iss.pagesAffected ?? 0;
+      if (iss.blocking) entry.blockingCount++;
+      entry.titles.push({
+        runId: run.id,
+        documentName: run.corpusDocument.filename,
+        completedAt: run.completedAt.toISOString(),
+        pagesAffected: iss.pagesAffected,
+        description: iss.description,
+        blocking: iss.blocking,
+      });
+      issuesByCategory.set(iss.category, entry);
+    }
+  }
+  const issuesLog = [...issuesByCategory.entries()]
+    .sort(([, a], [, b]) => b.titles.length - a.titles.length)
+    .map(([category, d]) => ({
+      category,
+      titleCount: d.titleCount.size,
+      totalPagesAffected: d.totalPagesAffected,
+      blockingCount: d.blockingCount,
+      titles: d.titles,
+    }));
+
+  // ── Section 6: extractor disagreement ─────────────────────────────────
+  // Group by final label; a zone "disagrees" when docling and pdfxt labels
+  // differ. Zones missing either extractor label are excluded so the rate
+  // reflects head-to-head comparisons only.
+  const disagreementMap = new Map<string, { total: number; disagreements: number }>();
+  for (const z of allZones) {
+    const final = finalLabelOf(z);
+    if (!final) continue;
+    if (!z.doclingLabel || !z.pdfxtLabel) continue;
+    const entry = disagreementMap.get(final) ?? { total: 0, disagreements: 0 };
+    entry.total++;
+    if (z.doclingLabel !== z.pdfxtLabel) entry.disagreements++;
+    disagreementMap.set(final, entry);
+  }
+  const extractorDisagreement = [...disagreementMap.entries()]
+    .sort(([, a], [, b]) => b.total - a.total)
+    .map(([finalLabel, d]) => ({
+      finalLabel,
+      totalZones: d.total,
+      disagreementPct: d.total > 0 ? (d.disagreements / d.total) * 100 : 0,
+    }));
+
+  return {
+    range: { from: range.from.toISOString(), to: range.to.toISOString() },
+    runsIncluded: runs.length,
+    headline: {
+      totalZones,
+      aiAgreementRate,
+      humanCorrectionRate,
+      humanRejectionRate,
+    },
+    confusionMatrix: { labels, cells },
+    perZoneType,
+    bucketFlow,
+    issuesLog,
+    extractorDisagreement,
+  };
+}
+
+// ── Timesheet summary ───────────────────────────────────────────────────
+
+export async function getTimesheetSummary(range: DateRange): Promise<TimesheetSummaryResult> {
+  const runs = await prisma.calibrationRun.findMany({
+    where: {
+      completedAt: { gte: range.from, lte: range.to, not: null },
+    },
+    select: {
+      id: true,
+      completedAt: true,
+      corpusDocument: { select: { filename: true, pageCount: true } },
+      zones: {
+        select: {
+          type: true,
+          decision: true,
+          verifiedBy: true,
+        },
+      },
+      annotationSessions: {
+        select: {
+          operatorId: true,
+          startedAt: true,
+          endedAt: true,
+          activeMs: true,
+          idleMs: true,
+          zonesReviewed: true,
+          zonesConfirmed: true,
+          zonesCorrected: true,
+          zonesRejected: true,
+          sessionLog: true,
+        },
+      },
+      _count: { select: { issues: true } },
+    },
+    orderBy: { completedAt: 'asc' },
+  });
+
+  if (runs.length === 0) return emptyTimesheetSummary(range);
+
+  // ── Totals ────────────────────────────────────────────────────────────
+  let totalActiveMs = 0;
+  let totalIdleMs = 0;
+  let totalZonesReviewed = 0;
+  let earliestStart: Date | null = null;
+  let latestEnd: Date | null = null;
+  for (const run of runs) {
+    for (const sess of run.annotationSessions) {
+      totalActiveMs += sess.activeMs;
+      totalIdleMs += sess.idleMs;
+      totalZonesReviewed += sess.zonesReviewed;
+      if (!earliestStart || sess.startedAt < earliestStart) earliestStart = sess.startedAt;
+      if (sess.endedAt && (!latestEnd || sess.endedAt > latestEnd)) latestEnd = sess.endedAt;
+    }
+  }
+  const totalActiveHours = totalActiveMs / 3_600_000;
+  const totalIdleHours = totalIdleMs / 3_600_000;
+  const totalWallClockHours =
+    earliestStart && latestEnd
+      ? (latestEnd.getTime() - earliestStart.getTime()) / 3_600_000
+      : totalActiveHours + totalIdleHours;
+  const totalZonesPerHour = totalActiveHours > 0 ? totalZonesReviewed / totalActiveHours : 0;
+  const totalCostInr = totalActiveHours * ANNOTATOR_RATE_INR_PER_HOUR;
+
+  // ── Per operator ──────────────────────────────────────────────────────
+  const operatorMap = new Map<
+    string,
+    {
+      activeMs: number;
+      zonesReviewed: number;
+      confirmed: number;
+      corrected: number;
+      rejected: number;
+      runIds: Set<string>;
+    }
+  >();
+  for (const run of runs) {
+    for (const sess of run.annotationSessions) {
+      const entry = operatorMap.get(sess.operatorId) ?? {
+        activeMs: 0,
+        zonesReviewed: 0,
+        confirmed: 0,
+        corrected: 0,
+        rejected: 0,
+        runIds: new Set<string>(),
+      };
+      entry.activeMs += sess.activeMs;
+      entry.zonesReviewed += sess.zonesReviewed;
+      entry.confirmed += sess.zonesConfirmed;
+      entry.corrected += sess.zonesCorrected;
+      entry.rejected += sess.zonesRejected;
+      entry.runIds.add(run.id);
+      operatorMap.set(sess.operatorId, entry);
+    }
+  }
+  const nameMap = await resolveOperatorNames([...operatorMap.keys()]);
+  const perOperator = [...operatorMap.entries()]
+    .map(([opId, d]) => {
+      const activeHours = d.activeMs / 3_600_000;
+      const decided = d.confirmed + d.corrected + d.rejected;
+      return {
+        operator: nameMap.get(opId) ?? opId,
+        activeHours,
+        zonesReviewed: d.zonesReviewed,
+        zonesPerHour: activeHours > 0 ? d.zonesReviewed / activeHours : 0,
+        confirmPct: decided > 0 ? (d.confirmed / decided) * 100 : 0,
+        correctPct: decided > 0 ? (d.corrected / decided) * 100 : 0,
+        rejectPct: decided > 0 ? (d.rejected / decided) * 100 : 0,
+        runsContributedTo: d.runIds.size,
+        costInr: activeHours * ANNOTATOR_RATE_INR_PER_HOUR,
+      };
+    })
+    .sort((a, b) => b.activeHours - a.activeHours);
+
+  // ── Per title ─────────────────────────────────────────────────────────
+  // IMPORTANT cost-parity invariant: per-title costInr MUST equal
+  //   sum(annotationSessions.activeMs for runId) / 3_600_000 * 400
+  // which is exactly what the per-run timesheet and the existing corpus
+  // analysis-summary path use. Do not "improve" this formula in isolation.
+  const perTitle = runs.map(run => {
+    const runActiveMs = run.annotationSessions.reduce((s, sess) => s + sess.activeMs, 0);
+    const runZonesReviewed = run.annotationSessions.reduce((s, sess) => s + sess.zonesReviewed, 0);
+    const runActiveHours = runActiveMs / 3_600_000;
+    return {
+      runId: run.id,
+      documentName: run.corpusDocument.filename,
+      pages: run.corpusDocument.pageCount ?? 0,
+      activeHours: runActiveHours,
+      zonesReviewed: runZonesReviewed,
+      zonesPerHour: runActiveHours > 0 ? runZonesReviewed / runActiveHours : 0,
+      costInr: runActiveHours * ANNOTATOR_RATE_INR_PER_HOUR,
+      issuesCount: run._count.issues,
+      completedAt: (run.completedAt ?? new Date(0)).toISOString(),
+    };
+  });
+
+  // ── Per zone type (avg seconds per zone) ──────────────────────────────
+  // Apportion totalActiveMs across zone types proportional to each type's
+  // share of reviewed zones. This matches the per-run approach of treating
+  // operator time as uniformly distributed over the zones actually decided.
+  const typeCounts = new Map<string, number>();
+  let decidedZoneCount = 0;
+  for (const run of runs) {
+    for (const z of run.zones) {
+      if (!z.decision) continue;
+      if (z.verifiedBy === 'auto-annotation') continue;
+      decidedZoneCount++;
+      const key = z.type || 'unknown';
+      typeCounts.set(key, (typeCounts.get(key) ?? 0) + 1);
+    }
+  }
+  const perZoneType = [...typeCounts.entries()]
+    .sort(([, a], [, b]) => b - a)
+    .map(([zoneType, count]) => {
+      const shareMs = decidedZoneCount > 0 ? totalActiveMs * (count / decidedZoneCount) : 0;
+      return {
+        zoneType,
+        totalZones: count,
+        avgSecondsPerZone: count > 0 ? shareMs / count / 1000 : 0,
+      };
+    });
+
+  // ── Throughput trend ──────────────────────────────────────────────────
+  // One bucket per UTC day in the range. A session is attributed to the day
+  // its `endedAt` (or `startedAt` fallback) falls on, mirroring how the
+  // per-run timesheet associates time with a wall-clock day.
+  const trendMap = new Map<
+    string,
+    { zonesReviewed: number; activeMs: number; operators: Set<string> }
+  >();
+  for (const d of enumerateDays(range.from, range.to)) {
+    trendMap.set(ymd(d), { zonesReviewed: 0, activeMs: 0, operators: new Set<string>() });
+  }
+  for (const run of runs) {
+    for (const sess of run.annotationSessions) {
+      const anchor = sess.endedAt ?? sess.startedAt;
+      const key = ymd(anchor);
+      const bucket = trendMap.get(key);
+      if (!bucket) continue; // session outside range — shouldn't happen given the run filter
+      bucket.zonesReviewed += sess.zonesReviewed;
+      bucket.activeMs += sess.activeMs;
+      bucket.operators.add(sess.operatorId);
+    }
+  }
+  const throughputTrend = [...trendMap.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, d]) => {
+      const activeHours = d.activeMs / 3_600_000;
+      return {
+        date,
+        zonesReviewed: d.zonesReviewed,
+        activeHours,
+        zonesPerHour: activeHours > 0 ? d.zonesReviewed / activeHours : 0,
+        operatorsActive: d.operators.size,
+      };
+    });
+
+  return {
+    range: { from: range.from.toISOString(), to: range.to.toISOString() },
+    runsIncluded: runs.length,
+    totals: {
+      wallClockHours: totalWallClockHours,
+      activeHours: totalActiveHours,
+      idleHours: totalIdleHours,
+      zonesReviewed: totalZonesReviewed,
+      zonesPerHour: totalZonesPerHour,
+      annotatorCostInr: totalCostInr,
+    },
+    perOperator,
+    perTitle,
+    perZoneType,
+    throughputTrend,
+  };
+}
+
+// ── CSV helpers ─────────────────────────────────────────────────────────
+
+function csvEscape(v: unknown): string {
+  const s = v === null || v === undefined ? '' : String(v);
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function csvRow(values: unknown[]): string {
+  return values.map(csvEscape).join(',');
+}
+
+// ── Lineage CSV export (flat per-zone) ──────────────────────────────────
+
+export async function exportLineageSummaryCsv(range: DateRange): Promise<string> {
+  const runs = await prisma.calibrationRun.findMany({
+    where: {
+      completedAt: { gte: range.from, lte: range.to, not: null },
+    },
+    select: {
+      id: true,
+      completedAt: true,
+      corpusDocument: { select: { filename: true } },
+      zones: {
+        select: {
+          id: true,
+          pageNumber: true,
+          type: true,
+          operatorLabel: true,
+          decision: true,
+          verifiedBy: true,
+          doclingLabel: true,
+          pdfxtLabel: true,
+          reconciliationBucket: true,
+          aiLabel: true,
+          aiDecision: true,
+          aiConfidence: true,
+        },
+        orderBy: [{ pageNumber: 'asc' }, { id: 'asc' }],
+      },
+    },
+    orderBy: { completedAt: 'asc' },
+  });
+
+  const headers = [
+    'runId',
+    'documentName',
+    'completedAt',
+    'pageNumber',
+    'zoneId',
+    'zoneIndex',
+    'doclingLabel',
+    'pdfxtLabel',
+    'reconciliationBucket',
+    'aiDecision',
+    'aiLabel',
+    'aiConfidence',
+    'humanDecision',
+    'humanLabel',
+    'verifiedBy',
+    'finalLabel',
+  ];
+  const lines: string[] = [headers.join(',')];
+
+  for (const run of runs) {
+    let zoneIndex = 0;
+    for (const z of run.zones) {
+      const humanLabel =
+        z.decision === 'CORRECTED' ? z.operatorLabel : z.decision === 'CONFIRMED' ? z.type : null;
+      lines.push(
+        csvRow([
+          run.id,
+          run.corpusDocument.filename,
+          run.completedAt ? run.completedAt.toISOString() : '',
+          z.pageNumber,
+          z.id,
+          zoneIndex,
+          z.doclingLabel ?? '',
+          z.pdfxtLabel ?? '',
+          z.reconciliationBucket ?? '',
+          z.aiDecision ?? '',
+          z.aiLabel ?? '',
+          z.aiConfidence !== null && z.aiConfidence !== undefined ? z.aiConfidence.toFixed(3) : '',
+          z.decision ?? '',
+          humanLabel ?? '',
+          z.verifiedBy ?? '',
+          finalLabelOf(z) ?? '',
+        ]),
+      );
+      zoneIndex++;
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ── Timesheet CSV exports ───────────────────────────────────────────────
+
+export async function exportTimesheetPerOperatorCsv(range: DateRange): Promise<string> {
+  const summary = await getTimesheetSummary(range);
+  const headers = [
+    'operator',
+    'activeHours',
+    'zonesReviewed',
+    'zonesPerHour',
+    'confirmPct',
+    'correctPct',
+    'rejectPct',
+    'runsContributedTo',
+    'costInr',
+  ];
+  const lines: string[] = [headers.join(',')];
+  for (const r of summary.perOperator) {
+    lines.push(
+      csvRow([
+        r.operator,
+        r.activeHours.toFixed(3),
+        r.zonesReviewed,
+        r.zonesPerHour.toFixed(1),
+        r.confirmPct.toFixed(1),
+        r.correctPct.toFixed(1),
+        r.rejectPct.toFixed(1),
+        r.runsContributedTo,
+        r.costInr.toFixed(2),
+      ]),
+    );
+  }
+  return lines.join('\n');
+}
+
+export async function exportTimesheetPerTitleCsv(range: DateRange): Promise<string> {
+  const summary = await getTimesheetSummary(range);
+  const headers = [
+    'runId',
+    'documentName',
+    'pages',
+    'activeHours',
+    'zonesReviewed',
+    'zonesPerHour',
+    'costInr',
+    'issuesCount',
+    'completedAt',
+  ];
+  const lines: string[] = [headers.join(',')];
+  for (const r of summary.perTitle) {
+    lines.push(
+      csvRow([
+        r.runId,
+        r.documentName,
+        r.pages,
+        r.activeHours.toFixed(3),
+        r.zonesReviewed,
+        r.zonesPerHour.toFixed(1),
+        r.costInr.toFixed(2),
+        r.issuesCount,
+        r.completedAt,
+      ]),
+    );
+  }
+  return lines.join('\n');
+}
+
+// ── Timesheet PDF export ────────────────────────────────────────────────
+
+export async function exportTimesheetSummaryPdf(range: DateRange): Promise<Buffer> {
+  const summary = await getTimesheetSummary(range);
+
+  const pdf = await PDFDocument.create();
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  const boldFont = await pdf.embedFont(StandardFonts.HelveticaBold);
+
+  const pageWidth = 612;
+  const pageHeight = 792;
+  const margin = 50;
+  let page = pdf.addPage([pageWidth, pageHeight]);
+  let y = pageHeight - margin;
+
+  const drawText = (text: string, x: number, yPos: number, size: number, useBold = false) => {
+    page.drawText(text, {
+      x,
+      y: yPos,
+      size,
+      font: useBold ? boldFont : font,
+      color: rgb(0, 0, 0),
+    });
+  };
+
+  const ensureSpace = (needed: number) => {
+    if (y < margin + needed) {
+      page = pdf.addPage([pageWidth, pageHeight]);
+      y = pageHeight - margin;
+    }
+  };
+
+  // Title
+  drawText('Corpus Timesheet Summary', margin, y, 18, true);
+  y -= 25;
+  drawText(
+    `Range: ${summary.range.from.slice(0, 10)} → ${summary.range.to.slice(0, 10)}  |  Runs: ${summary.runsIncluded}`,
+    margin,
+    y,
+    10,
+  );
+  y -= 25;
+
+  // Totals card
+  drawText('Totals', margin, y, 14, true);
+  y -= 18;
+  const t = summary.totals;
+  for (const line of [
+    `Active Hours: ${t.activeHours.toFixed(2)}`,
+    `Wall Clock Hours: ${t.wallClockHours.toFixed(2)}`,
+    `Idle Hours: ${t.idleHours.toFixed(2)}`,
+    `Zones Reviewed: ${t.zonesReviewed}`,
+    `Zones / Hour: ${t.zonesPerHour.toFixed(1)}`,
+    `Annotator Cost (INR): ₹${t.annotatorCostInr.toFixed(2)}`,
+  ]) {
+    drawText(line, margin + 10, y, 10);
+    y -= 14;
+  }
+  y -= 10;
+
+  // Per-operator
+  ensureSpace(60);
+  drawText('Per-Operator Breakdown', margin, y, 14, true);
+  y -= 18;
+  for (const op of summary.perOperator) {
+    ensureSpace(28);
+    drawText(
+      `${op.operator}: ${op.zonesReviewed} zones, ${op.activeHours.toFixed(2)}h, ${op.zonesPerHour.toFixed(0)} zones/hr, ₹${op.costInr.toFixed(0)}`,
+      margin + 10,
+      y,
+      9,
+    );
+    y -= 13;
+  }
+  y -= 10;
+
+  // Per-title
+  ensureSpace(60);
+  drawText('Per-Title Breakdown', margin, y, 14, true);
+  y -= 18;
+  for (const tit of summary.perTitle) {
+    ensureSpace(28);
+    drawText(
+      `${tit.documentName} (${tit.pages}p): ${tit.zonesReviewed} zones, ${tit.activeHours.toFixed(2)}h, ${tit.issuesCount} issues, ₹${tit.costInr.toFixed(0)}`,
+      margin + 10,
+      y,
+      9,
+    );
+    y -= 13;
+  }
+
+  const bytes = await pdf.save();
+  return Buffer.from(bytes);
+}

--- a/src/services/calibration/corpus-summary.service.ts
+++ b/src/services/calibration/corpus-summary.service.ts
@@ -183,6 +183,37 @@ function finalLabelOf(zone: {
   return null;
 }
 
+/**
+ * True when a zone's decision was written by an AI pipeline rather than a
+ * real human reviewer. The two known AI-authoring signals on
+ * `calibration_run_zones.verifiedBy` are the literal `auto-annotation` and
+ * any string prefixed with `ai:` (used by the zone-classification auto-
+ * annotate pass). Treating these as human review would inflate
+ * humanCorrection/rejection rates and feed AI-only decisions into
+ * aiAgreementRate / confusion-matrix computations (AI being graded
+ * against itself).
+ */
+function isAiVerifier(verifiedBy: string | null | undefined): boolean {
+  if (!verifiedBy) return false;
+  return verifiedBy === 'auto-annotation' || verifiedBy.startsWith('ai:');
+}
+
+/**
+ * Final label as set by a HUMAN reviewer. Returns null for AI-authored
+ * decisions even when `decision` is non-null. Used for lineage/agreement
+ * metrics; CSV exports keep using `finalLabelOf` directly so the raw
+ * export still surfaces AI-finalized labels for audit.
+ */
+function humanFinalLabelOf(zone: {
+  decision: string | null;
+  type: string;
+  operatorLabel: string | null;
+  verifiedBy: string | null;
+}): string | null {
+  if (isAiVerifier(zone.verifiedBy)) return null;
+  return finalLabelOf(zone);
+}
+
 /** Return a new Date set to the start of the UTC day containing `d`. */
 function startOfUtcDay(d: Date): Date {
   const copy = new Date(d);
@@ -274,6 +305,7 @@ export async function getLineageSummary(range: DateRange): Promise<LineageSummar
           type: true,
           operatorLabel: true,
           decision: true,
+          verifiedBy: true,
           aiLabel: true,
           aiDecision: true,
           reconciliationBucket: true,
@@ -302,13 +334,17 @@ export async function getLineageSummary(range: DateRange): Promise<LineageSummar
   );
   const totalZones = allZones.length;
 
-  // aiAgreementRate — of zones that have both an AI label AND a final label,
-  // how many match. Zones without either are excluded from the denominator so
-  // unreviewed / AI-untouched zones don't artificially deflate the rate.
+  // aiAgreementRate — of zones with an AI label AND a HUMAN-authored final
+  // label, how many match. Zones without either are excluded from the
+  // denominator so unreviewed / AI-untouched zones don't artificially
+  // deflate the rate. We specifically use `humanFinalLabelOf` (not
+  // `finalLabelOf`) to avoid comparing AI's prediction against its own
+  // auto-annotation — that would silently inflate agreement toward 100%
+  // for runs that went through the auto-annotate pipeline.
   let aiAgreementDenominator = 0;
   let aiAgreementNumerator = 0;
   for (const z of allZones) {
-    const final = finalLabelOf(z);
+    const final = humanFinalLabelOf(z);
     if (z.aiLabel && final) {
       aiAgreementDenominator++;
       if (z.aiLabel === final) aiAgreementNumerator++;
@@ -316,20 +352,25 @@ export async function getLineageSummary(range: DateRange): Promise<LineageSummar
   }
   const aiAgreementRate = aiAgreementDenominator > 0 ? aiAgreementNumerator / aiAgreementDenominator : 0;
 
-  // humanCorrection/Rejection — denominator is zones with ANY human decision.
-  const humanDecided = allZones.filter(z => z.decision != null);
+  // humanCorrection/Rejection — denominator is zones with a human decision,
+  // filtering out AI-authored decisions (verifiedBy = 'auto-annotation' or
+  // 'ai:*'). Otherwise ranges including pre-annotated runs would show
+  // inflated correction/rejection rates that don't reflect real reviewer
+  // behavior.
+  const humanDecided = allZones.filter(z => z.decision != null && !isAiVerifier(z.verifiedBy));
   const humanCorrectedCount = humanDecided.filter(z => z.decision === 'CORRECTED').length;
   const humanRejectedCount = humanDecided.filter(z => z.decision === 'REJECTED').length;
   const humanCorrectionRate = humanDecided.length > 0 ? humanCorrectedCount / humanDecided.length : 0;
   const humanRejectionRate = humanDecided.length > 0 ? humanRejectedCount / humanDecided.length : 0;
 
-  // ── Section 2: confusion matrix (AI × final) ──────────────────────────
+  // ── Section 2: confusion matrix (AI × human-final) ────────────────────
   // Only include labels that actually appear. Sorted alphabetically so the
-  // frontend receives a deterministic order.
+  // frontend receives a deterministic order. Same human-filter reasoning
+  // as aiAgreementRate above.
   const labelSet = new Set<string>();
   const pairs: Array<{ ai: string; final: string }> = [];
   for (const z of allZones) {
-    const final = finalLabelOf(z);
+    const final = humanFinalLabelOf(z);
     if (!z.aiLabel || !final) continue;
     labelSet.add(z.aiLabel);
     labelSet.add(final);
@@ -365,7 +406,10 @@ export async function getLineageSummary(range: DateRange): Promise<LineageSummar
     if (z.aiDecision === 'CONFIRMED') existing.aiConfirm++;
     else if (z.aiDecision === 'CORRECTED') existing.aiCorrect++;
     else if (z.aiDecision === 'REJECTED') existing.aiReject++;
-    if (z.decision === 'CORRECTED' && z.operatorLabel) {
+    // topCorrectedTo: which labels do HUMANS most often correct to. Skip
+    // AI-authored corrections so we don't leak AI self-labeling into the
+    // reviewer-intent signal.
+    if (z.decision === 'CORRECTED' && z.operatorLabel && !isAiVerifier(z.verifiedBy)) {
       existing.correctionCounts.set(z.operatorLabel, (existing.correctionCounts.get(z.operatorLabel) ?? 0) + 1);
     }
     zoneTypeMap.set(key, existing);
@@ -406,6 +450,11 @@ export async function getLineageSummary(range: DateRange): Promise<LineageSummar
     else if (bucket === 'RED') row = bucketFlow.red;
     if (!row) continue;
     row.total++;
+    // humanConfirmed/Corrected/Rejected counters must only track decisions
+    // written by a human reviewer. AI-written decisions have verifiedBy =
+    // 'auto-annotation' or 'ai:*' and would otherwise inflate these counts
+    // for ranges containing auto-annotated runs.
+    if (isAiVerifier(z.verifiedBy)) continue;
     if (z.decision === 'CONFIRMED') row.humanConfirmed++;
     else if (z.decision === 'CORRECTED') row.humanCorrected++;
     else if (z.decision === 'REJECTED') row.humanRejected++;
@@ -472,12 +521,14 @@ export async function getLineageSummary(range: DateRange): Promise<LineageSummar
     }));
 
   // ── Section 6: extractor disagreement ─────────────────────────────────
-  // Group by final label; a zone "disagrees" when docling and pdfxt labels
-  // differ. Zones missing either extractor label are excluded so the rate
-  // reflects head-to-head comparisons only.
+  // Group by human-authored final label; a zone "disagrees" when docling
+  // and pdfxt labels differ. Zones missing either extractor label are
+  // excluded so the rate reflects head-to-head comparisons only. We use
+  // the human-only label because extractor quality is measured against
+  // reviewer ground truth, not AI self-validation.
   const disagreementMap = new Map<string, { total: number; disagreements: number }>();
   for (const z of allZones) {
-    const final = finalLabelOf(z);
+    const final = humanFinalLabelOf(z);
     if (!final) continue;
     if (!z.doclingLabel || !z.pdfxtLabel) continue;
     const entry = disagreementMap.get(final) ?? { total: 0, disagreements: 0 };
@@ -654,37 +705,39 @@ export async function getTimesheetSummary(range: DateRange): Promise<TimesheetSu
   });
 
   // ── Per zone type (avg seconds per zone) ──────────────────────────────
-  // Apportion active time across zone types proportional to each type's
-  // share of reviewed zones. This matches the per-run approach of treating
-  // operator time as uniformly distributed over the zones actually decided.
+  // Apportion each RUN's active time across that run's decided zone types,
+  // then sum the per-type shares across runs. Using a single corpus-wide
+  // ratio (totalActiveMs × type-share-across-corpus) blended throughput
+  // across runs with different mixes — a slow text-heavy run and a fast
+  // figure-heavy run would end up distorting each other's averages. The
+  // per-run approach preserves each run's actual throughput.
   //
-  // IMPORTANT: only count active time from runs that actually contributed
-  // at least one human-decided zone. Otherwise a completed but abandoned
-  // run (annotation time, zero decided zones) would still bleed its hours
-  // into every other run's averages and inflate every avgSecondsPerZone.
+  // Abandoned runs (completed but zero human-decided zones) contribute
+  // zero here because their per-run denominator is zero and we `continue`.
   const typeCounts = new Map<string, number>();
-  let decidedZoneCount = 0;
-  let decidedRunActiveMs = 0;
+  const typeShareMs = new Map<string, number>();
   for (const run of runs) {
-    let runDecidedInThisLoop = 0;
+    const runTypeCounts = new Map<string, number>();
+    let runDecidedCount = 0;
     for (const z of run.zones) {
       if (!z.decision) continue;
       if (z.verifiedBy === 'auto-annotation') continue;
-      runDecidedInThisLoop++;
-      decidedZoneCount++;
       const key = z.type || 'unknown';
+      runDecidedCount++;
+      runTypeCounts.set(key, (runTypeCounts.get(key) ?? 0) + 1);
       typeCounts.set(key, (typeCounts.get(key) ?? 0) + 1);
     }
-    if (runDecidedInThisLoop > 0) {
-      for (const sess of run.annotationSessions) {
-        decidedRunActiveMs += sess.activeMs;
-      }
+    if (runDecidedCount === 0) continue;
+    const runActiveMs = run.annotationSessions.reduce((s, sess) => s + sess.activeMs, 0);
+    for (const [type, n] of runTypeCounts) {
+      const share = runActiveMs * (n / runDecidedCount);
+      typeShareMs.set(type, (typeShareMs.get(type) ?? 0) + share);
     }
   }
   const perZoneType = [...typeCounts.entries()]
     .sort(([, a], [, b]) => b - a)
     .map(([zoneType, count]) => {
-      const shareMs = decidedZoneCount > 0 ? decidedRunActiveMs * (count / decidedZoneCount) : 0;
+      const shareMs = typeShareMs.get(zoneType) ?? 0;
       return {
         zoneType,
         totalZones: count,
@@ -936,6 +989,31 @@ export async function exportTimesheetPerTitleCsv(range: DateRange): Promise<stri
 const PDF_MAX_PER_OPERATOR_ROWS = 200;
 const PDF_MAX_PER_TITLE_ROWS = 1000;
 
+/**
+ * pdf-lib's StandardFonts.Helvetica is WinAnsi-encoded, which cannot render
+ * characters like `→`, `₹`, `…`, smart quotes, or any BMP codepoint outside
+ * CP1252. Passing one of those to `page.drawText` throws at render time and
+ * blows up the whole export. Sanitize every string we're about to render —
+ * both our literal labels AND any user-supplied content (operator names,
+ * document filenames) — by replacing common glyphs with ASCII equivalents
+ * and substituting `?` for anything still out of range. We intentionally
+ * don't embed a Unicode font here to keep the PDF small and avoid pulling
+ * a font asset into the backend deployment.
+ */
+function toWinAnsi(s: string): string {
+  return s
+    .replace(/\u2192/g, '->') // →
+    .replace(/\u20b9/g, 'Rs.') // ₹
+    .replace(/\u2026/g, '...') // …
+    .replace(/[\u2018\u2019]/g, "'") // ‘ ’
+    .replace(/[\u201C\u201D]/g, '"') // “ ”
+    .replace(/\u2013/g, '-') // – en dash
+    .replace(/\u2014/g, '--') // — em dash
+    // Anything still outside the printable ASCII+Latin-1 range gets `?`.
+    // Keep 0x20-0x7E (printable ASCII) and 0xA0-0xFF (Latin-1 Supplement).
+    .replace(/[^\x20-\x7E\xA0-\xFF]/g, '?');
+}
+
 export async function exportTimesheetSummaryPdf(range: DateRange): Promise<Buffer> {
   const summary = await getTimesheetSummary(range);
 
@@ -950,7 +1028,9 @@ export async function exportTimesheetSummaryPdf(range: DateRange): Promise<Buffe
   let y = pageHeight - margin;
 
   const drawText = (text: string, x: number, yPos: number, size: number, useBold = false) => {
-    page.drawText(text, {
+    // Always route through toWinAnsi — StandardFonts.Helvetica cannot
+    // render characters outside CP1252 and would throw at render time.
+    page.drawText(toWinAnsi(text), {
       x,
       y: yPos,
       size,
@@ -987,7 +1067,7 @@ export async function exportTimesheetSummaryPdf(range: DateRange): Promise<Buffe
     `Idle Hours: ${t.idleHours.toFixed(2)}`,
     `Zones Reviewed: ${t.zonesReviewed}`,
     `Zones / Hour: ${t.zonesPerHour.toFixed(1)}`,
-    `Annotator Cost (INR): ₹${t.annotatorCostInr.toFixed(2)}`,
+    `Annotator Cost (INR): ${t.annotatorCostInr.toFixed(2)}`,
   ]) {
     drawText(line, margin + 10, y, 10);
     y -= 14;
@@ -1002,7 +1082,7 @@ export async function exportTimesheetSummaryPdf(range: DateRange): Promise<Buffe
   for (const op of operatorRows) {
     ensureSpace(28);
     drawText(
-      `${op.operator}: ${op.zonesReviewed} zones, ${op.activeHours.toFixed(2)}h, ${op.zonesPerHour.toFixed(0)} zones/hr, ₹${op.costInr.toFixed(0)}`,
+      `${op.operator}: ${op.zonesReviewed} zones, ${op.activeHours.toFixed(2)}h, ${op.zonesPerHour.toFixed(0)} zones/hr, INR ${op.costInr.toFixed(0)}`,
       margin + 10,
       y,
       9,
@@ -1029,7 +1109,7 @@ export async function exportTimesheetSummaryPdf(range: DateRange): Promise<Buffe
   for (const tit of titleRows) {
     ensureSpace(28);
     drawText(
-      `${tit.documentName} (${tit.pages}p): ${tit.zonesReviewed} zones, ${tit.activeHours.toFixed(2)}h, ${tit.issuesCount} issues, ₹${tit.costInr.toFixed(0)}`,
+      `${tit.documentName} (${tit.pages}p): ${tit.zonesReviewed} zones, ${tit.activeHours.toFixed(2)}h, ${tit.issuesCount} issues, INR ${tit.costInr.toFixed(0)}`,
       margin + 10,
       y,
       9,

--- a/src/services/calibration/corpus-summary.service.ts
+++ b/src/services/calibration/corpus-summary.service.ts
@@ -139,18 +139,28 @@ export interface TimesheetSummaryResult {
 
 const SYSTEM_OPERATOR_IDS = new Set(['auto-annotation', 'unknown']);
 
-/** Resolve operator UUIDs to human-readable display names. */
+/**
+ * Resolve operator UUIDs to human-readable display names.
+ *
+ * Privacy note: we intentionally do NOT fall back to the operator's email
+ * address. Corpus summaries are surfaced to tenant admins, rendered into
+ * CSV / PDF exports that may be shared with external publishers, and
+ * indexed by frontend caches — dropping an email into any of those paths
+ * would leak PII for no product benefit. When no first/last name is
+ * available we return a short UUID suffix instead, which is enough to
+ * disambiguate operators in a report without exposing personal data.
+ */
 async function resolveOperatorNames(ids: string[]): Promise<Map<string, string>> {
   const userIds = ids.filter(id => id && !SYSTEM_OPERATOR_IDS.has(id));
   const map = new Map<string, string>();
   if (userIds.length === 0) return map;
   const users = await prisma.user.findMany({
     where: { id: { in: userIds } },
-    select: { id: true, firstName: true, lastName: true, email: true },
+    select: { id: true, firstName: true, lastName: true },
   });
   for (const u of users) {
-    const name = [u.firstName, u.lastName].filter(Boolean).join(' ') || u.email || u.id;
-    map.set(u.id, name);
+    const name = [u.firstName, u.lastName].filter(Boolean).join(' ');
+    map.set(u.id, name || `Operator ${u.id.slice(0, 8)}`);
   }
   return map;
 }
@@ -664,22 +674,34 @@ export async function getTimesheetSummary(range: DateRange): Promise<TimesheetSu
     });
 
   // ── Throughput trend ──────────────────────────────────────────────────
-  // One bucket per UTC day in the range. A session is attributed to the day
-  // its `endedAt` (or `startedAt` fallback) falls on, mirroring how the
-  // per-run timesheet associates time with a wall-clock day.
+  // One bucket per UTC day. Runs are included by `completedAt`, but a
+  // session's actual wall-clock day can be earlier (long-running titles)
+  // or later (finalization sessions) than the request range. We seed the
+  // bucket map with every day in the request range so the chart always
+  // spans at least the requested window, and then add buckets on the fly
+  // for any session whose anchor day falls outside — otherwise
+  // sum(chart.activeHours) would silently disagree with totals.activeHours.
   const trendMap = new Map<
     string,
     { zonesReviewed: number; activeMs: number; operators: Set<string> }
   >();
+  const makeEmptyBucket = () => ({
+    zonesReviewed: 0,
+    activeMs: 0,
+    operators: new Set<string>(),
+  });
   for (const d of enumerateDays(range.from, range.to)) {
-    trendMap.set(ymd(d), { zonesReviewed: 0, activeMs: 0, operators: new Set<string>() });
+    trendMap.set(ymd(d), makeEmptyBucket());
   }
   for (const run of runs) {
     for (const sess of run.annotationSessions) {
       const anchor = sess.endedAt ?? sess.startedAt;
       const key = ymd(anchor);
-      const bucket = trendMap.get(key);
-      if (!bucket) continue; // session outside range — shouldn't happen given the run filter
+      let bucket = trendMap.get(key);
+      if (!bucket) {
+        bucket = makeEmptyBucket();
+        trendMap.set(key, bucket);
+      }
       bucket.zonesReviewed += sess.zonesReviewed;
       bucket.activeMs += sess.activeMs;
       bucket.operators.add(sess.operatorId);
@@ -885,6 +907,16 @@ export async function exportTimesheetPerTitleCsv(range: DateRange): Promise<stri
 
 // ── Timesheet PDF export ────────────────────────────────────────────────
 
+// Hard caps for the rendered PDF. pdf-lib builds the entire document in
+// memory before `save()`, so uncapped rendering scales with the row counts.
+// Realistic inputs sit in the low hundreds for titles and low tens for
+// operators, but we still cap here as a defense-in-depth against pathological
+// inputs (a 10-year range on a mature corpus). If a caller truly needs every
+// row they can pull the per-title / per-operator CSVs instead, which stream
+// cleanly and aren't subject to PDF layout memory.
+const PDF_MAX_PER_OPERATOR_ROWS = 200;
+const PDF_MAX_PER_TITLE_ROWS = 1000;
+
 export async function exportTimesheetSummaryPdf(range: DateRange): Promise<Buffer> {
   const summary = await getTimesheetSummary(range);
 
@@ -943,11 +975,12 @@ export async function exportTimesheetSummaryPdf(range: DateRange): Promise<Buffe
   }
   y -= 10;
 
-  // Per-operator
+  // Per-operator (capped)
   ensureSpace(60);
   drawText('Per-Operator Breakdown', margin, y, 14, true);
   y -= 18;
-  for (const op of summary.perOperator) {
+  const operatorRows = summary.perOperator.slice(0, PDF_MAX_PER_OPERATOR_ROWS);
+  for (const op of operatorRows) {
     ensureSpace(28);
     drawText(
       `${op.operator}: ${op.zonesReviewed} zones, ${op.activeHours.toFixed(2)}h, ${op.zonesPerHour.toFixed(0)} zones/hr, ₹${op.costInr.toFixed(0)}`,
@@ -957,19 +990,40 @@ export async function exportTimesheetSummaryPdf(range: DateRange): Promise<Buffe
     );
     y -= 13;
   }
+  if (summary.perOperator.length > PDF_MAX_PER_OPERATOR_ROWS) {
+    ensureSpace(28);
+    drawText(
+      `… ${summary.perOperator.length - PDF_MAX_PER_OPERATOR_ROWS} more operators truncated. Pull /per-operator-csv for the full list.`,
+      margin + 10,
+      y,
+      8,
+    );
+    y -= 13;
+  }
   y -= 10;
 
-  // Per-title
+  // Per-title (capped)
   ensureSpace(60);
   drawText('Per-Title Breakdown', margin, y, 14, true);
   y -= 18;
-  for (const tit of summary.perTitle) {
+  const titleRows = summary.perTitle.slice(0, PDF_MAX_PER_TITLE_ROWS);
+  for (const tit of titleRows) {
     ensureSpace(28);
     drawText(
       `${tit.documentName} (${tit.pages}p): ${tit.zonesReviewed} zones, ${tit.activeHours.toFixed(2)}h, ${tit.issuesCount} issues, ₹${tit.costInr.toFixed(0)}`,
       margin + 10,
       y,
       9,
+    );
+    y -= 13;
+  }
+  if (summary.perTitle.length > PDF_MAX_PER_TITLE_ROWS) {
+    ensureSpace(28);
+    drawText(
+      `… ${summary.perTitle.length - PDF_MAX_PER_TITLE_ROWS} more titles truncated. Pull /per-title-csv for the full list.`,
+      margin + 10,
+      y,
+      8,
     );
     y -= 13;
   }

--- a/tests/unit/schemas/corpus-summary.schema.test.ts
+++ b/tests/unit/schemas/corpus-summary.schema.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  corpusRangeQuerySchema,
+  resolveCorpusRange,
+} from '../../../src/schemas/corpus-summary.schema';
+
+describe('corpusRangeQuerySchema', () => {
+  it('accepts date-only strings (YYYY-MM-DD) per spec', () => {
+    const parsed = corpusRangeQuerySchema.safeParse({ from: '2026-04-01', to: '2026-04-13' });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts full ISO-8601 datetimes with offset', () => {
+    const parsed = corpusRangeQuerySchema.safeParse({
+      from: '2026-04-01T00:00:00Z',
+      to: '2026-04-13T23:59:59.999+05:30',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts an empty object (both params optional)', () => {
+    const parsed = corpusRangeQuerySchema.safeParse({});
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects malformed date strings', () => {
+    const parsed = corpusRangeQuerySchema.safeParse({ from: 'yesterday' });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects impossible calendar dates', () => {
+    const parsed = corpusRangeQuerySchema.safeParse({ from: '2026-02-31' });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects datetimes without timezone offset', () => {
+    // Naive datetimes are ambiguous → reject to keep the UTC contract clear.
+    const parsed = corpusRangeQuerySchema.safeParse({ from: '2026-04-01T12:00:00' });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects from > to', () => {
+    const parsed = corpusRangeQuerySchema.safeParse({
+      from: '2026-04-13',
+      to: '2026-04-01',
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('accepts same-day from = to when both are date-only', () => {
+    // from normalizes to 00:00Z, to normalizes to 23:59Z, so this is valid.
+    const parsed = corpusRangeQuerySchema.safeParse({
+      from: '2026-04-05',
+      to: '2026-04-05',
+    });
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('resolveCorpusRange', () => {
+  it('normalizes date-only `from` to start of UTC day', () => {
+    const { from } = resolveCorpusRange({ from: '2026-04-01', to: '2026-04-13' });
+    expect(from.toISOString()).toBe('2026-04-01T00:00:00.000Z');
+  });
+
+  it('normalizes date-only `to` to end of UTC day', () => {
+    const { to } = resolveCorpusRange({ from: '2026-04-01', to: '2026-04-13' });
+    expect(to.toISOString()).toBe('2026-04-13T23:59:59.999Z');
+  });
+
+  it('preserves full datetime `from` and `to` exactly as supplied', () => {
+    const { from, to } = resolveCorpusRange({
+      from: '2026-04-01T09:30:00Z',
+      to: '2026-04-13T17:45:00Z',
+    });
+    expect(from.toISOString()).toBe('2026-04-01T09:30:00.000Z');
+    expect(to.toISOString()).toBe('2026-04-13T17:45:00.000Z');
+  });
+
+  it('defaults to last 30 days when both params omitted', () => {
+    const before = Date.now();
+    const { from, to } = resolveCorpusRange({});
+    const after = Date.now();
+
+    // `to` ≈ now
+    expect(to.getTime()).toBeGreaterThanOrEqual(before);
+    expect(to.getTime()).toBeLessThanOrEqual(after);
+    // `from` ≈ to − 30 days
+    const spanMs = to.getTime() - from.getTime();
+    expect(spanMs).toBeCloseTo(30 * 24 * 60 * 60 * 1000, -2);
+  });
+
+  it('defaults `from` to 30 days before `to` when only `to` is supplied', () => {
+    const { from, to } = resolveCorpusRange({ to: '2026-04-13' });
+    expect(to.toISOString()).toBe('2026-04-13T23:59:59.999Z');
+    const spanMs = to.getTime() - from.getTime();
+    expect(spanMs).toBeCloseTo(30 * 24 * 60 * 60 * 1000, -2);
+  });
+});

--- a/tests/unit/services/calibration/corpus-summary.service.test.ts
+++ b/tests/unit/services/calibration/corpus-summary.service.test.ts
@@ -1,0 +1,543 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Prisma mock ───────────────────────────────────────────────────────
+const mockCalibrationRunFindMany = vi.fn();
+const mockUserFindMany = vi.fn();
+
+vi.mock('../../../../src/lib/prisma', () => ({
+  default: {
+    calibrationRun: {
+      findMany: (...args: unknown[]) => mockCalibrationRunFindMany(...args),
+    },
+    user: {
+      findMany: (...args: unknown[]) => mockUserFindMany(...args),
+    },
+  },
+}));
+
+import {
+  getLineageSummary,
+  getTimesheetSummary,
+  ANNOTATOR_RATE_INR_PER_HOUR,
+} from '../../../../src/services/calibration/corpus-summary.service';
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+const RANGE = {
+  from: new Date('2026-04-01T00:00:00.000Z'),
+  to: new Date('2026-04-13T23:59:59.999Z'),
+};
+
+/** Minimal zone factory. */
+function zone(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: `z-${Math.random().toString(36).slice(2, 8)}`,
+    pageNumber: 1,
+    type: 'Text',
+    operatorLabel: null,
+    decision: null,
+    verifiedBy: null,
+    aiLabel: null,
+    aiDecision: null,
+    aiConfidence: null,
+    reconciliationBucket: null,
+    doclingLabel: null,
+    pdfxtLabel: null,
+    ...overrides,
+  };
+}
+
+/** Minimal session factory — activeMs in ms. */
+function session(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    operatorId: 'op-alice',
+    startedAt: new Date('2026-04-05T09:00:00Z'),
+    endedAt: new Date('2026-04-05T10:00:00Z'),
+    activeMs: 60 * 60 * 1000, // 1 hour
+    idleMs: 0,
+    zonesReviewed: 0,
+    zonesConfirmed: 0,
+    zonesCorrected: 0,
+    zonesRejected: 0,
+    sessionLog: null,
+    ...overrides,
+  };
+}
+
+/** Run with completedAt, zones, sessions, and issue count. */
+function makeRun(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'run-1',
+    completedAt: new Date('2026-04-05T10:00:00Z'),
+    corpusDocument: { filename: 'Book A.pdf', pageCount: 100 },
+    zones: [],
+    annotationSessions: [],
+    issues: [],
+    _count: { issues: 0 },
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUserFindMany.mockResolvedValue([]);
+});
+
+describe('getTimesheetSummary', () => {
+  it('empty range returns a valid zeroed envelope (not a 404 or throw)', async () => {
+    mockCalibrationRunFindMany.mockResolvedValue([]);
+
+    const result = await getTimesheetSummary(RANGE);
+
+    expect(result.runsIncluded).toBe(0);
+    expect(result.totals).toEqual({
+      wallClockHours: 0,
+      activeHours: 0,
+      idleHours: 0,
+      zonesReviewed: 0,
+      zonesPerHour: 0,
+      annotatorCostInr: 0,
+    });
+    expect(result.perOperator).toEqual([]);
+    expect(result.perTitle).toEqual([]);
+    expect(result.perZoneType).toEqual([]);
+    // Throughput trend still emits one bucket per UTC day in the range.
+    expect(result.throughputTrend.length).toBeGreaterThan(0);
+    expect(result.throughputTrend.every(d => d.activeHours === 0)).toBe(true);
+  });
+
+  it('passes completedAt filter for the supplied range to Prisma', async () => {
+    mockCalibrationRunFindMany.mockResolvedValue([]);
+
+    await getTimesheetSummary(RANGE);
+
+    const call = mockCalibrationRunFindMany.mock.calls[0]![0] as {
+      where: { completedAt: { gte: Date; lte: Date; not: null } };
+    };
+    expect(call.where.completedAt.gte).toEqual(RANGE.from);
+    expect(call.where.completedAt.lte).toEqual(RANGE.to);
+    expect(call.where.completedAt.not).toBeNull();
+  });
+
+  // ── Cost parity ──────────────────────────────────────────────────
+  // This is the load-bearing invariant the whole PR #2 hinges on. If
+  // per-run and per-corpus costs ever diverge, the rate discrepancy will
+  // surface immediately in the finance report. These assertions exist so
+  // nobody can "simplify" the formula without tripping a loud test.
+  describe('cost-parity invariant (ANNOTATOR_RATE_INR_PER_HOUR × sum(activeMs) / 3_600_000)', () => {
+    it('constant matches the value the spec and per-run path use', () => {
+      expect(ANNOTATOR_RATE_INR_PER_HOUR).toBe(400);
+    });
+
+    it('perTitle[i].costInr = (sum of session activeMs for that run) / 3_600_000 × 400', async () => {
+      // Run A: two sessions totaling 2.5h → expect ₹1000
+      // Run B: one session of 45 minutes → expect ₹300
+      const runA = makeRun({
+        id: 'run-A',
+        corpusDocument: { filename: 'Alpha.pdf', pageCount: 50 },
+        annotationSessions: [
+          session({ operatorId: 'op-alice', activeMs: 90 * 60 * 1000, zonesReviewed: 30 }),
+          session({ operatorId: 'op-bob', activeMs: 60 * 60 * 1000, zonesReviewed: 20 }),
+        ],
+        _count: { issues: 2 },
+      });
+      const runB = makeRun({
+        id: 'run-B',
+        corpusDocument: { filename: 'Beta.pdf', pageCount: 75 },
+        annotationSessions: [
+          session({ operatorId: 'op-alice', activeMs: 45 * 60 * 1000, zonesReviewed: 10 }),
+        ],
+        _count: { issues: 0 },
+      });
+      mockCalibrationRunFindMany.mockResolvedValue([runA, runB]);
+
+      const result = await getTimesheetSummary(RANGE);
+
+      const byName = new Map(result.perTitle.map(t => [t.documentName, t]));
+      const alpha = byName.get('Alpha.pdf')!;
+      const beta = byName.get('Beta.pdf')!;
+
+      expect(alpha.activeHours).toBeCloseTo(2.5, 6);
+      expect(alpha.costInr).toBeCloseTo(2.5 * ANNOTATOR_RATE_INR_PER_HOUR, 6);
+      expect(alpha.costInr).toBeCloseTo(1000, 6);
+
+      expect(beta.activeHours).toBeCloseTo(0.75, 6);
+      expect(beta.costInr).toBeCloseTo(0.75 * ANNOTATOR_RATE_INR_PER_HOUR, 6);
+      expect(beta.costInr).toBeCloseTo(300, 6);
+    });
+
+    it('totals.annotatorCostInr = sum(perTitle.costInr) — per-run and per-corpus paths cannot drift', async () => {
+      const runA = makeRun({
+        id: 'run-A',
+        corpusDocument: { filename: 'Alpha.pdf', pageCount: 50 },
+        annotationSessions: [
+          session({ operatorId: 'op-alice', activeMs: 90 * 60 * 1000 }),
+          session({ operatorId: 'op-bob', activeMs: 60 * 60 * 1000 }),
+        ],
+      });
+      const runB = makeRun({
+        id: 'run-B',
+        corpusDocument: { filename: 'Beta.pdf', pageCount: 75 },
+        annotationSessions: [session({ operatorId: 'op-alice', activeMs: 45 * 60 * 1000 })],
+      });
+      mockCalibrationRunFindMany.mockResolvedValue([runA, runB]);
+
+      const result = await getTimesheetSummary(RANGE);
+
+      const sumOfTitleCosts = result.perTitle.reduce((s, t) => s + t.costInr, 0);
+      expect(result.totals.annotatorCostInr).toBeCloseTo(sumOfTitleCosts, 6);
+
+      // And the overall total must equal totalActiveHours × 400
+      expect(result.totals.annotatorCostInr).toBeCloseTo(
+        result.totals.activeHours * ANNOTATOR_RATE_INR_PER_HOUR,
+        6,
+      );
+
+      // Sanity: total = 3.25h × 400 = ₹1300
+      expect(result.totals.annotatorCostInr).toBeCloseTo(1300, 6);
+    });
+
+    it('perOperator[i].costInr = operator.activeHours × 400 (no hidden multipliers)', async () => {
+      const run = makeRun({
+        annotationSessions: [
+          session({ operatorId: 'op-alice', activeMs: 120 * 60 * 1000 }), // 2h
+          session({ operatorId: 'op-bob', activeMs: 30 * 60 * 1000 }), //   0.5h
+        ],
+      });
+      mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+      const result = await getTimesheetSummary(RANGE);
+      for (const op of result.perOperator) {
+        expect(op.costInr).toBeCloseTo(op.activeHours * ANNOTATOR_RATE_INR_PER_HOUR, 6);
+      }
+      // Labels resolve to UUID since user lookup returned [] — fine, we key on activeHours
+      const alice = result.perOperator.find(o => o.activeHours === 2)!;
+      const bob = result.perOperator.find(o => o.activeHours === 0.5)!;
+      expect(alice.costInr).toBeCloseTo(800, 6);
+      expect(bob.costInr).toBeCloseTo(200, 6);
+    });
+  });
+
+  it('per-operator rolls up sessions across multiple runs', async () => {
+    const runA = makeRun({
+      id: 'run-A',
+      annotationSessions: [
+        session({
+          operatorId: 'op-alice',
+          activeMs: 60 * 60 * 1000,
+          zonesReviewed: 10,
+          zonesConfirmed: 8,
+          zonesCorrected: 2,
+          zonesRejected: 0,
+        }),
+      ],
+    });
+    const runB = makeRun({
+      id: 'run-B',
+      corpusDocument: { filename: 'Beta.pdf', pageCount: 50 },
+      annotationSessions: [
+        session({
+          operatorId: 'op-alice',
+          activeMs: 30 * 60 * 1000,
+          zonesReviewed: 5,
+          zonesConfirmed: 3,
+          zonesCorrected: 1,
+          zonesRejected: 1,
+        }),
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([runA, runB]);
+
+    const result = await getTimesheetSummary(RANGE);
+    expect(result.perOperator).toHaveLength(1);
+    const op = result.perOperator[0]!;
+    expect(op.activeHours).toBeCloseTo(1.5, 6);
+    expect(op.zonesReviewed).toBe(15);
+    expect(op.runsContributedTo).toBe(2);
+    // confirm/correct/reject percentages across combined decisions (11 conf, 3 corr, 1 rej = 15 decided)
+    expect(op.confirmPct).toBeCloseTo((11 / 15) * 100, 6);
+    expect(op.correctPct).toBeCloseTo((3 / 15) * 100, 6);
+    expect(op.rejectPct).toBeCloseTo((1 / 15) * 100, 6);
+  });
+
+  it('perZoneType avgSecondsPerZone apportions totalActiveMs across decided zones', async () => {
+    // 1 run, 1h active, 4 decided zones (3 Text + 1 Heading) and 1 undecided zone.
+    // Expected share: Text gets 3/4 of 3600s = 2700s → 900s/zone.
+    //                 Heading gets 1/4 of 3600s = 900s → 900s/zone.
+    const run = makeRun({
+      zones: [
+        zone({ type: 'Text', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+        zone({ type: 'Text', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+        zone({ type: 'Text', decision: 'CORRECTED', operatorLabel: 'Heading', verifiedBy: 'op-alice' }),
+        zone({ type: 'Heading', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+        zone({ type: 'Text' }), // undecided → excluded
+      ],
+      annotationSessions: [session({ activeMs: 60 * 60 * 1000 })],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getTimesheetSummary(RANGE);
+    const byType = new Map(result.perZoneType.map(r => [r.zoneType, r]));
+    expect(byType.get('Text')!.totalZones).toBe(3);
+    expect(byType.get('Text')!.avgSecondsPerZone).toBeCloseTo(900, 3);
+    expect(byType.get('Heading')!.totalZones).toBe(1);
+    expect(byType.get('Heading')!.avgSecondsPerZone).toBeCloseTo(900, 3);
+  });
+
+  it('auto-annotated zones are excluded from perZoneType apportionment', async () => {
+    const run = makeRun({
+      zones: [
+        zone({ type: 'Text', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+        zone({ type: 'Text', decision: 'CONFIRMED', verifiedBy: 'auto-annotation' }),
+      ],
+      annotationSessions: [session({ activeMs: 60 * 60 * 1000 })],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getTimesheetSummary(RANGE);
+    const text = result.perZoneType.find(r => r.zoneType === 'Text')!;
+    // Only 1 operator-decided zone → whole 3600s attributed to it.
+    expect(text.totalZones).toBe(1);
+    expect(text.avgSecondsPerZone).toBeCloseTo(3600, 3);
+  });
+
+  it('throughputTrend attributes sessions to UTC end-day', async () => {
+    const run = makeRun({
+      annotationSessions: [
+        session({
+          operatorId: 'op-alice',
+          startedAt: new Date('2026-04-05T23:30:00Z'),
+          endedAt: new Date('2026-04-06T00:30:00Z'), // crosses midnight UTC
+          activeMs: 60 * 60 * 1000,
+          zonesReviewed: 20,
+        }),
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getTimesheetSummary(RANGE);
+    const byDate = new Map(result.throughputTrend.map(d => [d.date, d]));
+    // Session attributed to endedAt day (2026-04-06), not startedAt day.
+    expect(byDate.get('2026-04-06')!.zonesReviewed).toBe(20);
+    expect(byDate.get('2026-04-06')!.activeHours).toBeCloseTo(1, 6);
+    expect(byDate.get('2026-04-05')!.zonesReviewed).toBe(0);
+  });
+
+  it('resolves operator display names from User table when available', async () => {
+    const run = makeRun({
+      annotationSessions: [session({ operatorId: 'user-uuid-1', activeMs: 60 * 60 * 1000 })],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+    mockUserFindMany.mockResolvedValue([
+      { id: 'user-uuid-1', firstName: 'Alice', lastName: 'Example', email: 'alice@example.com' },
+    ]);
+
+    const result = await getTimesheetSummary(RANGE);
+    expect(result.perOperator[0]!.operator).toBe('Alice Example');
+  });
+});
+
+describe('getLineageSummary', () => {
+  it('empty range returns a zeroed envelope', async () => {
+    mockCalibrationRunFindMany.mockResolvedValue([]);
+
+    const result = await getLineageSummary(RANGE);
+    expect(result.runsIncluded).toBe(0);
+    expect(result.headline.totalZones).toBe(0);
+    expect(result.headline.aiAgreementRate).toBe(0);
+    expect(result.confusionMatrix.labels).toEqual([]);
+    expect(result.issuesLog).toEqual([]);
+  });
+
+  it('passes completedAt filter for the supplied range to Prisma', async () => {
+    mockCalibrationRunFindMany.mockResolvedValue([]);
+    await getLineageSummary(RANGE);
+    const call = mockCalibrationRunFindMany.mock.calls[0]![0] as {
+      where: { completedAt: { gte: Date; lte: Date; not: null } };
+    };
+    expect(call.where.completedAt.gte).toEqual(RANGE.from);
+    expect(call.where.completedAt.lte).toEqual(RANGE.to);
+  });
+
+  it('headline.aiAgreementRate excludes zones without both aiLabel and finalLabel', async () => {
+    // 4 zones:
+    //   A: aiLabel=Text, CONFIRMED Text → agreement denominator +1, numerator +1
+    //   B: aiLabel=Text, CORRECTED Heading → denom +1, num 0
+    //   C: aiLabel=null, CONFIRMED Text → excluded (no AI label)
+    //   D: aiLabel=Text, decision=null → excluded (no final label)
+    const run = makeRun({
+      zones: [
+        zone({ aiLabel: 'Text', type: 'Text', decision: 'CONFIRMED' }),
+        zone({ aiLabel: 'Text', type: 'Text', decision: 'CORRECTED', operatorLabel: 'Heading' }),
+        zone({ aiLabel: null, type: 'Text', decision: 'CONFIRMED' }),
+        zone({ aiLabel: 'Text', type: 'Text', decision: null }),
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getLineageSummary(RANGE);
+    // 1/2 agreed → 0.5
+    expect(result.headline.aiAgreementRate).toBeCloseTo(0.5, 6);
+  });
+
+  it('humanCorrectionRate and humanRejectionRate use all human-decided zones as denominator', async () => {
+    const run = makeRun({
+      zones: [
+        zone({ decision: 'CONFIRMED' }),
+        zone({ decision: 'CONFIRMED' }),
+        zone({ decision: 'CORRECTED', operatorLabel: 'Heading' }),
+        zone({ decision: 'REJECTED' }),
+        zone({ decision: null }), // excluded
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getLineageSummary(RANGE);
+    expect(result.headline.humanCorrectionRate).toBeCloseTo(1 / 4, 6);
+    expect(result.headline.humanRejectionRate).toBeCloseTo(1 / 4, 6);
+  });
+
+  it('confusionMatrix sorts labels alphabetically and counts (ai, final) pairs', async () => {
+    const run = makeRun({
+      zones: [
+        zone({ aiLabel: 'Text', type: 'Text', decision: 'CONFIRMED' }), // Text→Text
+        zone({ aiLabel: 'Text', type: 'Text', decision: 'CONFIRMED' }), // Text→Text
+        zone({ aiLabel: 'Text', type: 'Text', decision: 'CORRECTED', operatorLabel: 'Heading' }), // Text→Heading
+        zone({ aiLabel: 'Heading', type: 'Heading', decision: 'CONFIRMED' }), // Heading→Heading
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getLineageSummary(RANGE);
+    expect(result.confusionMatrix.labels).toEqual(['Heading', 'Text']);
+    // rows=ai, cols=final; alphabetical order
+    //       Heading  Text
+    // H:       1      0
+    // T:       1      2
+    expect(result.confusionMatrix.cells).toEqual([
+      [1, 0],
+      [1, 2],
+    ]);
+  });
+
+  it('bucketFlow counts human decisions per reconciliation bucket', async () => {
+    const run = makeRun({
+      zones: [
+        zone({ reconciliationBucket: 'GREEN', decision: 'CONFIRMED' }),
+        zone({ reconciliationBucket: 'GREEN', decision: 'CONFIRMED' }),
+        zone({ reconciliationBucket: 'AMBER', decision: 'CORRECTED', operatorLabel: 'Heading' }),
+        zone({ reconciliationBucket: 'AMBER', decision: 'REJECTED' }),
+        zone({ reconciliationBucket: 'RED', decision: 'REJECTED' }),
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getLineageSummary(RANGE);
+    expect(result.bucketFlow.green).toEqual({
+      total: 2,
+      humanConfirmed: 2,
+      humanCorrected: 0,
+      humanRejected: 0,
+    });
+    expect(result.bucketFlow.amber).toEqual({
+      total: 2,
+      humanConfirmed: 0,
+      humanCorrected: 1,
+      humanRejected: 1,
+    });
+    expect(result.bucketFlow.red).toEqual({
+      total: 1,
+      humanConfirmed: 0,
+      humanCorrected: 0,
+      humanRejected: 1,
+    });
+  });
+
+  it('issuesLog groups issues by category across titles and counts distinct titles', async () => {
+    const runA = makeRun({
+      id: 'run-A',
+      corpusDocument: { filename: 'Alpha.pdf', pageCount: 50 },
+      issues: [
+        {
+          category: 'PAGE_ALIGNMENT_MISMATCH',
+          pagesAffected: 5,
+          description: 'mismatch A1',
+          blocking: true,
+        },
+        {
+          category: 'PAGE_ALIGNMENT_MISMATCH',
+          pagesAffected: 2,
+          description: 'mismatch A2',
+          blocking: false,
+        },
+      ],
+    });
+    const runB = makeRun({
+      id: 'run-B',
+      corpusDocument: { filename: 'Beta.pdf', pageCount: 75 },
+      issues: [
+        {
+          category: 'PAGE_ALIGNMENT_MISMATCH',
+          pagesAffected: 3,
+          description: 'mismatch B',
+          blocking: false,
+        },
+        { category: 'OTHER', pagesAffected: null, description: 'other thing', blocking: false },
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([runA, runB]);
+
+    const result = await getLineageSummary(RANGE);
+    const byCategory = new Map(result.issuesLog.map(i => [i.category, i]));
+    const pam = byCategory.get('PAGE_ALIGNMENT_MISMATCH')!;
+    expect(pam.titleCount).toBe(2); // distinct runs A + B
+    expect(pam.totalPagesAffected).toBe(5 + 2 + 3);
+    expect(pam.blockingCount).toBe(1);
+    expect(pam.titles).toHaveLength(3);
+
+    const other = byCategory.get('OTHER')!;
+    expect(other.titleCount).toBe(1);
+    expect(other.totalPagesAffected).toBe(0);
+  });
+
+  it('extractorDisagreement excludes zones missing either extractor label', async () => {
+    const run = makeRun({
+      zones: [
+        // included: both extractors present, agreement → disagreement count 0
+        zone({
+          type: 'Text',
+          decision: 'CONFIRMED',
+          doclingLabel: 'Text',
+          pdfxtLabel: 'Text',
+        }),
+        // included: disagreement → disagreement count 1
+        zone({
+          type: 'Text',
+          decision: 'CONFIRMED',
+          doclingLabel: 'Text',
+          pdfxtLabel: 'Heading',
+        }),
+        // excluded: missing pdfxt
+        zone({
+          type: 'Text',
+          decision: 'CONFIRMED',
+          doclingLabel: 'Text',
+          pdfxtLabel: null,
+        }),
+        // excluded: no final label
+        zone({
+          type: 'Text',
+          decision: null,
+          doclingLabel: 'Text',
+          pdfxtLabel: 'Text',
+        }),
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getLineageSummary(RANGE);
+    const textRow = result.extractorDisagreement.find(r => r.finalLabel === 'Text')!;
+    expect(textRow.totalZones).toBe(2);
+    expect(textRow.disagreementPct).toBeCloseTo(50, 6);
+  });
+});

--- a/tests/unit/services/calibration/corpus-summary.service.test.ts
+++ b/tests/unit/services/calibration/corpus-summary.service.test.ts
@@ -284,6 +284,38 @@ describe('getTimesheetSummary', () => {
     expect(byType.get('Heading')!.avgSecondsPerZone).toBeCloseTo(900, 3);
   });
 
+  it('perZoneType apportions active time per-run, not blended across runs', async () => {
+    // Two runs with very different throughput:
+    //   Run A: 1h active, 2 Text zones → 1800s/Text
+    //   Run B: 4h active, 2 Figure zones → 7200s/Figure
+    // A global ratio (5h × 2/4 = 2.5h for each type = 4500s per zone) would
+    // have blended them. Per-run apportionment keeps them distinct: Text
+    // gets its 1h and Figure gets its 4h, avg = 1800s and 7200s.
+    const runA = makeRun({
+      id: 'run-A',
+      zones: [
+        zone({ type: 'Text', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+        zone({ type: 'Text', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+      ],
+      annotationSessions: [session({ activeMs: 60 * 60 * 1000 })],
+    });
+    const runB = makeRun({
+      id: 'run-B',
+      corpusDocument: { filename: 'Figures.pdf', pageCount: 20 },
+      zones: [
+        zone({ type: 'Figure', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+        zone({ type: 'Figure', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+      ],
+      annotationSessions: [session({ activeMs: 4 * 60 * 60 * 1000 })],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([runA, runB]);
+
+    const result = await getTimesheetSummary(RANGE);
+    const byType = new Map(result.perZoneType.map(r => [r.zoneType, r]));
+    expect(byType.get('Text')!.avgSecondsPerZone).toBeCloseTo(1800, 3);
+    expect(byType.get('Figure')!.avgSecondsPerZone).toBeCloseTo(7200, 3);
+  });
+
   it('perZoneType ignores active time from runs with zero decided zones', async () => {
     // Run A: 1h active, 2 decided Text zones (operator-verified).
     // Run B: 1h active, ZERO decided zones — an abandoned/QA-only run.
@@ -552,6 +584,60 @@ describe('getLineageSummary', () => {
     const other = byCategory.get('OTHER')!;
     expect(other.titleCount).toBe(1);
     expect(other.totalPagesAffected).toBe(0);
+  });
+
+  it('AI-authored decisions do not count as human review in lineage metrics', async () => {
+    // Three zones, all with aiLabel=Text and decision=CONFIRMED:
+    //   - zone A: verifiedBy='op-alice'        → real human confirm
+    //   - zone B: verifiedBy='auto-annotation' → AI-authored, must be skipped
+    //   - zone C: verifiedBy='ai:gemini'       → AI-authored, must be skipped
+    // One human corrected Text → Heading.
+    // Expected: humanDecided = 2 (A + correction), not 4.
+    //           humanCorrectionRate = 1/2, humanRejectionRate = 0
+    //           aiAgreementRate computes over 2 human decisions:
+    //             A: ai=Text final=Text   → match
+    //             corrected: ai=Text final=Heading → no match
+    //           → 0.5
+    const run = makeRun({
+      zones: [
+        zone({ aiLabel: 'Text', type: 'Text', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+        zone({ aiLabel: 'Text', type: 'Text', decision: 'CONFIRMED', verifiedBy: 'auto-annotation' }),
+        zone({ aiLabel: 'Text', type: 'Text', decision: 'CONFIRMED', verifiedBy: 'ai:gemini' }),
+        zone({
+          aiLabel: 'Text',
+          type: 'Text',
+          decision: 'CORRECTED',
+          operatorLabel: 'Heading',
+          verifiedBy: 'op-alice',
+        }),
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getLineageSummary(RANGE);
+    expect(result.headline.humanCorrectionRate).toBeCloseTo(1 / 2, 6);
+    expect(result.headline.humanRejectionRate).toBeCloseTo(0, 6);
+    expect(result.headline.aiAgreementRate).toBeCloseTo(1 / 2, 6);
+  });
+
+  it('bucketFlow skips AI-authored decisions', async () => {
+    // Same GREEN bucket, 2 CONFIRMED zones but one is AI-authored. Only
+    // the human one should count toward humanConfirmed.
+    const run = makeRun({
+      zones: [
+        zone({ reconciliationBucket: 'GREEN', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+        zone({
+          reconciliationBucket: 'GREEN',
+          decision: 'CONFIRMED',
+          verifiedBy: 'auto-annotation',
+        }),
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getLineageSummary(RANGE);
+    expect(result.bucketFlow.green.total).toBe(2); // bucket total still counts both
+    expect(result.bucketFlow.green.humanConfirmed).toBe(1); // but only 1 human confirm
   });
 
   it('extractorDisagreement excludes zones missing either extractor label', async () => {

--- a/tests/unit/services/calibration/corpus-summary.service.test.ts
+++ b/tests/unit/services/calibration/corpus-summary.service.test.ts
@@ -284,6 +284,60 @@ describe('getTimesheetSummary', () => {
     expect(byType.get('Heading')!.avgSecondsPerZone).toBeCloseTo(900, 3);
   });
 
+  it('perZoneType ignores active time from runs with zero decided zones', async () => {
+    // Run A: 1h active, 2 decided Text zones (operator-verified).
+    // Run B: 1h active, ZERO decided zones — an abandoned/QA-only run.
+    // Regression: previously runB's 1h was apportioned across runA's zones,
+    // inflating avgSecondsPerZone from 1800s to 3600s.
+    const runA = makeRun({
+      id: 'run-A',
+      zones: [
+        zone({ type: 'Text', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+        zone({ type: 'Text', decision: 'CONFIRMED', verifiedBy: 'op-alice' }),
+      ],
+      annotationSessions: [session({ activeMs: 60 * 60 * 1000 })],
+    });
+    const runB = makeRun({
+      id: 'run-B',
+      corpusDocument: { filename: 'Abandoned.pdf', pageCount: 10 },
+      zones: [], // nothing decided
+      annotationSessions: [session({ activeMs: 60 * 60 * 1000 })],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([runA, runB]);
+
+    const result = await getTimesheetSummary(RANGE);
+    const text = result.perZoneType.find(r => r.zoneType === 'Text')!;
+    expect(text.totalZones).toBe(2);
+    // 1h active / 2 zones = 1800s per zone. runB's hour does NOT contribute.
+    expect(text.avgSecondsPerZone).toBeCloseTo(1800, 3);
+  });
+
+  it('totals.wallClockHours sums per-session durations, not range span', async () => {
+    // Two 1-hour sessions 24 hours apart. A naive max(endedAt)-min(startedAt)
+    // would report ~25h. Correct answer is 2h: the gap between sessions is
+    // not work time.
+    const run = makeRun({
+      annotationSessions: [
+        session({
+          startedAt: new Date('2026-04-05T09:00:00Z'),
+          endedAt: new Date('2026-04-05T10:00:00Z'),
+          activeMs: 60 * 60 * 1000,
+        }),
+        session({
+          operatorId: 'op-bob',
+          startedAt: new Date('2026-04-06T09:00:00Z'),
+          endedAt: new Date('2026-04-06T10:00:00Z'),
+          activeMs: 60 * 60 * 1000,
+        }),
+      ],
+    });
+    mockCalibrationRunFindMany.mockResolvedValue([run]);
+
+    const result = await getTimesheetSummary(RANGE);
+    expect(result.totals.wallClockHours).toBeCloseTo(2, 6);
+    expect(result.totals.activeHours).toBeCloseTo(2, 6);
+  });
+
   it('auto-annotated zones are excluded from perZoneType apportionment', async () => {
     const run = makeRun({
       zones: [


### PR DESCRIPTION
## Summary

Backend PR #2 of `BACKEND_SPEC_MARK_COMPLETE_AND_CORPUS_SUMMARY.md`. Adds
cross-title corpus-level aggregations with time-range filtering, plus
CSV/PDF exports. All new endpoints complement (not replace) the existing
per-run annotation report and the legacy `/corpus/analysis-summary`.

### New endpoints

- `GET /calibration/corpus/lineage-summary?from=&to=` — cross-title zone
  lineage: headline agreement/correction/rejection rates, confusion
  matrix (AI × final), per-zone-type performance, bucket flow, issues
  log grouped by category, extractor disagreement.
- `GET /calibration/corpus/timesheet-summary?from=&to=` — operator time
  & cost aggregations across all completed runs in range.
- `GET /calibration/corpus/lineage-summary/export/csv` — flat per-zone
  lineage CSV.
- `GET /calibration/corpus/timesheet-summary/export/per-operator-csv`
- `GET /calibration/corpus/timesheet-summary/export/per-title-csv`
- `GET /calibration/corpus/timesheet-summary/export/pdf`

### Extended endpoint

- `GET /calibration/corpus/analysis-summary` now accepts optional
  `from`/`to` query params and includes `completedAt` and `issuesCount`
  in each per-title cost row. Back-compat preserved: calling without
  params still works (legacy path).

### Query params

Both `from` and `to` are optional ISO-8601 strings (Zod
`.datetime({ offset: true })`). When omitted, default range is **the
last 30 days ending now**. Range is inclusive on both ends. `from > to`
returns 422.

## Cost-parity invariant (belt-and-braces)

This is the load-bearing correctness claim of the PR. Per-run and
per-corpus cost formulas MUST use the same rate and the same source of
truth for `activeMs`. The service exports
`ANNOTATOR_RATE_INR_PER_HOUR = 400` and all cost computations go through
it. Three layers of tests enforce parity:

1. `perTitle[i].costInr === (sum session.activeMs for runId) / 3_600_000 × 400`
2. `totals.annotatorCostInr === sum(perTitle.costInr) === totals.activeHours × 400`
3. `perOperator[i].costInr === op.activeHours × 400`

If anyone "improves" the formula in isolation, all three assertions
fire immediately instead of surfacing as a finance-report discrepancy.

## Aggregation rules (per spec)

- Only runs with `completedAt ∈ [from, to]` are included.
- Empty range returns a zeroed envelope (never 404, never throw).
  Throughput trend still emits one bucket per UTC day.
- Lineage `aiAgreementRate` excludes zones without BOTH `aiLabel` AND a
  final label, so unreviewed zones don't deflate the rate.
- Confusion matrix labels sorted alphabetically for deterministic
  frontend order.
- `perZoneType` `avgSecondsPerZone` apportions `totalActiveMs` across
  decided zones proportional to type share. Auto-annotated zones are
  excluded from apportionment.
- Throughput trend attributes sessions to `endedAt` UTC day (fallback:
  `startedAt`).

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/unit/services/calibration/corpus-summary.service.test.ts` — 19 passing
- [x] Full mark-complete + corpus-summary suite — 41 passing
- [ ] Staging smoke: GET lineage-summary/timesheet-summary with default and explicit ranges
- [ ] Staging smoke: CSV / PDF exports download correctly
- [ ] Staging smoke: cost-parity — per-run timesheet cost matches the corresponding row in corpus timesheet-summary `perTitle`

## Out of scope

- Frontend (Frontend PR #2 will start after this lands).
- New cost rates or currency handling — we intentionally reuse the
  existing per-run constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Corpus-level lineage and timesheet summaries with optional validated date-range filtering; per-operator/per-title breakdowns, daily throughput trends, and updated cost/time aggregations
  * Range-capable CSV and PDF export endpoints that set proper content type and filename including the selected date range
  * Range-aware empty-result behavior returns zeroed summaries for requested ranges

* **Bug Fixes**
  * Improved date-range validation with clear 422 responses; server errors now return a generic client message while preserving server-side logs
  * Preserved legacy "full history" behavior when no range is provided

* **Tests**
  * Unit tests covering schema validation and summary/export computations (lineage & timesheet)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->