### PR TITLE
fix: add UI label abbreviations to YOLO export CLASS_MAP

### DIFF
--- a/training-export-service/export.py
+++ b/training-export-service/export.py
@@ -10,6 +10,9 @@ CLASS_MAP = {
     'toci': 9, 'formula': 10,
     # Map heading levels → section-header for YOLO
     'h1': 1, 'h2': 1, 'h3': 1, 'h4': 1, 'h5': 1, 'h6': 1,
+    # Map UI dropdown abbreviations (stored as operatorLabel)
+    'p': 0, 'hdr': 6, 'ftr': 7, 'li': 8,
+    'fn': 5, 'fig': 3, 'tbl': 2, 'cap': 4,
 }
 ARTIFACT_TYPES = {'header', 'footer'}
 

--- a/training-export-service/test_export.py
+++ b/training-export-service/test_export.py
@@ -105,16 +105,26 @@ class TestStratifiedSplit(unittest.TestCase):
 
 class TestConstants(unittest.TestCase):
 
-    def test_class_map_has_8_types(self):
-        self.assertEqual(len(CLASS_MAP), 8)
+    def test_class_map_covers_all_11_classes(self):
+        """All 11 YOLO classes (0-10) must be represented in CLASS_MAP values."""
+        self.assertEqual(sorted(set(CLASS_MAP.values())), list(range(11)))
 
-    def test_class_indices_are_0_to_7(self):
-        self.assertEqual(
-            sorted(CLASS_MAP.values()), list(range(8))
-        )
+    def test_ui_abbreviations_map_correctly(self):
+        """UI dropdown labels must map to the same class as their canonical form."""
+        self.assertEqual(CLASS_MAP['hdr'], CLASS_MAP['header'])      # 6
+        self.assertEqual(CLASS_MAP['ftr'], CLASS_MAP['footer'])      # 7
+        self.assertEqual(CLASS_MAP['li'], CLASS_MAP['list-item'])    # 8
+        self.assertEqual(CLASS_MAP['fn'], CLASS_MAP['footnote'])     # 5
+        self.assertEqual(CLASS_MAP['fig'], CLASS_MAP['figure'])      # 3
+        self.assertEqual(CLASS_MAP['tbl'], CLASS_MAP['table'])       # 2
+        self.assertEqual(CLASS_MAP['cap'], CLASS_MAP['caption'])     # 4
+        self.assertEqual(CLASS_MAP['p'], CLASS_MAP['paragraph'])     # 0
 
-    def test_artifact_types_excluded_from_tags(self):
-        # header and footer are artifacts
+    def test_heading_levels_map_to_section_header(self):
+        for h in ('h1', 'h2', 'h3', 'h4', 'h5', 'h6'):
+            self.assertEqual(CLASS_MAP[h], CLASS_MAP['section-header'])
+
+    def test_artifact_types_in_class_map(self):
         for t in ARTIFACT_TYPES:
             self.assertIn(t, CLASS_MAP)
 


### PR DESCRIPTION
## Summary

- **Bug:** The annotation UI stores operator labels as abbreviations (`hdr`, `ftr`, `li`, `fn`, `fig`, `tbl`, `cap`, `p`) but `CLASS_MAP` in `training-export-service/export.py` only had canonical forms. Zones with abbreviation labels fell through to `CLASS_MAP.get(zone_type, 0)` — silently mislabeling 1,508 zones as class 0 (paragraph).
- **Fix:** Add abbreviation → class mappings to `CLASS_MAP`. Update tests to cover all 11 YOLO classes, UI abbreviations, and heading levels.

## Changed files

| File | Change |
|------|--------|
| `training-export-service/export.py` | Added 8 UI abbreviation entries to `CLASS_MAP` |
| `training-export-service/test_export.py` | Replaced outdated 8-class assertions with 11-class + abbreviation + heading tests |

## Test plan

- [x] `python -m unittest test_export -v` — 13/13 pass
- [ ] Re-run YOLO export on a corpus doc and verify abbreviation labels get correct class indices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended element recognition to classify additional document components including headers, footers, list items, footnotes, figures, tables, and captions for improved document structure understanding.

* **Tests**
  * Added validation to ensure consistent classification of document elements and proper recognition of element aliases across the training system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->