### PR TITLE
fix: restrict YOLO export to human-verified zones only

### DIFF
--- a/src/services/calibration/training-export.service.ts
+++ b/src/services/calibration/training-export.service.ts
@@ -49,7 +49,7 @@ export interface ExportOptions {
 export async function getTrainingExportData(
   options: ExportOptions = {},
 ): Promise<TrainingExportResult> {
-  const { documentIds, minConfidence = 0, includeAiOnly = true } = options;
+  const { documentIds, minConfidence = 0, includeAiOnly = false } = options;
 
   // Get corpus documents with calibration runs
   const whereDoc: Record<string, unknown> = {};

--- a/training-export-service/export.py
+++ b/training-export-service/export.py
@@ -16,27 +16,15 @@ CLASS_MAP = {
 }
 ARTIFACT_TYPES = {'header', 'footer'}
 
-# Minimum AI confidence to use aiLabel in training export
-AI_CONFIDENCE_THRESHOLD = 0.95
 
-
-def resolve_label(zone: dict, ai_threshold: float = AI_CONFIDENCE_THRESHOLD) -> str:
-    """Resolve the best label for a zone using priority:
-    operatorLabel > aiLabel (if high confidence) > type.
-    Zones with decision=REJECTED are excluded upstream."""
-    # 1. Human-verified label (highest trust)
+def resolve_label(zone: dict) -> str | None:
+    """Return the zone label ONLY if a human operator verified it.
+    Returns None for zones without human review — these are
+    excluded from training export to prevent unverified labels
+    from corrupting ground truth."""
     if zone.get('operatorLabel'):
         return zone['operatorLabel']
-
-    # 2. AI label if confidence meets threshold
-    ai_label = zone.get('aiLabel')
-    ai_conf = zone.get('aiConfidence', 0) or 0
-    ai_decision = zone.get('aiDecision')
-    if ai_label and ai_conf >= ai_threshold and ai_decision != 'REJECTED':
-        return ai_label
-
-    # 3. Fall back to extraction type
-    return zone.get('type', 'paragraph')
+    return None
 
 
 def render_page_to_jpg(
@@ -146,7 +134,7 @@ def export_corpus(
                aiLabel, aiConfidence, aiDecision }]
     }
 
-    Label priority: operatorLabel > aiLabel (conf >= 0.95) > type
+    Label source: operatorLabel only (human-verified ground truth)
 
     Returns stats dict.
     """
@@ -175,13 +163,18 @@ def export_corpus(
             by_page.setdefault(pn, []).append(z)
 
         for page_num, page_zones in by_page.items():
-            # Filter out rejected zones and artifact-only pages
-            content_zones = [
-                z for z in page_zones
-                if z.get('decision') != 'REJECTED'
-                and z.get('aiDecision') != 'REJECTED'
-                and resolve_label(z) not in ARTIFACT_TYPES
-            ]
+            # Only include zones with human-verified labels
+            # Skip rejected zones, unreviewed zones, and artifact-only pages
+            content_zones = []
+            for z in page_zones:
+                if z.get('decision') == 'REJECTED':
+                    continue
+                label = resolve_label(z)
+                if label is None:
+                    continue  # No human review — skip
+                if label.lower() in ARTIFACT_TYPES:
+                    continue
+                content_zones.append(z)
             if not content_zones:
                 skipped_pages += 1
                 continue

--- a/training-export-service/test_export.py
+++ b/training-export-service/test_export.py
@@ -1,7 +1,7 @@
 import sys, os, unittest
 sys.path.insert(0, os.path.dirname(__file__))
 from export import (
-    bbox_to_yolo, stratified_split, CLASS_MAP, ARTIFACT_TYPES
+    bbox_to_yolo, stratified_split, resolve_label, CLASS_MAP, ARTIFACT_TYPES
 )
 
 
@@ -101,6 +101,26 @@ class TestStratifiedSplit(unittest.TestCase):
         # Should not raise — falls back to 'unknown'
         splits = stratified_split(docs)
         self.assertEqual(len(splits), 6)
+
+
+class TestResolveLabel(unittest.TestCase):
+
+    def test_returns_operator_label(self):
+        """Human-verified operatorLabel is returned."""
+        self.assertEqual(resolve_label({'operatorLabel': 'table'}), 'table')
+
+    def test_returns_none_without_operator_label(self):
+        """Zones without operatorLabel return None (excluded from export)."""
+        self.assertIsNone(resolve_label({'type': 'paragraph', 'aiLabel': 'figure', 'aiConfidence': 0.99}))
+
+    def test_returns_none_for_empty_zone(self):
+        """Empty zone dict returns None."""
+        self.assertIsNone(resolve_label({}))
+
+    def test_ai_only_zone_excluded(self):
+        """AI label with high confidence but no human review returns None."""
+        zone = {'aiLabel': 'table', 'aiConfidence': 0.98, 'aiDecision': 'ACCEPTED'}
+        self.assertIsNone(resolve_label(zone))
 
 
 class TestConstants(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Removed AI-label fallback chain from `resolve_label()` — only zones with a human `operatorLabel` are included in training export
- `resolve_label()` now returns `None` for zones without human review, and the export loop skips them
- Flipped `includeAiOnly` default from `true` to `false` in the DB query so unreviewed zones are filtered at the database level too
- Removed unused `AI_CONFIDENCE_THRESHOLD` constant

**Why:** 20.7% of exported zones were using unverified AI/extractor labels as ground truth. AI accuracy on figures (29.6%) and tables (33.5%) means ~2/3 of fallback labels for those types were wrong, directly corrupting training data.

## Test plan
- [x] 17 Python unit tests pass (`python -m unittest test_export -v`)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] CI Lint, Test & Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified training data export behavior: only zones with human-reviewed decisions are now included by default, excluding AI-only predictions without operator labels from the training dataset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->