### PR TITLE
feat: add EmptyPageReview model + endpoints for in-workspace categorization

### DIFF
--- a/prisma/migrations/20260428000000_add_empty_page_review/migration.sql
+++ b/prisma/migrations/20260428000000_add_empty_page_review/migration.sql
@@ -1,0 +1,62 @@
+-- CreateEnum: EmptyPageCategory
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'EmptyPageCategory') THEN
+    CREATE TYPE "EmptyPageCategory" AS ENUM (
+      'LEGIT_EMPTY',
+      'DETECTION_FAILURE',
+      'UNSURE'
+    );
+  END IF;
+END $$;
+
+-- CreateTable: EmptyPageReview
+-- Note: SQL-level DEFAULT gen_random_uuid()::text mirrors the pattern used in
+-- prior migrations (e.g. 20260413000000_add_calibration_run_issues) so that
+-- raw-SQL inserts or Prisma versions that do not auto-fill @default(uuid())
+-- still satisfy the NOT NULL constraint.
+CREATE TABLE IF NOT EXISTS "EmptyPageReview" (
+  "id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  "calibrationRunId" TEXT NOT NULL,
+  "pageNumber" INTEGER NOT NULL,
+  "category" "EmptyPageCategory" NOT NULL,
+  "pageType" TEXT NOT NULL,
+  "expectedContent" TEXT,
+  "notes" TEXT,
+  "annotatorId" TEXT NOT NULL,
+  "reviewedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "EmptyPageReview_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "EmptyPageReview_calibrationRunId_pageNumber_key" ON "EmptyPageReview"("calibrationRunId", "pageNumber");
+CREATE INDEX IF NOT EXISTS "EmptyPageReview_calibrationRunId_idx" ON "EmptyPageReview"("calibrationRunId");
+CREATE INDEX IF NOT EXISTS "EmptyPageReview_annotatorId_idx" ON "EmptyPageReview"("annotatorId");
+
+-- AddForeignKey: EmptyPageReview -> CalibrationRun
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'EmptyPageReview_calibrationRunId_fkey'
+  ) THEN
+    ALTER TABLE "EmptyPageReview"
+      ADD CONSTRAINT "EmptyPageReview_calibrationRunId_fkey"
+      FOREIGN KEY ("calibrationRunId") REFERENCES "CalibrationRun"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey: EmptyPageReview -> User
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'EmptyPageReview_annotatorId_fkey'
+  ) THEN
+    ALTER TABLE "EmptyPageReview"
+      ADD CONSTRAINT "EmptyPageReview_annotatorId_fkey"
+      FOREIGN KEY ("annotatorId") REFERENCES "User"("id")
+      ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,7 @@ model User {
   remediationItemsFixer RemediationItem[] @relation("RemediationFixer")
   editorSessions      EditorSession[]
   notifications       Notification[]
+  emptyPageReviews    EmptyPageReview[]
 
   @@index([tenantId])
   @@index([email])
@@ -2105,6 +2106,7 @@ model CalibrationRun {
   aiAnnotationRuns       AiAnnotationRun[]
   annotationComparisons  AnnotationComparison[]
   issues                 CalibrationRunIssue[]
+  emptyPageReviews       EmptyPageReview[]
   corpusDocument         CorpusDocument @relation(fields: [documentId], references: [id])
 
   @@index([documentId])
@@ -2134,6 +2136,32 @@ enum RunIssueCategory {
   ZONE_CONTENT_DIVERGENCE
   COMPLETED_WITH_REDUCED_SCOPE
   OTHER
+}
+
+enum EmptyPageCategory {
+  LEGIT_EMPTY
+  DETECTION_FAILURE
+  UNSURE
+}
+
+model EmptyPageReview {
+  id               String            @id @default(uuid())
+  calibrationRunId String
+  calibrationRun   CalibrationRun    @relation(fields: [calibrationRunId], references: [id], onDelete: Cascade)
+  pageNumber       Int
+  category         EmptyPageCategory
+  pageType         String
+  expectedContent  String?           @db.Text
+  notes            String?           @db.Text
+  annotatorId      String
+  annotator        User              @relation(fields: [annotatorId], references: [id])
+  reviewedAt       DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+  createdAt        DateTime          @default(now())
+
+  @@unique([calibrationRunId, pageNumber])
+  @@index([calibrationRunId])
+  @@index([annotatorId])
 }
 
 model AnnotationSession {

--- a/src/controllers/empty-page-review.controller.ts
+++ b/src/controllers/empty-page-review.controller.ts
@@ -1,0 +1,156 @@
+import { Request, Response } from 'express';
+import { logger } from '../lib/logger';
+import {
+  pageNumberParamSchema,
+  upsertEmptyPageReviewSchema,
+} from '../schemas/empty-page-review.schema';
+import {
+  calibrationRunExists,
+  deleteReview,
+  getReview,
+  listReviews,
+  upsertReview,
+} from '../services/empty-page-review.service';
+
+const ROLE_VALUES = ['admin', 'ADMIN', 'OPERATOR'];
+
+function isAdminOrOperator(req: Request): boolean {
+  const role = req.user?.role;
+  return role !== undefined && ROLE_VALUES.includes(role);
+}
+
+function forbidden(res: Response) {
+  return res.status(403).json({
+    success: false,
+    error: { code: 'FORBIDDEN', message: 'Admin or Operator role required' },
+  });
+}
+
+function notFound(res: Response, message: string, code = 'NOT_FOUND') {
+  return res.status(404).json({
+    success: false,
+    error: { code, message },
+  });
+}
+
+function validationError(res: Response, message: string, details: unknown) {
+  return res.status(422).json({
+    success: false,
+    error: { code: 'VALIDATION_ERROR', message, details },
+  });
+}
+
+function internalError(res: Response, err: unknown) {
+  return res.status(500).json({
+    success: false,
+    error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+  });
+}
+
+function parsePageNumber(raw: string) {
+  return pageNumberParamSchema.safeParse(raw);
+}
+
+export async function listEmptyPageReviews(req: Request, res: Response) {
+  try {
+    if (!isAdminOrOperator(req)) return forbidden(res);
+
+    const { runId } = req.params;
+    if (!(await calibrationRunExists(runId))) {
+      return notFound(res, 'Calibration run not found', 'RUN_NOT_FOUND');
+    }
+
+    const reviews = await listReviews(runId);
+    return res.json({ success: true, data: { reviews } });
+  } catch (err) {
+    logger.error(`[empty-page-review] list failed: ${(err as Error).message}`);
+    return internalError(res, err);
+  }
+}
+
+export async function getEmptyPageReview(req: Request, res: Response) {
+  try {
+    if (!isAdminOrOperator(req)) return forbidden(res);
+
+    const { runId } = req.params;
+    const pageParse = parsePageNumber(req.params.pageNumber);
+    if (!pageParse.success) {
+      return validationError(res, 'pageNumber must be a positive integer', pageParse.error.issues);
+    }
+
+    if (!(await calibrationRunExists(runId))) {
+      return notFound(res, 'Calibration run not found', 'RUN_NOT_FOUND');
+    }
+
+    const review = await getReview(runId, pageParse.data);
+    if (!review) {
+      return notFound(res, 'No review exists for this page', 'REVIEW_NOT_FOUND');
+    }
+
+    return res.json({ success: true, data: review });
+  } catch (err) {
+    logger.error(`[empty-page-review] get failed: ${(err as Error).message}`);
+    return internalError(res, err);
+  }
+}
+
+export async function upsertEmptyPageReview(req: Request, res: Response) {
+  try {
+    if (!isAdminOrOperator(req)) return forbidden(res);
+
+    const { runId } = req.params;
+    const pageParse = parsePageNumber(req.params.pageNumber);
+    if (!pageParse.success) {
+      return validationError(res, 'pageNumber must be a positive integer', pageParse.error.issues);
+    }
+
+    const bodyParse = upsertEmptyPageReviewSchema.safeParse(req.body);
+    if (!bodyParse.success) {
+      return validationError(res, 'Request validation failed', bodyParse.error.issues);
+    }
+
+    if (!(await calibrationRunExists(runId))) {
+      return notFound(res, 'Calibration run not found', 'RUN_NOT_FOUND');
+    }
+
+    const annotatorId = req.user?.id;
+    if (!annotatorId) {
+      return res.status(401).json({
+        success: false,
+        error: { code: 'UNAUTHENTICATED', message: 'No authenticated user on request' },
+      });
+    }
+
+    const review = await upsertReview(runId, pageParse.data, annotatorId, bodyParse.data);
+    return res.json({ success: true, data: review });
+  } catch (err) {
+    logger.error(`[empty-page-review] upsert failed: ${(err as Error).message}`);
+    return internalError(res, err);
+  }
+}
+
+export async function deleteEmptyPageReview(req: Request, res: Response) {
+  try {
+    if (!isAdminOrOperator(req)) return forbidden(res);
+
+    const { runId } = req.params;
+    const pageParse = parsePageNumber(req.params.pageNumber);
+    if (!pageParse.success) {
+      return validationError(res, 'pageNumber must be a positive integer', pageParse.error.issues);
+    }
+
+    if (!(await calibrationRunExists(runId))) {
+      return notFound(res, 'Calibration run not found', 'RUN_NOT_FOUND');
+    }
+
+    const deleted = await deleteReview(runId, pageParse.data);
+    if (!deleted) {
+      return notFound(res, 'No review exists for this page', 'REVIEW_NOT_FOUND');
+    }
+
+    return res.json({ success: true, data: { deleted: true } });
+  } catch (err) {
+    logger.error(`[empty-page-review] delete failed: ${(err as Error).message}`);
+    return internalError(res, err);
+  }
+}

--- a/src/routes/calibration.routes.ts
+++ b/src/routes/calibration.routes.ts
@@ -13,9 +13,24 @@ import { getAnnotationFeedback, getAggregateFeedback } from '../services/calibra
 import { getTrainingExportData } from '../services/calibration/training-export.service';
 import { runBulkAiAnnotation } from '../services/calibration/bulk-ai-annotation.service';
 import { getAggregateComparison } from '../services/calibration/aggregate-comparison.service';
+import {
+  deleteEmptyPageReview,
+  getEmptyPageReview,
+  listEmptyPageReviews,
+  upsertEmptyPageReview,
+} from '../controllers/empty-page-review.controller';
 import { logger } from '../lib/logger';
 
 const router = Router();
+
+// --- Empty page review sub-router ---
+// Mounted at /api/v1/calibration/runs/:runId/empty-page-reviews
+const emptyPageReviewRouter = Router({ mergeParams: true });
+emptyPageReviewRouter.get('/', authenticate, listEmptyPageReviews);
+emptyPageReviewRouter.get('/:pageNumber', authenticate, getEmptyPageReview);
+emptyPageReviewRouter.put('/:pageNumber', authenticate, upsertEmptyPageReview);
+emptyPageReviewRouter.delete('/:pageNumber', authenticate, deleteEmptyPageReview);
+router.use('/runs/:runId/empty-page-reviews', emptyPageReviewRouter);
 
 const runBodySchema = z.object({
   documentId: z.string().min(1),

--- a/src/schemas/empty-page-review.schema.ts
+++ b/src/schemas/empty-page-review.schema.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+// Mirrors the PAGE_TYPES constant in
+// ninja-frontend/docs/empty-pages-review/sheet-setup.gs.
+// Keep verbatim — the frontend dropdown enforces the same list.
+export const EMPTY_PAGE_TYPES = [
+  'blank',
+  'cover',
+  'copyright',
+  'dedication',
+  'colophon',
+  'chapter_divider',
+  'toc_divider',
+  'image_plate',
+  'ornament',
+  'text_normal',
+  'text_complex',
+  'table',
+  'figure',
+  'mixed',
+  'other',
+] as const;
+
+export const EMPTY_PAGE_CATEGORIES = ['LEGIT_EMPTY', 'DETECTION_FAILURE', 'UNSURE'] as const;
+
+export const emptyPageCategorySchema = z.enum(EMPTY_PAGE_CATEGORIES);
+export const emptyPageTypeSchema = z.enum(EMPTY_PAGE_TYPES);
+
+export type EmptyPageCategoryInput = z.infer<typeof emptyPageCategorySchema>;
+export type EmptyPageTypeInput = z.infer<typeof emptyPageTypeSchema>;
+
+const baseUpsertShape = {
+  category: emptyPageCategorySchema,
+  pageType: emptyPageTypeSchema,
+  expectedContent: z.string().trim().max(5000).optional(),
+  notes: z.string().trim().max(2000).optional(),
+};
+
+// expectedContent is required when category === 'DETECTION_FAILURE' (annotator
+// must explain what they expected the page to contain). Optional otherwise.
+export const upsertEmptyPageReviewSchema = z
+  .object(baseUpsertShape)
+  .superRefine((data, ctx) => {
+    if (data.category === 'DETECTION_FAILURE') {
+      const v = data.expectedContent;
+      if (v === undefined || v.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['expectedContent'],
+          message: 'expectedContent is required when category is DETECTION_FAILURE',
+        });
+      }
+    }
+  });
+
+export type UpsertEmptyPageReviewInput = z.infer<typeof upsertEmptyPageReviewSchema>;
+
+export const pageNumberParamSchema = z.coerce.number().int().positive();

--- a/src/services/empty-page-review.service.ts
+++ b/src/services/empty-page-review.service.ts
@@ -1,0 +1,140 @@
+import { Prisma } from '@prisma/client';
+import prisma from '../lib/prisma';
+import { logger } from '../lib/logger';
+import type { UpsertEmptyPageReviewInput } from '../schemas/empty-page-review.schema';
+
+const annotatorSelect = {
+  id: true,
+  firstName: true,
+  lastName: true,
+  email: true,
+} as const;
+
+const reviewInclude = {
+  annotator: { select: annotatorSelect },
+} as const;
+
+export type EmptyPageReviewWithAnnotator = Prisma.EmptyPageReviewGetPayload<{
+  include: typeof reviewInclude;
+}>;
+
+export interface EmptyPageReviewDTO {
+  pageNumber: number;
+  category: 'LEGIT_EMPTY' | 'DETECTION_FAILURE' | 'UNSURE';
+  pageType: string;
+  expectedContent: string | null;
+  notes: string | null;
+  annotator: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
+  reviewedAt: string;
+  updatedAt: string;
+}
+
+function toDTO(review: EmptyPageReviewWithAnnotator): EmptyPageReviewDTO {
+  return {
+    pageNumber: review.pageNumber,
+    category: review.category,
+    pageType: review.pageType,
+    expectedContent: review.expectedContent ?? null,
+    notes: review.notes ?? null,
+    annotator: {
+      id: review.annotator.id,
+      firstName: review.annotator.firstName,
+      lastName: review.annotator.lastName,
+      email: review.annotator.email,
+    },
+    reviewedAt: review.reviewedAt.toISOString(),
+    updatedAt: review.updatedAt.toISOString(),
+  };
+}
+
+export async function calibrationRunExists(runId: string): Promise<boolean> {
+  const run = await prisma.calibrationRun.findUnique({
+    where: { id: runId },
+    select: { id: true },
+  });
+  return run !== null;
+}
+
+export async function listReviews(runId: string): Promise<EmptyPageReviewDTO[]> {
+  const reviews = await prisma.emptyPageReview.findMany({
+    where: { calibrationRunId: runId },
+    include: reviewInclude,
+    orderBy: { pageNumber: 'asc' },
+  });
+  return reviews.map(toDTO);
+}
+
+export async function getReview(
+  runId: string,
+  pageNumber: number,
+): Promise<EmptyPageReviewDTO | null> {
+  const review = await prisma.emptyPageReview.findUnique({
+    where: { calibrationRunId_pageNumber: { calibrationRunId: runId, pageNumber } },
+    include: reviewInclude,
+  });
+  return review ? toDTO(review) : null;
+}
+
+export async function upsertReview(
+  runId: string,
+  pageNumber: number,
+  annotatorId: string,
+  input: UpsertEmptyPageReviewInput,
+): Promise<EmptyPageReviewDTO> {
+  const expectedContent = input.expectedContent ?? null;
+  const notes = input.notes ?? null;
+
+  const review = await prisma.emptyPageReview.upsert({
+    where: { calibrationRunId_pageNumber: { calibrationRunId: runId, pageNumber } },
+    create: {
+      calibrationRunId: runId,
+      pageNumber,
+      category: input.category,
+      pageType: input.pageType,
+      expectedContent,
+      notes,
+      annotatorId,
+    },
+    update: {
+      category: input.category,
+      pageType: input.pageType,
+      expectedContent,
+      notes,
+      annotatorId,
+      reviewedAt: new Date(),
+    },
+    include: reviewInclude,
+  });
+
+  logger.info(
+    `[empty-page-review] upsert run=${runId} page=${pageNumber} category=${input.category} by=${annotatorId}`,
+  );
+
+  return toDTO(review);
+}
+
+export async function deleteReview(
+  runId: string,
+  pageNumber: number,
+): Promise<boolean> {
+  try {
+    await prisma.emptyPageReview.delete({
+      where: { calibrationRunId_pageNumber: { calibrationRunId: runId, pageNumber } },
+    });
+    logger.info(`[empty-page-review] delete run=${runId} page=${pageNumber}`);
+    return true;
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2025'
+    ) {
+      return false;
+    }
+    throw err;
+  }
+}

--- a/tests/unit/controllers/empty-page-review.controller.test.ts
+++ b/tests/unit/controllers/empty-page-review.controller.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mockListReviews = vi.fn();
+const mockGetReview = vi.fn();
+const mockUpsertReview = vi.fn();
+const mockDeleteReview = vi.fn();
+const mockCalibrationRunExists = vi.fn();
+
+vi.mock('../../../src/services/empty-page-review.service', () => ({
+  listReviews: (...args: unknown[]) => mockListReviews(...args),
+  getReview: (...args: unknown[]) => mockGetReview(...args),
+  upsertReview: (...args: unknown[]) => mockUpsertReview(...args),
+  deleteReview: (...args: unknown[]) => mockDeleteReview(...args),
+  calibrationRunExists: (...args: unknown[]) => mockCalibrationRunExists(...args),
+}));
+
+vi.mock('../../../src/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  deleteEmptyPageReview,
+  getEmptyPageReview,
+  listEmptyPageReviews,
+  upsertEmptyPageReview,
+} from '../../../src/controllers/empty-page-review.controller';
+
+const RUN_ID = 'run-abc';
+
+function buildApp(role: string | undefined, userId = 'user-1') {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (role !== undefined) {
+      req.user = {
+        id: userId,
+        email: 'u@example.com',
+        tenantId: 'tenant-1',
+        role,
+      } as never;
+    }
+    next();
+  });
+
+  const sub = express.Router({ mergeParams: true });
+  sub.get('/', listEmptyPageReviews);
+  sub.get('/:pageNumber', getEmptyPageReview);
+  sub.put('/:pageNumber', upsertEmptyPageReview);
+  sub.delete('/:pageNumber', deleteEmptyPageReview);
+  app.use('/runs/:runId/empty-page-reviews', sub);
+
+  return app;
+}
+
+const sampleDTO = {
+  pageNumber: 5,
+  category: 'LEGIT_EMPTY' as const,
+  pageType: 'blank',
+  expectedContent: null,
+  notes: null,
+  annotator: { id: 'user-1', firstName: 'Ada', lastName: 'L', email: 'a@x.com' },
+  reviewedAt: '2026-04-28T10:00:00.000Z',
+  updatedAt: '2026-04-28T10:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCalibrationRunExists.mockResolvedValue(true);
+});
+
+describe('empty-page-review controller — authorization', () => {
+  it('returns 403 for users without ADMIN or OPERATOR role', async () => {
+    const app = buildApp('USER');
+
+    const list = await request(app).get(`/runs/${RUN_ID}/empty-page-reviews`);
+    expect(list.status).toBe(403);
+
+    const upsert = await request(app)
+      .put(`/runs/${RUN_ID}/empty-page-reviews/5`)
+      .send({ category: 'LEGIT_EMPTY', pageType: 'blank' });
+    expect(upsert.status).toBe(403);
+
+    const del = await request(app).delete(`/runs/${RUN_ID}/empty-page-reviews/5`);
+    expect(del.status).toBe(403);
+  });
+
+  it('allows OPERATOR role to read and write', async () => {
+    const app = buildApp('OPERATOR');
+    mockListReviews.mockResolvedValueOnce([sampleDTO]);
+    mockUpsertReview.mockResolvedValueOnce(sampleDTO);
+
+    const list = await request(app).get(`/runs/${RUN_ID}/empty-page-reviews`);
+    expect(list.status).toBe(200);
+    expect(list.body.success).toBe(true);
+    expect(list.body.data.reviews).toHaveLength(1);
+
+    const upsert = await request(app)
+      .put(`/runs/${RUN_ID}/empty-page-reviews/5`)
+      .send({ category: 'LEGIT_EMPTY', pageType: 'blank' });
+    expect(upsert.status).toBe(200);
+    expect(mockUpsertReview).toHaveBeenCalledWith(
+      RUN_ID,
+      5,
+      'user-1',
+      expect.objectContaining({ category: 'LEGIT_EMPTY', pageType: 'blank' }),
+    );
+  });
+
+  it('allows ADMIN role to read and write', async () => {
+    const app = buildApp('ADMIN');
+    mockListReviews.mockResolvedValueOnce([]);
+    const list = await request(app).get(`/runs/${RUN_ID}/empty-page-reviews`);
+    expect(list.status).toBe(200);
+  });
+});
+
+describe('empty-page-review controller — endpoints', () => {
+  it('GET /:pageNumber returns 404 when no review exists', async () => {
+    const app = buildApp('OPERATOR');
+    mockGetReview.mockResolvedValueOnce(null);
+
+    const res = await request(app).get(`/runs/${RUN_ID}/empty-page-reviews/5`);
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('REVIEW_NOT_FOUND');
+  });
+
+  it('GET /:pageNumber returns the review when present', async () => {
+    const app = buildApp('OPERATOR');
+    mockGetReview.mockResolvedValueOnce(sampleDTO);
+
+    const res = await request(app).get(`/runs/${RUN_ID}/empty-page-reviews/5`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.pageNumber).toBe(5);
+  });
+
+  it('GET / returns 404 when the run does not exist', async () => {
+    const app = buildApp('OPERATOR');
+    mockCalibrationRunExists.mockResolvedValueOnce(false);
+
+    const res = await request(app).get(`/runs/${RUN_ID}/empty-page-reviews`);
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('RUN_NOT_FOUND');
+  });
+
+  it('PUT /:pageNumber rejects bad category values with 422', async () => {
+    const app = buildApp('OPERATOR');
+    const res = await request(app)
+      .put(`/runs/${RUN_ID}/empty-page-reviews/5`)
+      .send({ category: 'BOGUS', pageType: 'blank' });
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(mockUpsertReview).not.toHaveBeenCalled();
+  });
+
+  it('PUT /:pageNumber rejects pageType outside the vocabulary', async () => {
+    const app = buildApp('OPERATOR');
+    const res = await request(app)
+      .put(`/runs/${RUN_ID}/empty-page-reviews/5`)
+      .send({ category: 'LEGIT_EMPTY', pageType: 'half_title' });
+    expect(res.status).toBe(422);
+  });
+
+  it('PUT /:pageNumber rejects DETECTION_FAILURE without expectedContent', async () => {
+    const app = buildApp('OPERATOR');
+    const res = await request(app)
+      .put(`/runs/${RUN_ID}/empty-page-reviews/5`)
+      .send({ category: 'DETECTION_FAILURE', pageType: 'text_normal' });
+    expect(res.status).toBe(422);
+    const issue = res.body.error.details.find(
+      (d: { path: (string | number)[] }) => d.path?.[0] === 'expectedContent',
+    );
+    expect(issue).toBeDefined();
+  });
+
+  it('PUT /:pageNumber rejects non-positive pageNumber', async () => {
+    const app = buildApp('OPERATOR');
+    const res = await request(app)
+      .put(`/runs/${RUN_ID}/empty-page-reviews/0`)
+      .send({ category: 'LEGIT_EMPTY', pageType: 'blank' });
+    expect(res.status).toBe(422);
+  });
+
+  it('DELETE /:pageNumber returns 200 with deleted=true on success', async () => {
+    const app = buildApp('OPERATOR');
+    mockDeleteReview.mockResolvedValueOnce(true);
+
+    const res = await request(app).delete(`/runs/${RUN_ID}/empty-page-reviews/5`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ deleted: true });
+  });
+
+  it('DELETE /:pageNumber returns 404 when no review existed', async () => {
+    const app = buildApp('OPERATOR');
+    mockDeleteReview.mockResolvedValueOnce(false);
+
+    const res = await request(app).delete(`/runs/${RUN_ID}/empty-page-reviews/5`);
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('REVIEW_NOT_FOUND');
+  });
+});

--- a/tests/unit/schemas/empty-page-review.schema.test.ts
+++ b/tests/unit/schemas/empty-page-review.schema.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EMPTY_PAGE_TYPES,
+  pageNumberParamSchema,
+  upsertEmptyPageReviewSchema,
+} from '../../../src/schemas/empty-page-review.schema';
+
+describe('upsertEmptyPageReviewSchema', () => {
+  it('rejects category values not in the enum', () => {
+    const result = upsertEmptyPageReviewSchema.safeParse({
+      category: 'BOGUS',
+      pageType: 'blank',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const onCategory = result.error.issues.some(i => i.path.join('.') === 'category');
+      expect(onCategory).toBe(true);
+    }
+  });
+
+  it('rejects pageType values not in the controlled vocabulary', () => {
+    const result = upsertEmptyPageReviewSchema.safeParse({
+      category: 'LEGIT_EMPTY',
+      pageType: 'half_title',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const onPageType = result.error.issues.some(i => i.path.join('.') === 'pageType');
+      expect(onPageType).toBe(true);
+    }
+  });
+
+  it('rejects DETECTION_FAILURE without expectedContent', () => {
+    const result = upsertEmptyPageReviewSchema.safeParse({
+      category: 'DETECTION_FAILURE',
+      pageType: 'text_normal',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const onExpected = result.error.issues.some(
+        i => i.path.join('.') === 'expectedContent',
+      );
+      expect(onExpected).toBe(true);
+    }
+  });
+
+  it('rejects DETECTION_FAILURE with empty expectedContent', () => {
+    const result = upsertEmptyPageReviewSchema.safeParse({
+      category: 'DETECTION_FAILURE',
+      pageType: 'text_normal',
+      expectedContent: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts DETECTION_FAILURE with non-empty expectedContent', () => {
+    const result = upsertEmptyPageReviewSchema.safeParse({
+      category: 'DETECTION_FAILURE',
+      pageType: 'text_normal',
+      expectedContent: 'paragraph of text and a figure',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts LEGIT_EMPTY without expectedContent', () => {
+    const result = upsertEmptyPageReviewSchema.safeParse({
+      category: 'LEGIT_EMPTY',
+      pageType: 'blank',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts UNSURE without expectedContent', () => {
+    const result = upsertEmptyPageReviewSchema.safeParse({
+      category: 'UNSURE',
+      pageType: 'mixed',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('caps notes at 2000 characters', () => {
+    const result = upsertEmptyPageReviewSchema.safeParse({
+      category: 'LEGIT_EMPTY',
+      pageType: 'blank',
+      notes: 'a'.repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts every entry of the controlled vocabulary', () => {
+    for (const pageType of EMPTY_PAGE_TYPES) {
+      const result = upsertEmptyPageReviewSchema.safeParse({
+        category: 'LEGIT_EMPTY',
+        pageType,
+      });
+      expect(result.success, `pageType=${pageType} should validate`).toBe(true);
+    }
+  });
+
+  it('controlled vocabulary matches the frontend PAGE_TYPES list verbatim', () => {
+    expect([...EMPTY_PAGE_TYPES]).toEqual([
+      'blank',
+      'cover',
+      'copyright',
+      'dedication',
+      'colophon',
+      'chapter_divider',
+      'toc_divider',
+      'image_plate',
+      'ornament',
+      'text_normal',
+      'text_complex',
+      'table',
+      'figure',
+      'mixed',
+      'other',
+    ]);
+  });
+});
+
+describe('pageNumberParamSchema', () => {
+  it('accepts a positive integer string', () => {
+    const r = pageNumberParamSchema.safeParse('5');
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toBe(5);
+  });
+
+  it('rejects zero', () => {
+    expect(pageNumberParamSchema.safeParse('0').success).toBe(false);
+  });
+
+  it('rejects negative numbers', () => {
+    expect(pageNumberParamSchema.safeParse('-3').success).toBe(false);
+  });
+
+  it('rejects non-numeric strings', () => {
+    expect(pageNumberParamSchema.safeParse('abc').success).toBe(false);
+  });
+
+  it('rejects floats', () => {
+    expect(pageNumberParamSchema.safeParse('1.5').success).toBe(false);
+  });
+});

--- a/tests/unit/services/empty-page-review.service.test.ts
+++ b/tests/unit/services/empty-page-review.service.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Prisma } from '@prisma/client';
+
+const mockReviewFindUnique = vi.fn();
+const mockReviewFindMany = vi.fn();
+const mockReviewUpsert = vi.fn();
+const mockReviewDelete = vi.fn();
+const mockCalibrationRunFindUnique = vi.fn();
+
+vi.mock('../../../src/lib/prisma', () => ({
+  default: {
+    emptyPageReview: {
+      findUnique: (...args: unknown[]) => mockReviewFindUnique(...args),
+      findMany: (...args: unknown[]) => mockReviewFindMany(...args),
+      upsert: (...args: unknown[]) => mockReviewUpsert(...args),
+      delete: (...args: unknown[]) => mockReviewDelete(...args),
+    },
+    calibrationRun: {
+      findUnique: (...args: unknown[]) => mockCalibrationRunFindUnique(...args),
+    },
+  },
+}));
+
+vi.mock('../../../src/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import {
+  calibrationRunExists,
+  deleteReview,
+  getReview,
+  listReviews,
+  upsertReview,
+} from '../../../src/services/empty-page-review.service';
+
+const RUN_ID = 'run-abc';
+const ANNOTATOR_ID = 'user-123';
+
+const annotator = {
+  id: ANNOTATOR_ID,
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  email: 'ada@example.com',
+};
+
+function makeReview(overrides: Partial<{ pageNumber: number; category: string }> = {}) {
+  return {
+    id: 'review-1',
+    calibrationRunId: RUN_ID,
+    pageNumber: overrides.pageNumber ?? 5,
+    category: (overrides.category ?? 'LEGIT_EMPTY') as 'LEGIT_EMPTY' | 'DETECTION_FAILURE' | 'UNSURE',
+    pageType: 'blank',
+    expectedContent: null,
+    notes: null,
+    annotatorId: ANNOTATOR_ID,
+    annotator,
+    reviewedAt: new Date('2026-04-28T10:00:00.000Z'),
+    updatedAt: new Date('2026-04-28T10:00:00.000Z'),
+    createdAt: new Date('2026-04-28T10:00:00.000Z'),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('empty-page-review.service', () => {
+  describe('calibrationRunExists', () => {
+    it('returns true when the run exists', async () => {
+      mockCalibrationRunFindUnique.mockResolvedValueOnce({ id: RUN_ID });
+      await expect(calibrationRunExists(RUN_ID)).resolves.toBe(true);
+      expect(mockCalibrationRunFindUnique).toHaveBeenCalledWith({
+        where: { id: RUN_ID },
+        select: { id: true },
+      });
+    });
+
+    it('returns false when the run does not exist', async () => {
+      mockCalibrationRunFindUnique.mockResolvedValueOnce(null);
+      await expect(calibrationRunExists(RUN_ID)).resolves.toBe(false);
+    });
+  });
+
+  describe('listReviews', () => {
+    it('returns reviews sorted by pageNumber ascending', async () => {
+      mockReviewFindMany.mockResolvedValueOnce([
+        makeReview({ pageNumber: 3 }),
+        makeReview({ pageNumber: 7 }),
+        makeReview({ pageNumber: 12 }),
+      ]);
+
+      const result = await listReviews(RUN_ID);
+
+      expect(mockReviewFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { calibrationRunId: RUN_ID },
+          orderBy: { pageNumber: 'asc' },
+        }),
+      );
+      expect(result.map(r => r.pageNumber)).toEqual([3, 7, 12]);
+      expect(result[0].annotator).toEqual(annotator);
+      expect(typeof result[0].reviewedAt).toBe('string');
+    });
+
+    it('returns an empty array when no reviews exist', async () => {
+      mockReviewFindMany.mockResolvedValueOnce([]);
+      await expect(listReviews(RUN_ID)).resolves.toEqual([]);
+    });
+  });
+
+  describe('getReview', () => {
+    it('returns a single review when it exists', async () => {
+      mockReviewFindUnique.mockResolvedValueOnce(makeReview({ pageNumber: 9 }));
+      const result = await getReview(RUN_ID, 9);
+      expect(result).not.toBeNull();
+      expect(result?.pageNumber).toBe(9);
+      expect(mockReviewFindUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { calibrationRunId_pageNumber: { calibrationRunId: RUN_ID, pageNumber: 9 } },
+        }),
+      );
+    });
+
+    it('returns null when no review exists for that page', async () => {
+      mockReviewFindUnique.mockResolvedValueOnce(null);
+      await expect(getReview(RUN_ID, 9)).resolves.toBeNull();
+    });
+  });
+
+  describe('upsertReview', () => {
+    it('creates a new review and returns it as a DTO', async () => {
+      mockReviewUpsert.mockResolvedValueOnce(makeReview({ pageNumber: 5, category: 'LEGIT_EMPTY' }));
+
+      const dto = await upsertReview(RUN_ID, 5, ANNOTATOR_ID, {
+        category: 'LEGIT_EMPTY',
+        pageType: 'blank',
+      });
+
+      expect(dto.pageNumber).toBe(5);
+      expect(dto.category).toBe('LEGIT_EMPTY');
+      expect(dto.expectedContent).toBeNull();
+      expect(dto.notes).toBeNull();
+
+      expect(mockReviewUpsert).toHaveBeenCalledTimes(1);
+      const upsertArg = mockReviewUpsert.mock.calls[0][0];
+      expect(upsertArg.where).toEqual({
+        calibrationRunId_pageNumber: { calibrationRunId: RUN_ID, pageNumber: 5 },
+      });
+      expect(upsertArg.create).toMatchObject({
+        calibrationRunId: RUN_ID,
+        pageNumber: 5,
+        category: 'LEGIT_EMPTY',
+        pageType: 'blank',
+        expectedContent: null,
+        notes: null,
+        annotatorId: ANNOTATOR_ID,
+      });
+      expect(upsertArg.update).toMatchObject({
+        category: 'LEGIT_EMPTY',
+        pageType: 'blank',
+        expectedContent: null,
+        notes: null,
+        annotatorId: ANNOTATOR_ID,
+      });
+      expect(upsertArg.update.reviewedAt).toBeInstanceOf(Date);
+    });
+
+    it('updates an existing review when called twice with the same payload (idempotent)', async () => {
+      const stored = makeReview({ pageNumber: 5, category: 'DETECTION_FAILURE' });
+      stored.expectedContent = 'Chapter 1 opening';
+      mockReviewUpsert.mockResolvedValue(stored);
+
+      const payload = {
+        category: 'DETECTION_FAILURE' as const,
+        pageType: 'text_normal',
+        expectedContent: 'Chapter 1 opening',
+      };
+
+      const first = await upsertReview(RUN_ID, 5, ANNOTATOR_ID, payload);
+      const second = await upsertReview(RUN_ID, 5, ANNOTATOR_ID, payload);
+
+      expect(first).toEqual(second);
+      expect(mockReviewUpsert).toHaveBeenCalledTimes(2);
+      const args = mockReviewUpsert.mock.calls.map(c => c[0]);
+      expect(args[0].where).toEqual(args[1].where);
+      expect(args[0].create.expectedContent).toBe('Chapter 1 opening');
+      expect(args[0].update.expectedContent).toBe('Chapter 1 opening');
+    });
+
+    it('persists undefined optional fields as null', async () => {
+      mockReviewUpsert.mockResolvedValueOnce(makeReview());
+
+      await upsertReview(RUN_ID, 5, ANNOTATOR_ID, {
+        category: 'UNSURE',
+        pageType: 'other',
+      });
+
+      const arg = mockReviewUpsert.mock.calls[0][0];
+      expect(arg.create.expectedContent).toBeNull();
+      expect(arg.create.notes).toBeNull();
+      expect(arg.update.expectedContent).toBeNull();
+      expect(arg.update.notes).toBeNull();
+    });
+  });
+
+  describe('deleteReview', () => {
+    it('returns true when a review is deleted', async () => {
+      mockReviewDelete.mockResolvedValueOnce({ id: 'r-1' });
+      await expect(deleteReview(RUN_ID, 5)).resolves.toBe(true);
+      expect(mockReviewDelete).toHaveBeenCalledWith({
+        where: { calibrationRunId_pageNumber: { calibrationRunId: RUN_ID, pageNumber: 5 } },
+      });
+    });
+
+    it('returns false when the review does not exist (P2025)', async () => {
+      const err = new Prisma.PrismaClientKnownRequestError('Record not found', {
+        code: 'P2025',
+        clientVersion: '5.22.0',
+      });
+      mockReviewDelete.mockRejectedValueOnce(err);
+      await expect(deleteReview(RUN_ID, 5)).resolves.toBe(false);
+    });
+
+    it('rethrows non-P2025 errors', async () => {
+      mockReviewDelete.mockRejectedValueOnce(new Error('connection lost'));
+      await expect(deleteReview(RUN_ID, 5)).rejects.toThrow('connection lost');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds persistence layer so annotators can triage pages with no detected zones (legit_empty / detection_failure / unsure + page-type sub-category) directly in the zone-review workspace, replacing the legacy Google Sheet workflow.
- New `EmptyPageReview` Prisma model + idempotent migration; back-relations on `CalibrationRun.emptyPageReviews` and `User.emptyPageReviews`. Cascade-on-delete from the run.
- Four REST endpoints under `/api/v1/calibration/runs/:runId/empty-page-reviews` (GET list, GET one, PUT upsert, DELETE), restricted to ADMIN/OPERATOR roles.

## Endpoints
| Method | Path | Purpose |
|---|---|---|
| GET | `/` | List all reviews for the run, sorted by pageNumber |
| GET | `/:pageNumber` | Single review (404 if no review exists) |
| PUT | `/:pageNumber` | Upsert; records acting user as `annotatorId` |
| DELETE | `/:pageNumber` | Clear the review (404 if none) |

Composite unique key `@@unique([calibrationRunId, pageNumber])` enforces one review per page per run; the upsert keys on it.

## Validation (Zod)
- `category` ∈ `LEGIT_EMPTY` / `DETECTION_FAILURE` / `UNSURE`
- `pageType` ∈ controlled vocabulary of 15 strings (mirrors frontend `PAGE_TYPES`):
  `blank, cover, copyright, dedication, colophon, chapter_divider, toc_divider, image_plate, ornament, text_normal, text_complex, table, figure, mixed, other`
- `expectedContent` required when `category=DETECTION_FAILURE` (via `superRefine`); optional otherwise
- `notes` capped at 2000 chars
- `pageNumber` path param: positive integer

## Files
- `prisma/schema.prisma` — model + enum + back-relations
- `prisma/migrations/20260428000000_add_empty_page_review/migration.sql` — idempotent `DO $$ … END $$` blocks matching prior style
- `src/schemas/empty-page-review.schema.ts`
- `src/services/empty-page-review.service.ts`
- `src/controllers/empty-page-review.controller.ts`
- `src/routes/calibration.routes.ts` — sub-router mounted at `/runs/:runId/empty-page-reviews`
- `tests/unit/{services,schemas,controllers}/empty-page-review.*.test.ts` — 39 tests

## Deviations from spec (worth a look)
1. Spec asked for UUID validation on `runId` path param. `CalibrationRun.id` is actually `cuid()` in the schema, so I check existence via DB lookup and 404 instead of regex-validating.
2. Spec suggested `mockDeep<PrismaClient>` for tests. The codebase uses Vitest with `vi.mock`-based mocking (no `jest-mock-extended`); I followed the existing pattern.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint --max-warnings 0` passes on all touched files
- [x] 39/39 unit tests pass (services 12, schemas 15, controllers 12)
- [ ] CI green
- [ ] Smoke-test the four endpoints on staging after deploy:
  ```
  GET    /api/v1/calibration/runs/$RUN_ID/empty-page-reviews
  GET    /api/v1/calibration/runs/$RUN_ID/empty-page-reviews/12
  PUT    /api/v1/calibration/runs/$RUN_ID/empty-page-reviews/12  -d '{"category":"DETECTION_FAILURE","pageType":"text_normal","expectedContent":"Chapter 3 opening"}'
  DELETE /api/v1/calibration/runs/$RUN_ID/empty-page-reviews/12
  ```

## Out of scope
- Frontend changes (separate PR in `ninja-frontend`)
- Google Sheet data migration (greenfield; no data exists)
- Batch endpoints — single-page upsert is enough for v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints for managing empty page reviews with list, retrieve, update, and delete operations.
  * Introduced review categorization system with multiple classification options.
  * Added data validation and storage capabilities for review metadata.

* **Tests**
  * Added comprehensive test coverage for review operations, validation logic, and database interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->