### PR TITLE
chore: add ECS-runnable backfill script for empty page stats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,9 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/package*.json ./
 
-# Copy operational scripts (spot-check, etc.)
+# Copy operational scripts (spot-check, backfills, etc.)
 COPY scripts/spot-check-ecs.js ./scripts/
+COPY scripts/backfill-empty-pages.js ./scripts/
 
 # Rebuild native modules for Debian (sharp, prisma) and set permissions
 RUN npm rebuild sharp --platform=linux --arch=x64 \

--- a/scripts/backfill-empty-pages.js
+++ b/scripts/backfill-empty-pages.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Backfill script — populate CalibrationRun.summary.{emptyPages, emptyPageCount,
  * pagesWithZonesCount} for runs that completed before the fields were introduced.
@@ -63,7 +62,9 @@ async function main() {
           }
         : {}),
     },
-    include: {
+    select: {
+      id: true,
+      summary: true,
       corpusDocument: { select: { id: true, filename: true, pageCount: true } },
     },
     orderBy: { runDate: 'asc' },
@@ -102,7 +103,13 @@ async function main() {
         select: { pageNumber: true },
         distinct: ['pageNumber'],
       });
-      const zonePages = new Set(zoneRows.map((r) => r.pageNumber));
+      // Clamp to [1, pageCount] so pagesWithZonesCount stays consistent with
+      // emptyPages/emptyPageCount — matches calibration.service.ts.
+      const zonePages = new Set(
+        zoneRows
+          .map((r) => r.pageNumber)
+          .filter((p) => Number.isInteger(p) && p >= 1 && p <= pageCount),
+      );
 
       const patch = computeEmptyPages(pageCount, zonePages);
       const nextSummary = { ...existingSummary, ...patch };

--- a/scripts/backfill-empty-pages.js
+++ b/scripts/backfill-empty-pages.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Backfill script — populate CalibrationRun.summary.{emptyPages, emptyPageCount,
+ * pagesWithZonesCount} for runs that completed before the fields were introduced.
+ *
+ * Idempotent: running twice produces the same result.
+ * Safe: processes one run at a time; failure on one run does not affect others.
+ *
+ * Designed to run as an ECS task inside the VPC where staging RDS is accessible.
+ *
+ * Usage (via ECS run-task command override):
+ *   node scripts/backfill-empty-pages.js --dry-run
+ *   node scripts/backfill-empty-pages.js
+ *   node scripts/backfill-empty-pages.js --filter=Aulakh,Govoni_Lovell
+ *   node scripts/backfill-empty-pages.js --force
+ *
+ * Environment (injected by ECS task definition):
+ *   DATABASE_URL — PostgreSQL connection string (from Secrets Manager)
+ */
+
+'use strict';
+
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+const argv = process.argv.slice(2);
+const DRY_RUN = argv.includes('--dry-run');
+const FORCE = argv.includes('--force');
+const filterArg = argv.find((a) => a.startsWith('--filter='));
+const filenameFilter = filterArg
+  ? filterArg
+      .replace('--filter=', '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  : null;
+
+function computeEmptyPages(pageCount, zonePages) {
+  const empty = [];
+  for (let p = 1; p <= pageCount; p++) {
+    if (!zonePages.has(p)) empty.push(p);
+  }
+  return {
+    emptyPages: empty,
+    emptyPageCount: empty.length,
+    pagesWithZonesCount: zonePages.size,
+  };
+}
+
+async function main() {
+  const runs = await prisma.calibrationRun.findMany({
+    where: {
+      completedAt: { not: null },
+      ...(filenameFilter
+        ? {
+            corpusDocument: {
+              filename: {
+                in: filenameFilter,
+                mode: 'insensitive',
+              },
+            },
+          }
+        : {}),
+    },
+    include: {
+      corpusDocument: { select: { id: true, filename: true, pageCount: true } },
+    },
+    orderBy: { runDate: 'asc' },
+  });
+
+  console.log(
+    `Found ${runs.length} completed run(s)` +
+      (filenameFilter ? ` matching filter [${filenameFilter.join(', ')}]` : '') +
+      '.',
+  );
+  if (DRY_RUN) console.log('DRY RUN — no writes will be performed.\n');
+
+  let updated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const run of runs) {
+    const docName = run.corpusDocument?.filename ?? '<unknown>';
+    const pageCount = run.corpusDocument?.pageCount ?? 0;
+
+    if (!pageCount) {
+      console.warn(`[skip] ${docName} (run ${run.id}) — document has no pageCount`);
+      skipped++;
+      continue;
+    }
+
+    const existingSummary = run.summary ?? {};
+    if (!FORCE && typeof existingSummary.emptyPageCount === 'number') {
+      skipped++;
+      continue;
+    }
+
+    try {
+      const zoneRows = await prisma.zone.findMany({
+        where: { calibrationRunId: run.id },
+        select: { pageNumber: true },
+        distinct: ['pageNumber'],
+      });
+      const zonePages = new Set(zoneRows.map((r) => r.pageNumber));
+
+      const patch = computeEmptyPages(pageCount, zonePages);
+      const nextSummary = { ...existingSummary, ...patch };
+
+      console.log(
+        `[${DRY_RUN ? 'would update' : 'update'}] ${docName} — pageCount=${pageCount}, ` +
+          `pagesWithZones=${patch.pagesWithZonesCount}, emptyPages=${patch.emptyPageCount}`,
+      );
+
+      if (!DRY_RUN) {
+        await prisma.calibrationRun.update({
+          where: { id: run.id },
+          data: { summary: nextSummary },
+        });
+      }
+      updated++;
+    } catch (err) {
+      failed++;
+      console.error(`[fail] ${docName} (run ${run.id}):`, err);
+    }
+  }
+
+  console.log(
+    `\nDone. updated=${updated} skipped=${skipped} failed=${failed}` +
+      (DRY_RUN ? ' (dry run)' : ''),
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

Operational script to backfill `CalibrationRun.summary.{emptyPages, emptyPageCount, pagesWithZonesCount}` for runs that completed before #351 added these fields.

Plain CJS `.js` following the `scripts/spot-check-ecs.js` pattern — staging RDS is in a private VPC, so this needs to run via `aws ecs run-task` with `DATABASE_URL` injected from Secrets Manager. Dockerfile updated to COPY the script into the production image alongside `spot-check-ecs.js`.

### Safety
- **Idempotent**: skips runs that already have `emptyPageCount` unless `--force`
- **Per-run**: a failure on one run logs and continues; does not corrupt others
- **Dry-run supported**: `--dry-run` prints what would change without writing

### Usage

```
# dry run
aws ecs run-task --cluster ninja-cluster --task-definition ninja-backend-task \
  --launch-type FARGATE \
  --network-configuration '{"awsvpcConfiguration":{"subnets":["<...>"],"securityGroups":["<...>"],"assignPublicIp":"ENABLED"}}' \
  --overrides '{"containerOverrides":[{"name":"ninja-backend","command":["node","scripts/backfill-empty-pages.js","--dry-run"]}]}' \
  --region ap-south-1

# real run
... "command":["node","scripts/backfill-empty-pages.js"]

# filtered
... "command":["node","scripts/backfill-empty-pages.js","--filter=Aulakh,Govoni_Lovell"]
```

## Test plan
- [ ] CI green (lint + test + build)
- [ ] After merge + deploy, run dry-run via ECS and inspect logs; confirm `Found N completed run(s)` and expected `[would update]` / `[skip]` mix
- [ ] Then run for real; verify a sample `CalibrationRun.summary` in the DB now has the three fields and `emptyPages.length === emptyPageCount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an operational backfill tool to populate missing empty-page metadata for calibration records; supports dry-run, force updates, and filename filtering.
  * Updated the production image to include the operational scripts so backfills can run in deployed environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->