### PR TITLE
fix: cap CORS preflight cache at 10 minutes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,9 @@ const corsOptions = {
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'Accept', 'Origin', 'X-Requested-With'],
   exposedHeaders: ['Content-Disposition', 'Content-Length', 'Content-Type'],
+  // Cap preflight cache at 10 minutes so a bad preflight during an ECS task
+  // swap can't poison browser caches for the UA default (Chrome 2h, FF 24h).
+  maxAge: 600,
 };
 
 app.options('*', cors(corsOptions));


### PR DESCRIPTION
## Summary

- Adds `maxAge: 600` to the Express CORS middleware options in `src/index.ts:54–56`, so preflight responses include `Access-Control-Max-Age: 600`.
- Caps the browser preflight cache at 10 minutes instead of the UA default (Chrome 2h, Firefox 24h).
- Preventive only — bounds the blast radius of a bad preflight during an ECS task swap. Not a fix for the 2026-04-14 staging CORS symptom, which investigation proved was client-side (browser preflight cache from the 00:11–00:12 UTC task rotation, service worker, or wrong API base URL).

## Why 10 minutes

| Window | Risk | Benefit |
|---|---|---|
| No `max-age` (current) | UA default TTL — poisoned preflight can linger for hours | Full preflight caching once a good preflight lands |
| 600s (this PR) | 10-minute max damage window from any bad preflight | Still eliminates preflight chatter on normal navigation |
| 0 | No damage window | Every cross-origin request pays a preflight RTT |

10 minutes is the sweet spot: short enough that an ECS task swap (~60 seconds) can't leave failed preflights in user caches through the next coffee break, long enough that normal SPA navigation doesn't re-preflight on every route change.

## Background

Full incident write-up: `Ninja-Documentation/Annotations/2026-04-14-staging-cors-regression-investigation.md` (in the docs repo).

Key evidence that the backend is healthy independent of this change:
- `OPTIONS` + real-request probes through CloudFront returned full CORS headers on both `/api/v1/notifications/unread` and `/api/v1/calibration/runs/:id/complete`.
- CloudWatch `/ecs/ninja-backend-task` showed zero frontend-originated requests during the reported incident window — the browser never reached CloudFront.
- No backend commits between PR #344 merge and the incident report.

This PR is the one preventive backend change that came out of the investigation — it does not address the reported symptom (already gone on the affected machine after cache clear) but closes the door on that class of regression.

## Test plan

- [ ] After deploy, re-run the edge preflight probe and confirm response now includes `Access-Control-Max-Age: 600`:
  ```
  curl -D - -X OPTIONS 'https://d1ruc3qmc844x9.cloudfront.net/api/v1/notifications/unread' \
    -H 'Origin: https://dhi5xqbewozlg.cloudfront.net' \
    -H 'Access-Control-Request-Method: GET' \
    -H 'Access-Control-Request-Headers: authorization,content-type'
  ```
- [ ] Smoke-test from the frontend that normal navigation still works (no new preflight issues).
- [ ] No unit/integration test added — this is a single config value passed through to the `cors` npm library; testing it would be testing the library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved server response caching to enhance application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->