### PR TITLE
feat: add Status Tracker endpoints + schema for Corpus Summary v2 tab

### DIFF
--- a/prisma/migrations/20260507000000_add_status_tracker_fields/migration.sql
+++ b/prisma/migrations/20260507000000_add_status_tracker_fields/migration.sql
@@ -1,0 +1,40 @@
+-- AlterTable: add Status Tracker fields to CorpusDocument.
+-- Idempotent ADD COLUMN blocks so the migration can be safely re-applied
+-- (e.g. against a database that was hand-baselined). Reverse with
+-- `ALTER TABLE "CorpusDocument" DROP COLUMN ...` for each column below.
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'CorpusDocument' AND column_name = 'statusNote'
+  ) THEN
+    ALTER TABLE "CorpusDocument" ADD COLUMN "statusNote" TEXT;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'CorpusDocument' AND column_name = 'statusOverride'
+  ) THEN
+    ALTER TABLE "CorpusDocument" ADD COLUMN "statusOverride" TEXT;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'CorpusDocument' AND column_name = 'statusUpdatedAt'
+  ) THEN
+    ALTER TABLE "CorpusDocument" ADD COLUMN "statusUpdatedAt" TIMESTAMP(3);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'CorpusDocument' AND column_name = 'statusUpdatedBy'
+  ) THEN
+    ALTER TABLE "CorpusDocument" ADD COLUMN "statusUpdatedBy" TEXT;
+  END IF;
+END $$;

--- a/prisma/migrations/20260507000000_add_status_tracker_fields/migration.sql
+++ b/prisma/migrations/20260507000000_add_status_tracker_fields/migration.sql
@@ -2,11 +2,15 @@
 -- Idempotent ADD COLUMN blocks so the migration can be safely re-applied
 -- (e.g. against a database that was hand-baselined). Reverse with
 -- `ALTER TABLE "CorpusDocument" DROP COLUMN ...` for each column below.
+-- Existence checks scope on table_schema = current_schema() so an unrelated
+-- table/column in another schema cannot accidentally cause the ALTER to skip.
 
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'CorpusDocument' AND column_name = 'statusNote'
+    WHERE table_schema = current_schema()
+      AND table_name = 'CorpusDocument'
+      AND column_name = 'statusNote'
   ) THEN
     ALTER TABLE "CorpusDocument" ADD COLUMN "statusNote" TEXT;
   END IF;
@@ -15,7 +19,9 @@ END $$;
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'CorpusDocument' AND column_name = 'statusOverride'
+    WHERE table_schema = current_schema()
+      AND table_name = 'CorpusDocument'
+      AND column_name = 'statusOverride'
   ) THEN
     ALTER TABLE "CorpusDocument" ADD COLUMN "statusOverride" TEXT;
   END IF;
@@ -24,7 +30,9 @@ END $$;
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'CorpusDocument' AND column_name = 'statusUpdatedAt'
+    WHERE table_schema = current_schema()
+      AND table_name = 'CorpusDocument'
+      AND column_name = 'statusUpdatedAt'
   ) THEN
     ALTER TABLE "CorpusDocument" ADD COLUMN "statusUpdatedAt" TIMESTAMP(3);
   END IF;
@@ -33,7 +41,9 @@ END $$;
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'CorpusDocument' AND column_name = 'statusUpdatedBy'
+    WHERE table_schema = current_schema()
+      AND table_name = 'CorpusDocument'
+      AND column_name = 'statusUpdatedBy'
   ) THEN
     ALTER TABLE "CorpusDocument" ADD COLUMN "statusUpdatedBy" TEXT;
   END IF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2078,6 +2078,13 @@ model CorpusDocument {
   trainingSplit   String?   // "train" | "val" | "test" | null
   taggedPdfPath   String?   // S3 path to operator-uploaded pdfxt-tagged PDF
   uploadedAt      DateTime  @default(now())
+  // Status Tracker — operator-editable per-document state. Override values come from
+  // the AnnotationStatus union (NOT_STARTED|IN_PROGRESS|PENDING_REVIEW|COMPLETED|BLOCKED);
+  // when null, the row's status is derived from pagesAnnotated vs pageCount.
+  statusNote      String?   @db.Text
+  statusOverride  String?
+  statusUpdatedAt DateTime?
+  statusUpdatedBy String?
   bootstrapJobs   ZoneBootstrapJob[]
   calibrationRuns CalibrationRun[]
 }

--- a/src/controllers/corpus-status.controller.ts
+++ b/src/controllers/corpus-status.controller.ts
@@ -1,0 +1,105 @@
+import { Request, Response } from 'express';
+import { logger } from '../lib/logger';
+import {
+  listCorpusStatus,
+  updateDocumentStatus,
+} from '../services/calibration/corpus-status.service';
+import {
+  documentIdParamSchema,
+  updateCorpusStatusSchema,
+} from '../schemas/corpus-status.schema';
+
+const ADMIN_OR_OPERATOR = new Set(['admin', 'ADMIN', 'OPERATOR']);
+
+function hasAdminOrOperatorRole(req: Request): boolean {
+  return ADMIN_OR_OPERATOR.has(req.user?.role ?? '');
+}
+
+// GET /api/v1/calibration/corpus-status
+export async function getCorpusStatus(req: Request, res: Response) {
+  try {
+    if (!req.user) {
+      return res.status(401).json({
+        success: false,
+        error: { code: 'UNAUTHENTICATED', message: 'Authentication required' },
+      });
+    }
+    if (!hasAdminOrOperatorRole(req)) {
+      return res.status(403).json({
+        success: false,
+        error: { code: 'FORBIDDEN', message: 'Admin or Operator role required' },
+      });
+    }
+
+    const data = await listCorpusStatus();
+    return res.json({ success: true, data });
+  } catch (err) {
+    logger.error('GET /calibration/corpus-status error:', err);
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+}
+
+// PUT /api/v1/admin/corpus/documents/:documentId/status
+export async function putCorpusDocumentStatus(req: Request, res: Response) {
+  try {
+    if (!req.user) {
+      return res.status(401).json({
+        success: false,
+        error: { code: 'UNAUTHENTICATED', message: 'Authentication required' },
+      });
+    }
+    if (!hasAdminOrOperatorRole(req)) {
+      return res.status(403).json({
+        success: false,
+        error: { code: 'FORBIDDEN', message: 'Admin or Operator role required' },
+      });
+    }
+
+    const idParse = documentIdParamSchema.safeParse(req.params.documentId);
+    if (!idParse.success) {
+      return res.status(422).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid documentId',
+          details: idParse.error.issues,
+        },
+      });
+    }
+
+    const bodyParse = updateCorpusStatusSchema.safeParse(req.body);
+    if (!bodyParse.success) {
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Request validation failed',
+          details: bodyParse.error.issues,
+        },
+      });
+    }
+
+    const updated = await updateDocumentStatus(
+      idParse.data,
+      bodyParse.data,
+      req.user.id,
+    );
+    if (!updated) {
+      return res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Corpus document not found' },
+      });
+    }
+
+    return res.json({ success: true, data: updated });
+  } catch (err) {
+    logger.error('PUT /admin/corpus/documents/:documentId/status error:', err);
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+}

--- a/src/routes/admin/corpus.routes.ts
+++ b/src/routes/admin/corpus.routes.ts
@@ -9,6 +9,7 @@ import {
   registerCorpusDocument,
   listCorpusDocuments,
 } from '../../services/corpus/corpus-upload.service';
+import { putCorpusDocumentStatus } from '../../controllers/corpus-status.controller';
 import { s3Client } from '../../services/s3.service';
 import { config } from '../../config';
 import prisma from '../../lib/prisma';
@@ -583,6 +584,9 @@ router.post('/corpus/documents/:id/tagged-pdf', authenticate, (req: Request, res
     }
   });
 });
+
+// PUT /api/v1/admin/corpus/documents/:documentId/status — Status Tracker edit
+router.put('/corpus/documents/:documentId/status', authenticate, putCorpusDocumentStatus);
 
 // POST /api/v1/admin/corpus/reset-documents
 // Deletes selected corpus documents and their related data (zones, runs, sessions, jobs)

--- a/src/routes/calibration.routes.ts
+++ b/src/routes/calibration.routes.ts
@@ -19,6 +19,7 @@ import {
   listEmptyPageReviews,
   upsertEmptyPageReview,
 } from '../controllers/empty-page-review.controller';
+import { getCorpusStatus } from '../controllers/corpus-status.controller';
 import { logger } from '../lib/logger';
 
 const router = Router();
@@ -31,6 +32,9 @@ emptyPageReviewRouter.get('/:pageNumber', authenticate, getEmptyPageReview);
 emptyPageReviewRouter.put('/:pageNumber', authenticate, upsertEmptyPageReview);
 emptyPageReviewRouter.delete('/:pageNumber', authenticate, deleteEmptyPageReview);
 router.use('/runs/:runId/empty-page-reviews', emptyPageReviewRouter);
+
+// GET /api/v1/calibration/corpus-status — Status Tracker tab list endpoint
+router.get('/corpus-status', authenticate, getCorpusStatus);
 
 const runBodySchema = z.object({
   documentId: z.string().min(1),

--- a/src/schemas/corpus-status.schema.ts
+++ b/src/schemas/corpus-status.schema.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+// AnnotationStatus union for the Status Tracker tab.
+// JUST_STARTED was dropped during sizing — IN_PROGRESS with low pagesAnnotated
+// covers the same operational signal. NOT_STARTED, IN_PROGRESS, and COMPLETED
+// are reachable via derivation; PENDING_REVIEW and BLOCKED are override-only.
+export const ANNOTATION_STATUSES = [
+  'NOT_STARTED',
+  'IN_PROGRESS',
+  'PENDING_REVIEW',
+  'COMPLETED',
+  'BLOCKED',
+] as const;
+
+export const annotationStatusSchema = z.enum(ANNOTATION_STATUSES);
+export type AnnotationStatus = z.infer<typeof annotationStatusSchema>;
+
+// PUT /api/v1/admin/corpus/documents/:documentId/status body.
+// Either field may be provided; both are optional but at least one should be
+// present for the request to be meaningful. statusOverride === null clears
+// the override and reverts the row to its derived status.
+export const updateCorpusStatusSchema = z
+  .object({
+    statusOverride: annotationStatusSchema.nullable().optional(),
+    statusNote: z.string().trim().max(500).optional(),
+  })
+  .refine(
+    (data) => data.statusOverride !== undefined || data.statusNote !== undefined,
+    { message: 'Provide statusOverride and/or statusNote' },
+  );
+
+export type UpdateCorpusStatusInput = z.infer<typeof updateCorpusStatusSchema>;
+
+export const documentIdParamSchema = z.string().min(1);

--- a/src/services/calibration/corpus-status.service.ts
+++ b/src/services/calibration/corpus-status.service.ts
@@ -1,0 +1,293 @@
+import { Prisma } from '@prisma/client';
+import prisma from '../../lib/prisma';
+import type { AnnotationStatus } from '../../schemas/corpus-status.schema';
+
+// System "users" that show up in Zone.verifiedBy but are not real annotators.
+// Mirrors the SYSTEM_IDS set in annotation-timesheet.service.ts.
+const SYSTEM_IDS = new Set(['auto-annotation', 'unknown']);
+
+export interface PrimaryAnnotator {
+  userId: string | null;
+  displayName: string;
+  email: string | null;
+}
+
+export interface CorpusStatusRow {
+  serialNumber: number;
+  documentId: string;
+  filename: string;
+  pageCount: number;
+  pagesAnnotated: number;
+  status: AnnotationStatus;
+  statusOverride: AnnotationStatus | null;
+  primaryAnnotator: PrimaryAnnotator | null;
+  otherAnnotatorCount: number;
+  hoursSpent: number;
+  lastUpdatedAt: string | null;
+  statusNote: string | null;
+}
+
+export interface CorpusStatusListResponse {
+  rows: CorpusStatusRow[];
+  generatedAt: string;
+}
+
+/** Apply the derivation rule from the spec. statusOverride wins when set. */
+export function deriveStatus(
+  pagesAnnotated: number,
+  pageCount: number | null,
+  statusOverride: string | null,
+): AnnotationStatus {
+  if (statusOverride && isAnnotationStatus(statusOverride)) {
+    return statusOverride;
+  }
+  if (pagesAnnotated <= 0) return 'NOT_STARTED';
+  if (pageCount == null || pageCount <= 0) return 'IN_PROGRESS';
+  if (pagesAnnotated >= pageCount) return 'COMPLETED';
+  return 'IN_PROGRESS';
+}
+
+function isAnnotationStatus(value: string): value is AnnotationStatus {
+  return (
+    value === 'NOT_STARTED' ||
+    value === 'IN_PROGRESS' ||
+    value === 'PENDING_REVIEW' ||
+    value === 'COMPLETED' ||
+    value === 'BLOCKED'
+  );
+}
+
+function maxIso(...values: Array<Date | string | null | undefined>): string | null {
+  let best: number | null = null;
+  for (const v of values) {
+    if (!v) continue;
+    const t = v instanceof Date ? v.getTime() : new Date(v).getTime();
+    if (Number.isFinite(t) && (best === null || t > best)) best = t;
+  }
+  return best === null ? null : new Date(best).toISOString();
+}
+
+/**
+ * Build the Status Tracker rows for every CorpusDocument.
+ *
+ * One query per shape (documents, pages-annotated, hours, annotator counts,
+ * latest zone update, user names) so the table stays O(documents) rather than
+ * issuing per-document queries. For 17 documents this finishes well under the
+ * 500ms target the spec calls for; revisit if the corpus grows past ~100 rows.
+ */
+export async function listCorpusStatus(): Promise<CorpusStatusListResponse> {
+  const documents = await prisma.corpusDocument.findMany({
+    orderBy: { uploadedAt: 'asc' },
+    select: {
+      id: true,
+      filename: true,
+      pageCount: true,
+      uploadedAt: true,
+      statusNote: true,
+      statusOverride: true,
+      statusUpdatedAt: true,
+    },
+  });
+
+  if (documents.length === 0) {
+    return { rows: [], generatedAt: new Date().toISOString() };
+  }
+
+  const documentIds = documents.map((d) => d.id);
+
+  // Map of documentId -> [calibrationRunIds]
+  const runs = await prisma.calibrationRun.findMany({
+    where: { documentId: { in: documentIds } },
+    select: { id: true, documentId: true },
+  });
+
+  const runIdsByDoc = new Map<string, string[]>();
+  const docByRunId = new Map<string, string>();
+  for (const r of runs) {
+    docByRunId.set(r.id, r.documentId);
+    const list = runIdsByDoc.get(r.documentId) ?? [];
+    list.push(r.id);
+    runIdsByDoc.set(r.documentId, list);
+  }
+
+  const allRunIds = runs.map((r) => r.id);
+
+  // Aggregations only run when there is at least one calibration run; otherwise
+  // every doc is NOT_STARTED with zero hours.
+  const pagesAnnotatedByDoc = new Map<string, number>();
+  const hoursByDoc = new Map<string, number>();
+  const lastZoneUpdateByDoc = new Map<string, Date>();
+  const annotatorCountsByDoc = new Map<string, Map<string, number>>();
+
+  if (allRunIds.length > 0) {
+    // Pages annotated: distinct pageNumber where any zone is operatorVerified.
+    const verifiedPageRows = await prisma.$queryRaw<
+      { calibrationRunId: string; pagesAnnotated: bigint }[]
+    >`
+      SELECT "calibrationRunId",
+             COUNT(DISTINCT "pageNumber")::bigint AS "pagesAnnotated"
+      FROM "Zone"
+      WHERE "calibrationRunId" IN (${Prisma.join(allRunIds)})
+        AND "operatorVerified" = true
+      GROUP BY "calibrationRunId"
+    `;
+    for (const row of verifiedPageRows) {
+      const docId = docByRunId.get(row.calibrationRunId);
+      if (!docId) continue;
+      pagesAnnotatedByDoc.set(
+        docId,
+        (pagesAnnotatedByDoc.get(docId) ?? 0) + Number(row.pagesAnnotated),
+      );
+    }
+
+    // Hours: sum AnnotationSession.activeMs across all runs for the document.
+    const hourRows = await prisma.annotationSession.groupBy({
+      by: ['calibrationRunId'],
+      where: { calibrationRunId: { in: allRunIds } },
+      _sum: { activeMs: true },
+    });
+    for (const row of hourRows) {
+      const docId = docByRunId.get(row.calibrationRunId);
+      if (!docId) continue;
+      const ms = row._sum.activeMs ?? 0;
+      hoursByDoc.set(docId, (hoursByDoc.get(docId) ?? 0) + ms);
+    }
+
+    // Latest zone update — used for the lastUpdatedAt fallback when there is
+    // no explicit statusUpdatedAt.
+    const lastUpdateRows = await prisma.zone.groupBy({
+      by: ['calibrationRunId'],
+      where: { calibrationRunId: { in: allRunIds } },
+      _max: { updatedAt: true },
+    });
+    for (const row of lastUpdateRows) {
+      if (!row.calibrationRunId) continue;
+      const docId = docByRunId.get(row.calibrationRunId);
+      if (!docId || !row._max.updatedAt) continue;
+      const current = lastZoneUpdateByDoc.get(docId);
+      if (!current || row._max.updatedAt > current) {
+        lastZoneUpdateByDoc.set(docId, row._max.updatedAt);
+      }
+    }
+
+    // Per-annotator zone counts → primary annotator + other-annotator count.
+    const annotatorRows = await prisma.zone.groupBy({
+      by: ['calibrationRunId', 'verifiedBy'],
+      where: {
+        calibrationRunId: { in: allRunIds },
+        operatorVerified: true,
+        verifiedBy: { not: null },
+      },
+      _count: { _all: true },
+    });
+    for (const row of annotatorRows) {
+      if (!row.calibrationRunId || !row.verifiedBy) continue;
+      const docId = docByRunId.get(row.calibrationRunId);
+      if (!docId) continue;
+      if (SYSTEM_IDS.has(row.verifiedBy)) continue;
+      const inner = annotatorCountsByDoc.get(docId) ?? new Map<string, number>();
+      inner.set(row.verifiedBy, (inner.get(row.verifiedBy) ?? 0) + row._count._all);
+      annotatorCountsByDoc.set(docId, inner);
+    }
+  }
+
+  // Resolve user names/emails for every annotator id we saw.
+  const userIds = new Set<string>();
+  for (const inner of annotatorCountsByDoc.values()) {
+    for (const id of inner.keys()) userIds.add(id);
+  }
+  const users = userIds.size
+    ? await prisma.user.findMany({
+        where: { id: { in: [...userIds] } },
+        select: { id: true, firstName: true, lastName: true, email: true },
+      })
+    : [];
+  const userById = new Map(users.map((u) => [u.id, u]));
+
+  const rows: CorpusStatusRow[] = documents.map((doc, i) => {
+    const pagesAnnotated = pagesAnnotatedByDoc.get(doc.id) ?? 0;
+    const overrideRaw = doc.statusOverride;
+    const statusOverride =
+      overrideRaw && isAnnotationStatus(overrideRaw) ? overrideRaw : null;
+
+    const status = deriveStatus(pagesAnnotated, doc.pageCount, statusOverride);
+
+    const inner = annotatorCountsByDoc.get(doc.id);
+    let primaryAnnotator: PrimaryAnnotator | null = null;
+    let otherAnnotatorCount = 0;
+    if (inner && inner.size > 0) {
+      const sorted = [...inner.entries()].sort((a, b) => b[1] - a[1]);
+      const topId = sorted[0][0];
+      const u = userById.get(topId);
+      const displayName =
+        u && (u.firstName || u.lastName)
+          ? [u.firstName, u.lastName].filter(Boolean).join(' ')
+          : topId;
+      primaryAnnotator = {
+        userId: topId,
+        displayName,
+        email: u?.email ?? null,
+      };
+      otherAnnotatorCount = sorted.length - 1;
+    }
+
+    const hoursSpent = (hoursByDoc.get(doc.id) ?? 0) / 3_600_000;
+
+    const lastUpdatedAt = maxIso(
+      doc.statusUpdatedAt,
+      lastZoneUpdateByDoc.get(doc.id),
+    );
+
+    return {
+      serialNumber: i + 1,
+      documentId: doc.id,
+      filename: doc.filename,
+      pageCount: doc.pageCount ?? 0,
+      pagesAnnotated,
+      status,
+      statusOverride,
+      primaryAnnotator,
+      otherAnnotatorCount,
+      hoursSpent: Math.round(hoursSpent * 100) / 100,
+      lastUpdatedAt,
+      statusNote: doc.statusNote,
+    };
+  });
+
+  return { rows, generatedAt: new Date().toISOString() };
+}
+
+/**
+ * Update statusOverride and/or statusNote for a single document. Always
+ * stamps statusUpdatedAt and statusUpdatedBy. Pass `statusOverride: null`
+ * to clear the override.
+ */
+export async function updateDocumentStatus(
+  documentId: string,
+  payload: { statusOverride?: AnnotationStatus | null; statusNote?: string },
+  userId: string,
+): Promise<CorpusStatusRow | null> {
+  const existing = await prisma.corpusDocument.findUnique({
+    where: { id: documentId },
+    select: { id: true },
+  });
+  if (!existing) return null;
+
+  const data: Prisma.CorpusDocumentUpdateInput = {
+    statusUpdatedAt: new Date(),
+    statusUpdatedBy: userId,
+  };
+  if (payload.statusOverride !== undefined) {
+    data.statusOverride = payload.statusOverride;
+  }
+  if (payload.statusNote !== undefined) {
+    data.statusNote = payload.statusNote;
+  }
+
+  await prisma.corpusDocument.update({ where: { id: documentId }, data });
+
+  // Re-fetch the row so the response reflects the same shape (including
+  // recomputed derived status) the GET endpoint returns.
+  const list = await listCorpusStatus();
+  return list.rows.find((r) => r.documentId === documentId) ?? null;
+}

--- a/tests/unit/controllers/corpus-status.controller.test.ts
+++ b/tests/unit/controllers/corpus-status.controller.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Request, Response } from 'express';
+
+vi.mock('../../../src/services/calibration/corpus-status.service', () => ({
+  listCorpusStatus: vi.fn(),
+  updateDocumentStatus: vi.fn(),
+}));
+
+import {
+  listCorpusStatus,
+  updateDocumentStatus,
+} from '../../../src/services/calibration/corpus-status.service';
+import {
+  getCorpusStatus,
+  putCorpusDocumentStatus,
+} from '../../../src/controllers/corpus-status.controller';
+
+const mList = listCorpusStatus as ReturnType<typeof vi.fn>;
+const mUpdate = updateDocumentStatus as ReturnType<typeof vi.fn>;
+
+function makeRes() {
+  const res: Partial<Response> & { _status?: number; _body?: unknown } = {};
+  res.status = vi.fn().mockImplementation((code: number) => {
+    res._status = code;
+    return res as Response;
+  });
+  res.json = vi.fn().mockImplementation((body: unknown) => {
+    res._body = body;
+    return res as Response;
+  });
+  return res as Response & { _status?: number; _body?: unknown };
+}
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    params: {},
+    body: {},
+    query: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+describe('getCorpusStatus', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('returns 401 when unauthenticated', async () => {
+    const req = makeReq();
+    const res = makeRes();
+    await getCorpusStatus(req, res);
+    expect(res._status).toBe(401);
+    expect(mList).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for a USER role', async () => {
+    const req = makeReq({
+      user: { id: 'u1', email: 'x@x.com', tenantId: 't1', role: 'USER' },
+    } as Partial<Request>);
+    const res = makeRes();
+    await getCorpusStatus(req, res);
+    expect(res._status).toBe(403);
+    expect(mList).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with rows for OPERATOR', async () => {
+    const data = { rows: [], generatedAt: '2026-05-07T00:00:00Z' };
+    mList.mockResolvedValue(data);
+    const req = makeReq({
+      user: { id: 'u1', email: 'x@x.com', tenantId: 't1', role: 'OPERATOR' },
+    } as Partial<Request>);
+    const res = makeRes();
+    await getCorpusStatus(req, res);
+    expect(res._body).toEqual({ success: true, data });
+  });
+
+  it('returns 200 for ADMIN', async () => {
+    mList.mockResolvedValue({ rows: [], generatedAt: 'x' });
+    const req = makeReq({
+      user: { id: 'u1', email: 'x@x.com', tenantId: 't1', role: 'ADMIN' },
+    } as Partial<Request>);
+    const res = makeRes();
+    await getCorpusStatus(req, res);
+    expect(mList).toHaveBeenCalledOnce();
+  });
+});
+
+describe('putCorpusDocumentStatus', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  const adminUser = {
+    id: 'admin-1',
+    email: 'a@x.com',
+    tenantId: 't1',
+    role: 'ADMIN',
+  };
+
+  it('returns 401 when unauthenticated', async () => {
+    const req = makeReq({
+      params: { documentId: 'd1' },
+      body: { statusOverride: 'BLOCKED' },
+    });
+    const res = makeRes();
+    await putCorpusDocumentStatus(req, res);
+    expect(res._status).toBe(401);
+  });
+
+  it('returns 403 when role is USER', async () => {
+    const req = makeReq({
+      user: { ...adminUser, role: 'USER' },
+      params: { documentId: 'd1' },
+      body: { statusOverride: 'BLOCKED' },
+    } as Partial<Request>);
+    const res = makeRes();
+    await putCorpusDocumentStatus(req, res);
+    expect(res._status).toBe(403);
+  });
+
+  it('returns 400 for invalid statusOverride enum value', async () => {
+    const req = makeReq({
+      user: adminUser,
+      params: { documentId: 'd1' },
+      body: { statusOverride: 'GARBAGE' },
+    } as Partial<Request>);
+    const res = makeRes();
+    await putCorpusDocumentStatus(req, res);
+    expect(res._status).toBe(400);
+    expect(mUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for statusNote longer than 500 chars', async () => {
+    const req = makeReq({
+      user: adminUser,
+      params: { documentId: 'd1' },
+      body: { statusNote: 'x'.repeat(501) },
+    } as Partial<Request>);
+    const res = makeRes();
+    await putCorpusDocumentStatus(req, res);
+    expect(res._status).toBe(400);
+    expect(mUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when neither field is supplied', async () => {
+    const req = makeReq({
+      user: adminUser,
+      params: { documentId: 'd1' },
+      body: {},
+    } as Partial<Request>);
+    const res = makeRes();
+    await putCorpusDocumentStatus(req, res);
+    expect(res._status).toBe(400);
+  });
+
+  it('returns 404 when document does not exist', async () => {
+    mUpdate.mockResolvedValue(null);
+    const req = makeReq({
+      user: adminUser,
+      params: { documentId: 'missing' },
+      body: { statusOverride: 'BLOCKED' },
+    } as Partial<Request>);
+    const res = makeRes();
+    await putCorpusDocumentStatus(req, res);
+    expect(res._status).toBe(404);
+  });
+
+  it('returns 200 with updated row on success', async () => {
+    const updatedRow = {
+      serialNumber: 1,
+      documentId: 'd1',
+      filename: 'a.pdf',
+      pageCount: 100,
+      pagesAnnotated: 50,
+      status: 'BLOCKED',
+      statusOverride: 'BLOCKED',
+      primaryAnnotator: null,
+      otherAnnotatorCount: 0,
+      hoursSpent: 0,
+      lastUpdatedAt: '2026-05-07T00:00:00Z',
+      statusNote: 'engineering issue',
+    };
+    mUpdate.mockResolvedValue(updatedRow);
+    const req = makeReq({
+      user: adminUser,
+      params: { documentId: 'd1' },
+      body: { statusOverride: 'BLOCKED', statusNote: 'engineering issue' },
+    } as Partial<Request>);
+    const res = makeRes();
+
+    await putCorpusDocumentStatus(req, res);
+
+    expect(mUpdate).toHaveBeenCalledWith(
+      'd1',
+      { statusOverride: 'BLOCKED', statusNote: 'engineering issue' },
+      'admin-1',
+    );
+    expect(res._body).toEqual({ success: true, data: updatedRow });
+  });
+
+  it('accepts statusOverride: null to clear', async () => {
+    mUpdate.mockResolvedValue({ documentId: 'd1', status: 'NOT_STARTED' });
+    const req = makeReq({
+      user: adminUser,
+      params: { documentId: 'd1' },
+      body: { statusOverride: null },
+    } as Partial<Request>);
+    const res = makeRes();
+    await putCorpusDocumentStatus(req, res);
+    const args = mUpdate.mock.calls[0];
+    expect(args[1]).toEqual({ statusOverride: null });
+  });
+});

--- a/tests/unit/services/calibration/corpus-status.service.test.ts
+++ b/tests/unit/services/calibration/corpus-status.service.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../../../src/lib/prisma', () => ({
+  default: {
+    corpusDocument: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    calibrationRun: {
+      findMany: vi.fn(),
+    },
+    annotationSession: {
+      groupBy: vi.fn(),
+    },
+    zone: {
+      groupBy: vi.fn(),
+    },
+    user: {
+      findMany: vi.fn(),
+    },
+    $queryRaw: vi.fn(),
+  },
+}));
+
+import prisma from '../../../../src/lib/prisma';
+import {
+  deriveStatus,
+  listCorpusStatus,
+  updateDocumentStatus,
+} from '../../../../src/services/calibration/corpus-status.service';
+
+const mDocFindMany = prisma.corpusDocument.findMany as ReturnType<typeof vi.fn>;
+const mDocFindUnique = prisma.corpusDocument.findUnique as ReturnType<typeof vi.fn>;
+const mDocUpdate = prisma.corpusDocument.update as ReturnType<typeof vi.fn>;
+const mRunFindMany = prisma.calibrationRun.findMany as ReturnType<typeof vi.fn>;
+const mSessionGroupBy = prisma.annotationSession.groupBy as ReturnType<typeof vi.fn>;
+const mZoneGroupBy = prisma.zone.groupBy as ReturnType<typeof vi.fn>;
+const mUserFindMany = prisma.user.findMany as ReturnType<typeof vi.fn>;
+const mQueryRaw = prisma.$queryRaw as ReturnType<typeof vi.fn>;
+
+describe('deriveStatus', () => {
+  it('returns NOT_STARTED when pagesAnnotated is 0', () => {
+    expect(deriveStatus(0, 100, null)).toBe('NOT_STARTED');
+  });
+
+  it('returns IN_PROGRESS when pagesAnnotated < pageCount', () => {
+    expect(deriveStatus(45, 100, null)).toBe('IN_PROGRESS');
+  });
+
+  it('returns COMPLETED when pagesAnnotated == pageCount', () => {
+    expect(deriveStatus(100, 100, null)).toBe('COMPLETED');
+  });
+
+  it('returns COMPLETED when pagesAnnotated exceeds pageCount (defensive)', () => {
+    expect(deriveStatus(120, 100, null)).toBe('COMPLETED');
+  });
+
+  it('returns IN_PROGRESS when pageCount is null/0 but pages annotated', () => {
+    expect(deriveStatus(5, null, null)).toBe('IN_PROGRESS');
+    expect(deriveStatus(5, 0, null)).toBe('IN_PROGRESS');
+  });
+
+  it('override takes precedence over derivation', () => {
+    expect(deriveStatus(0, 100, 'BLOCKED')).toBe('BLOCKED');
+    expect(deriveStatus(50, 100, 'PENDING_REVIEW')).toBe('PENDING_REVIEW');
+    expect(deriveStatus(100, 100, 'IN_PROGRESS')).toBe('IN_PROGRESS');
+  });
+
+  it('ignores invalid override value and falls back to derivation', () => {
+    expect(deriveStatus(50, 100, 'GARBAGE')).toBe('IN_PROGRESS');
+  });
+});
+
+describe('listCorpusStatus', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns empty rows when there are no documents', async () => {
+    mDocFindMany.mockResolvedValue([]);
+    const result = await listCorpusStatus();
+    expect(result.rows).toEqual([]);
+    expect(typeof result.generatedAt).toBe('string');
+    expect(mRunFindMany).not.toHaveBeenCalled();
+  });
+
+  it('returns NOT_STARTED for a document with no calibration run or zones', async () => {
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'a.pdf',
+        pageCount: 100,
+        uploadedAt: new Date('2026-01-01'),
+        statusNote: null,
+        statusOverride: null,
+        statusUpdatedAt: null,
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([]);
+
+    const result = await listCorpusStatus();
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({
+      documentId: 'doc1',
+      pagesAnnotated: 0,
+      status: 'NOT_STARTED',
+      hoursSpent: 0,
+      primaryAnnotator: null,
+      otherAnnotatorCount: 0,
+      lastUpdatedAt: null,
+    });
+  });
+
+  it('aggregates pages, hours, primary annotator, and renders IN_PROGRESS', async () => {
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'crossbills.pdf',
+        pageCount: 226,
+        uploadedAt: new Date('2026-04-01'),
+        statusNote: 'on track',
+        statusOverride: null,
+        statusUpdatedAt: new Date('2026-05-01T10:00:00Z'),
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([
+      { id: 'run1', documentId: 'doc1' },
+    ]);
+    // 220 distinct verified pages
+    mQueryRaw.mockResolvedValue([
+      { calibrationRunId: 'run1', pagesAnnotated: BigInt(220) },
+    ]);
+    // 5.5 hours = 19,800,000 ms
+    mSessionGroupBy.mockResolvedValue([
+      { calibrationRunId: 'run1', _sum: { activeMs: 19_800_000 } },
+    ]);
+    mZoneGroupBy.mockImplementation((args: { by: string[] }) => {
+      if (args.by.includes('verifiedBy')) {
+        return Promise.resolve([
+          { calibrationRunId: 'run1', verifiedBy: 'user-poorna', _count: { _all: 800 } },
+          { calibrationRunId: 'run1', verifiedBy: 'user-nambi', _count: { _all: 50 } },
+          // System rows are filtered out:
+          { calibrationRunId: 'run1', verifiedBy: 'auto-annotation', _count: { _all: 1000 } },
+        ]);
+      }
+      // _max updatedAt
+      return Promise.resolve([
+        {
+          calibrationRunId: 'run1',
+          _max: { updatedAt: new Date('2026-05-06T15:30:00Z') },
+        },
+      ]);
+    });
+    mUserFindMany.mockResolvedValue([
+      { id: 'user-poorna', firstName: 'Poornakala', lastName: 'U', email: 'p@x.com' },
+      { id: 'user-nambi', firstName: 'Nambi', lastName: 'R', email: 'n@x.com' },
+    ]);
+
+    const result = await listCorpusStatus();
+    const row = result.rows[0];
+
+    expect(row.pagesAnnotated).toBe(220);
+    expect(row.status).toBe('IN_PROGRESS');
+    expect(row.hoursSpent).toBe(5.5);
+    expect(row.primaryAnnotator).toEqual({
+      userId: 'user-poorna',
+      displayName: 'Poornakala U',
+      email: 'p@x.com',
+    });
+    expect(row.otherAnnotatorCount).toBe(1);
+    // lastUpdatedAt is max(statusUpdatedAt, max zone updatedAt)
+    expect(row.lastUpdatedAt).toBe('2026-05-06T15:30:00.000Z');
+    expect(row.statusNote).toBe('on track');
+  });
+
+  it('override BLOCKED wins even when derivation would say COMPLETED', async () => {
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'patton.pdf',
+        pageCount: 50,
+        uploadedAt: new Date('2026-04-01'),
+        statusNote: null,
+        statusOverride: 'BLOCKED',
+        statusUpdatedAt: null,
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([{ id: 'run1', documentId: 'doc1' }]);
+    mQueryRaw.mockResolvedValue([
+      { calibrationRunId: 'run1', pagesAnnotated: BigInt(50) },
+    ]);
+    mSessionGroupBy.mockResolvedValue([]);
+    mZoneGroupBy.mockResolvedValue([]);
+    mUserFindMany.mockResolvedValue([]);
+
+    const result = await listCorpusStatus();
+    expect(result.rows[0].status).toBe('BLOCKED');
+    expect(result.rows[0].statusOverride).toBe('BLOCKED');
+    expect(result.rows[0].pagesAnnotated).toBe(50);
+  });
+
+  it('returns COMPLETED when pagesAnnotated == pageCount and no override', async () => {
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'aulakh.pdf',
+        pageCount: 295,
+        uploadedAt: new Date('2026-03-01'),
+        statusNote: null,
+        statusOverride: null,
+        statusUpdatedAt: null,
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([{ id: 'run1', documentId: 'doc1' }]);
+    mQueryRaw.mockResolvedValue([
+      { calibrationRunId: 'run1', pagesAnnotated: BigInt(295) },
+    ]);
+    mSessionGroupBy.mockResolvedValue([]);
+    mZoneGroupBy.mockResolvedValue([]);
+    mUserFindMany.mockResolvedValue([]);
+
+    const result = await listCorpusStatus();
+    expect(result.rows[0].status).toBe('COMPLETED');
+  });
+});
+
+describe('updateDocumentStatus', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns null when document does not exist', async () => {
+    mDocFindUnique.mockResolvedValue(null);
+    const result = await updateDocumentStatus(
+      'missing',
+      { statusOverride: 'BLOCKED' },
+      'user-1',
+    );
+    expect(result).toBeNull();
+    expect(mDocUpdate).not.toHaveBeenCalled();
+  });
+
+  it('writes statusOverride, statusNote, and stamps updater + timestamp', async () => {
+    mDocFindUnique.mockResolvedValue({ id: 'doc1' });
+    mDocUpdate.mockResolvedValue({});
+    // listCorpusStatus refetch — minimal happy path
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'a.pdf',
+        pageCount: 100,
+        uploadedAt: new Date('2026-01-01'),
+        statusNote: 'fresh note',
+        statusOverride: 'PENDING_REVIEW',
+        statusUpdatedAt: new Date('2026-05-07T00:00:00Z'),
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([]);
+
+    const result = await updateDocumentStatus(
+      'doc1',
+      { statusOverride: 'PENDING_REVIEW', statusNote: 'fresh note' },
+      'user-99',
+    );
+
+    expect(mDocUpdate).toHaveBeenCalledOnce();
+    const updateArg = mDocUpdate.mock.calls[0][0] as {
+      where: { id: string };
+      data: {
+        statusOverride?: unknown;
+        statusNote?: unknown;
+        statusUpdatedAt?: unknown;
+        statusUpdatedBy?: unknown;
+      };
+    };
+    expect(updateArg.where.id).toBe('doc1');
+    expect(updateArg.data.statusOverride).toBe('PENDING_REVIEW');
+    expect(updateArg.data.statusNote).toBe('fresh note');
+    expect(updateArg.data.statusUpdatedBy).toBe('user-99');
+    expect(updateArg.data.statusUpdatedAt).toBeInstanceOf(Date);
+
+    expect(result?.status).toBe('PENDING_REVIEW');
+    expect(result?.statusNote).toBe('fresh note');
+  });
+
+  it('clears the override when statusOverride: null is sent', async () => {
+    mDocFindUnique.mockResolvedValue({ id: 'doc1' });
+    mDocUpdate.mockResolvedValue({});
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'a.pdf',
+        pageCount: 100,
+        uploadedAt: new Date('2026-01-01'),
+        statusNote: null,
+        statusOverride: null,
+        statusUpdatedAt: new Date(),
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([]);
+
+    await updateDocumentStatus('doc1', { statusOverride: null }, 'user-99');
+
+    const updateArg = mDocUpdate.mock.calls[0][0] as {
+      data: { statusOverride?: unknown };
+    };
+    expect(updateArg.data.statusOverride).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Backend for the new **Status Tracker** tab on Corpus Summary v2 — an operational per-title view of pages annotated, status pill, hours, primary annotator, and editable notes. Replaces the weekly CSV-via-email reconciliation workflow.

Spec: `Ninja-Documentation/Annotations/STATUS_TRACKER_TAB_SPEC.md`

A frontend PR will land separately and consume the contract below.

## Schema changes

New nullable fields on `CorpusDocument`:

| Field | Type | Purpose |
|---|---|---|
| `statusNote` | `String? @db.Text` | Free-text annotator/operator notes (≤500 chars enforced at API) |
| `statusOverride` | `String?` | Manual status override; when null the row uses derived status |
| `statusUpdatedAt` | `DateTime?` | Stamped by the API on every PUT |
| `statusUpdatedBy` | `String?` | User id of the last editor |

Migration `20260507000000_add_status_tracker_fields` uses idempotent `DO $$ ... IF NOT EXISTS` blocks (matching repo convention from the empty-page-review migration). Reverse with `ALTER TABLE "CorpusDocument" DROP COLUMN ...` for each column.

`AnnotationStatus` is a TypeScript/Zod string union (not a Prisma enum — it never was):
`NOT_STARTED | IN_PROGRESS | PENDING_REVIEW | COMPLETED | BLOCKED`. `JUST_STARTED` was dropped during sizing — `IN_PROGRESS` with low `pagesAnnotated` covers the same operational signal.

## API contract

### `GET /api/v1/calibration/corpus-status`

Auth: `authenticate` + admin/operator role. Response:

```ts
{
  success: true,
  data: {
    rows: Array<{
      serialNumber: number;
      documentId: string;
      filename: string;
      pageCount: number;
      pagesAnnotated: number;        // distinct pageNumber where any zone is operatorVerified=true
      status: AnnotationStatus;       // derived OR override
      statusOverride: AnnotationStatus | null;
      primaryAnnotator: { userId: string; displayName: string; email: string | null } | null;
      otherAnnotatorCount: number;    // for the "+N" badge
      hoursSpent: number;             // sum of AnnotationSession.activeMs / 3.6e6
      lastUpdatedAt: string | null;   // max(statusUpdatedAt, max(zone.updatedAt))
      statusNote: string | null;
    }>;
    generatedAt: string;
  }
}
```

**Status derivation:** override wins when set; else `NOT_STARTED` when `pagesAnnotated === 0`, `IN_PROGRESS` when partial, `COMPLETED` when `pagesAnnotated >= pageCount`.

**Performance:** O(documents) — one query per shape (documents, verified-page count, hours, annotator counts, latest zone update, user names) instead of per-row aggregation. Comfortably under the 500ms target for the current 17-doc corpus.

### `PUT /api/v1/admin/corpus/documents/:documentId/status`

Auth: same as above. Body (Zod-validated, at least one field required):

```ts
{
  statusOverride?: AnnotationStatus | null;  // null clears the override
  statusNote?: string;                        // trimmed, max 500 chars
}
```

Stamps `statusUpdatedAt = now()` and `statusUpdatedBy = req.user.id`. Returns the same row shape as one entry from the GET endpoint above (refetched so derived status is recomputed).

Status codes: `400` invalid body / both fields missing, `401` unauthenticated, `403` non-admin/operator, `404` document not found.

## Test plan

- [x] 27 new Vitest unit tests, all passing
  - Service: derivation branches, override-takes-precedence, BigInt page counts, system-id annotator filtering, hours math, lastUpdatedAt fallback, null-pageCount edge case
  - Controller: 401/403/400/404 paths, happy path, `statusOverride: null` clear path
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean on all touched files
- [x] Pre-existing failures in `workflow-config.integration.test.ts` and `workflow-websocket.test.ts` are unchanged from main (verified by checking out main and re-running)
- [ ] Migration apply on staging via the existing deploy workflow
- [ ] Manual `curl` against staging `GET /corpus-status` after deploy, response handed to the frontend agent for contract confirmation

## Out of scope (per spec)

Audit trail / change-log endpoints, Slack notifications, status webhooks, bulk edit endpoints, server-side CSV export (frontend handles CSV via `Blob`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Corpus status dashboard for calibration documents showing pages annotated, primary annotator, other annotator count, hours spent, and last-updated timestamp.
  * Operators and administrators can view status and update a document’s status with an optional note or override; changes are audit-stamped.
* **Tests**
  * Added unit tests covering status derivation, listing, updates, validation, and controller behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->