### PR TITLE
fix: add empty page stats to calibration run summary

### DIFF
--- a/scripts/spot-check-ecs.js
+++ b/scripts/spot-check-ecs.js
@@ -7,7 +7,7 @@
  *
  * Usage (via ECS run-task command override):
  *   node scripts/spot-check-ecs.js list
- *   node scripts/spot-check-ecs.js pick  <runId> [pages=30] [seed=42]
+ *   node scripts/spot-check-ecs.js pick  <runId> [pages=30] [seed=42] [maxPage]
  *   node scripts/spot-check-ecs.js reset <runId>
  *   node scripts/spot-check-ecs.js compare <runId>
  *   node scripts/spot-check-ecs.js restore <runId>
@@ -152,7 +152,7 @@ async function cmdList() {
 // ---------------------------------------------------------------------------
 // pick — select random pages and snapshot baseline
 // ---------------------------------------------------------------------------
-async function cmdPick(runId, numPages, seed) {
+async function cmdPick(runId, numPages, seed, maxPage) {
   // Verify run exists
   const run = await prisma.calibrationRun.findUnique({
     where: { id: runId },
@@ -173,7 +173,14 @@ async function cmdPick(runId, numPages, seed) {
     distinct: ['pageNumber'],
     orderBy: { pageNumber: 'asc' },
   });
-  const annotatedPages = pages.map(p => p.pageNumber);
+  let annotatedPages = pages.map(p => p.pageNumber);
+
+  // Filter by maxPage if specified (exclude pages beyond the annotated range)
+  if (maxPage != null) {
+    const beforeFilter = annotatedPages.length;
+    annotatedPages = annotatedPages.filter(p => p <= maxPage);
+    console.log(`maxPage filter: ${maxPage} (kept ${annotatedPages.length} of ${beforeFilter} pages)`);
+  }
 
   if (annotatedPages.length === 0) {
     console.error('ERROR: No annotated pages found for this run.');
@@ -233,6 +240,7 @@ async function cmdPick(runId, numPages, seed) {
     title: run.corpusDocument?.filename || null,
     createdAt: new Date().toISOString(),
     seed,
+    maxPage: maxPage || null,
     selectedPages,
     totalAnnotatedPages: annotatedPages.length,
     totalZonesOnPages: baseline.length,
@@ -574,10 +582,15 @@ Spot-check annotation quality for YOLO training data.
 
 Usage:
   node scripts/spot-check-ecs.js list
-  node scripts/spot-check-ecs.js pick  <runId> [pages] [seed]
+  node scripts/spot-check-ecs.js pick  <runId> [pages] [seed] [maxPage]
   node scripts/spot-check-ecs.js reset <runId>
   node scripts/spot-check-ecs.js compare <runId>
   node scripts/spot-check-ecs.js restore <runId>
+
+Arguments for pick:
+  pages   - Number of pages to sample (default: 30)
+  seed    - Random seed for reproducibility (default: random)
+  maxPage - Only sample from pages <= this number (default: no limit)
 
 Plan files stored at: s3://${S3_BUCKET}/${S3_PREFIX}/spot-check-<runId>.json
     `);
@@ -593,8 +606,9 @@ Plan files stored at: s3://${S3_BUCKET}/${S3_PREFIX}/spot-check-<runId>.json
         const runId = args[0];
         const numPages = parseInt(args[1]) || 30;
         const seed = args[2] != null ? parseInt(args[2]) : null;
-        if (!runId) { console.error('Usage: pick <runId> [pages] [seed]'); process.exit(1); }
-        await cmdPick(runId, numPages, seed);
+        const maxPage = args[3] != null ? parseInt(args[3]) : null;
+        if (!runId) { console.error('Usage: pick <runId> [pages] [seed] [maxPage]'); process.exit(1); }
+        await cmdPick(runId, numPages, seed, maxPage);
         break;
       }
       case 'reset': {

--- a/src/services/calibration/calibration.service.ts
+++ b/src/services/calibration/calibration.service.ts
@@ -142,11 +142,18 @@ export async function runCalibration(
   const matches = matchZones(doclingZones, pdfxtZones);
   const summary = summariseCalibrationRun(matches);
 
-  const zonePages = new Set<number>([
+  const totalPages = doc.pageCount ?? 0;
+  const extractedZonePages = [
     ...matches.map((m) => (m.doclingZone ?? m.pdfxtZone!).pageNumber),
     ...pdfxtGhostZones.map((gz) => gz.pageNumber),
-  ]);
-  const totalPages = doc.pageCount ?? 0;
+  ];
+  // Clamp to [1, totalPages] so pagesWithZonesCount stays consistent with
+  // emptyPageCount/emptyPages when an extractor emits an out-of-range page.
+  const zonePages = new Set<number>(
+    totalPages > 0
+      ? extractedZonePages.filter((p) => Number.isInteger(p) && p >= 1 && p <= totalPages)
+      : extractedZonePages,
+  );
   const emptyPages: number[] = [];
   for (let p = 1; p <= totalPages; p++) {
     if (!zonePages.has(p)) emptyPages.push(p);

--- a/src/services/calibration/calibration.service.ts
+++ b/src/services/calibration/calibration.service.ts
@@ -142,6 +142,16 @@ export async function runCalibration(
   const matches = matchZones(doclingZones, pdfxtZones);
   const summary = summariseCalibrationRun(matches);
 
+  const zonePages = new Set<number>([
+    ...matches.map((m) => (m.doclingZone ?? m.pdfxtZone!).pageNumber),
+    ...pdfxtGhostZones.map((gz) => gz.pageNumber),
+  ]);
+  const totalPages = doc.pageCount ?? 0;
+  const emptyPages: number[] = [];
+  for (let p = 1; p <= totalPages; p++) {
+    if (!zonePages.has(p)) emptyPages.push(p);
+  }
+
   // 5. Persist in transaction
   await prisma.$transaction([
     prisma.calibrationRun.update({
@@ -156,6 +166,9 @@ export async function runCalibration(
         durationMs: Date.now() - startTime,
         summary: {
           ...summary,
+          pagesWithZonesCount: zonePages.size,
+          emptyPageCount: emptyPages.length,
+          emptyPages,
           ...(pdfxtExtractionStats ? { pdfxtExtractionStats } : {}),
           ...(doclingFailed ? { doclingFailed: true } : {}),
         } as unknown as Prisma.InputJsonValue,


### PR DESCRIPTION
## Summary

Adds `pagesWithZonesCount`, `emptyPageCount`, and `emptyPages` to the `CalibrationRun.summary` JSON persisted at the end of `runCalibration()`. Powers the new "Empty Pages" column + drill-down modal on `/admin/corpus` (frontend consumes `calibrationRuns[0].summary` via the existing `GET /admin/corpus/documents` endpoint — no new endpoint).

### Fields
- `pagesWithZonesCount: number` — distinct pages with at least one zone (matched or ghost)
- `emptyPageCount: number` — `document.pageCount - pagesWithZonesCount`
- `emptyPages: number[]` — sorted ascending, 1-indexed page numbers in `[1, pageCount]` that have zero zones. Invariant: `emptyPages.length === emptyPageCount`

### Why
Triage tooling for the annotation team. When a reviewer flags "N pages missing zones in Title X," the drill-down shows *which* pages (front matter? one bad range? scattered?) so we can decide legitimate (blanks, image plates) vs. detection failure needing re-run.

### Behavior on failed runs
When both sources return zero zones the run writes `{ error, status: 'FAILED' }` and throws before the new block — consistent with "omit when not COMPLETED."

## Test plan
- [ ] Unit/type: `npm run typecheck` passes (verified locally)
- [ ] Manual: run calibration against a known corpus doc; verify `summary.emptyPages`, `summary.emptyPageCount`, `summary.pagesWithZonesCount` are populated and `emptyPages.length === emptyPageCount`
- [ ] Manual: verify `/admin/corpus` frontend drill-down renders the list
- [ ] Edge: `doc.pageCount === null` → `emptyPages = []`, `emptyPageCount = 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calibration runs now include page-level metrics: count of pages containing detected zones, total number of empty pages, and an explicit list of empty page numbers.
  * These metrics are stored in the run summary so users can quickly see which pages had no detected zones and review processing completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->