### PR TITLE
fix: add skippedNoHumanReview counter to YOLO export stats

### DIFF
--- a/training-export-service/export.py
+++ b/training-export-service/export.py
@@ -147,6 +147,7 @@ def export_corpus(
     total_images = 0
     total_labels = 0
     skipped_pages = 0
+    skipped_no_human_review = 0
     split_sizes = {'train': 0, 'val': 0, 'test': 0}
 
     for doc in documents:
@@ -176,6 +177,10 @@ def export_corpus(
                     continue
                 content_zones.append(z)
             if not content_zones:
+                # Check if skip is because no zones had human review
+                has_any_human = any(z.get('operatorLabel') for z in page_zones)
+                if not has_any_human:
+                    skipped_no_human_review += 1
                 skipped_pages += 1
                 continue
 
@@ -252,6 +257,7 @@ def export_corpus(
         'totalImages':  total_images,
         'totalLabels':  total_labels,
         'skippedPages': skipped_pages,
+        'skippedNoHumanReview': skipped_no_human_review,
         'splitSizes':   split_sizes,
         'datasetYaml':  str(out / 'dataset.yaml'),
     }


### PR DESCRIPTION
## Summary
- Added `skipped_no_human_review` counter to `export_corpus` that tracks pages skipped specifically because no zones had human review
- Distinguishes "no human review" skips from other skip reasons (artifact-only pages, render errors)
- New `skippedNoHumanReview` field in the return stats dict

**Why:** On partially annotated titles, knowing how many pages were skipped due to missing human review vs. other reasons helps diagnose export coverage gaps.

## Test plan
- [x] 17 Python unit tests pass (`python -m unittest test_export -v`)
- [ ] CI Lint, Test & Build passes
- [ ] After all 4 fixes deployed, run test export and verify `skippedNoHumanReview` matches pages the annotator never opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for pages skipped due to the absence of human-reviewed zones. Export statistics now include a new metric detailing these skipped pages, providing clearer insight into data processing and handling of unreviewed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->