### PR TITLE
fix(calibration): trust pagesReviewed from Mark Complete in corpus status

### DIFF
--- a/src/services/calibration/corpus-status.service.ts
+++ b/src/services/calibration/corpus-status.service.ts
@@ -125,23 +125,33 @@ export async function listCorpusStatus(): Promise<CorpusStatusListResponse> {
   //      reviewing, including pages where they agreed with every AI label
   //      (which leave no operatorVerified=true zones behind).
   //   2. distinct count of pageNumbers with operatorVerified=true is the
-  //      fallback for runs still in progress (no Mark Complete yet).
-  // For documents with multiple completed runs we trust the most recently
-  // completed one — that's the latest pass over the document.
-  const pagesReviewedByDoc = new Map<string, number>();
-  const latestCompletedAtByDoc = new Map<string, Date>();
+  //      fallback for runs still in progress (no Mark Complete yet) AND
+  //      for documents whose latest completed run is missing
+  //      `pagesReviewed` (e.g. completed via a legacy / partial-bodied
+  //      client) — using a stale `pagesReviewed` from an older run would
+  //      mask the latest reality.
+  // We pick the latest completed run by completedAt regardless of whether
+  // it carries pagesReviewed; pagesReviewedByDoc is populated only when
+  // that latest run actually has a usable pagesReviewed value.
+  const latestCompletedRunByDoc = new Map<
+    string,
+    { completedAt: Date; pagesReviewed: number | null }
+  >();
   for (const r of runs) {
-    if (
-      r.completedAt == null ||
-      r.pagesReviewed == null ||
-      r.pagesReviewed < 0
-    ) {
-      continue;
+    if (r.completedAt == null) continue;
+    const current = latestCompletedRunByDoc.get(r.documentId);
+    if (!current || r.completedAt > current.completedAt) {
+      latestCompletedRunByDoc.set(r.documentId, {
+        completedAt: r.completedAt,
+        pagesReviewed: r.pagesReviewed,
+      });
     }
-    const current = latestCompletedAtByDoc.get(r.documentId);
-    if (!current || r.completedAt > current) {
-      latestCompletedAtByDoc.set(r.documentId, r.completedAt);
-      pagesReviewedByDoc.set(r.documentId, r.pagesReviewed);
+  }
+
+  const pagesReviewedByDoc = new Map<string, number>();
+  for (const [docId, latest] of latestCompletedRunByDoc) {
+    if (latest.pagesReviewed != null && latest.pagesReviewed >= 0) {
+      pagesReviewedByDoc.set(docId, latest.pagesReviewed);
     }
   }
 

--- a/src/services/calibration/corpus-status.service.ts
+++ b/src/services/calibration/corpus-status.service.ts
@@ -95,10 +95,17 @@ export async function listCorpusStatus(): Promise<CorpusStatusListResponse> {
 
   const documentIds = documents.map((d) => d.id);
 
-  // Map of documentId -> [calibrationRunIds]
+  // Map of documentId -> [calibrationRunIds]. Also pull pagesReviewed +
+  // completedAt so we can prefer the operator-stated page count from Mark
+  // Complete over the operatorVerified-zone heuristic below.
   const runs = await prisma.calibrationRun.findMany({
     where: { documentId: { in: documentIds } },
-    select: { id: true, documentId: true },
+    select: {
+      id: true,
+      documentId: true,
+      pagesReviewed: true,
+      completedAt: true,
+    },
   });
 
   const runIdsByDoc = new Map<string, string[]>();
@@ -111,6 +118,32 @@ export async function listCorpusStatus(): Promise<CorpusStatusListResponse> {
   }
 
   const allRunIds = runs.map((r) => r.id);
+
+  // Page-count signal precedence:
+  //   1. operator-stated `pagesReviewed` (set via Mark Complete) is
+  //      authoritative — it's what the annotator actually committed to
+  //      reviewing, including pages where they agreed with every AI label
+  //      (which leave no operatorVerified=true zones behind).
+  //   2. distinct count of pageNumbers with operatorVerified=true is the
+  //      fallback for runs still in progress (no Mark Complete yet).
+  // For documents with multiple completed runs we trust the most recently
+  // completed one — that's the latest pass over the document.
+  const pagesReviewedByDoc = new Map<string, number>();
+  const latestCompletedAtByDoc = new Map<string, Date>();
+  for (const r of runs) {
+    if (
+      r.completedAt == null ||
+      r.pagesReviewed == null ||
+      r.pagesReviewed < 0
+    ) {
+      continue;
+    }
+    const current = latestCompletedAtByDoc.get(r.documentId);
+    if (!current || r.completedAt > current) {
+      latestCompletedAtByDoc.set(r.documentId, r.completedAt);
+      pagesReviewedByDoc.set(r.documentId, r.pagesReviewed);
+    }
+  }
 
   // Aggregations only run when there is at least one calibration run; otherwise
   // every doc is NOT_STARTED with zero hours.
@@ -205,7 +238,12 @@ export async function listCorpusStatus(): Promise<CorpusStatusListResponse> {
   const userById = new Map(users.map((u) => [u.id, u]));
 
   const rows: CorpusStatusRow[] = documents.map((doc, i) => {
-    const pagesAnnotated = pagesAnnotatedByDoc.get(doc.id) ?? 0;
+    // operator-stated pagesReviewed (set via Mark Complete) is authoritative;
+    // the verified-zone count is a fallback for runs still in progress.
+    const pagesAnnotated =
+      pagesReviewedByDoc.get(doc.id) ??
+      pagesAnnotatedByDoc.get(doc.id) ??
+      0;
     const overrideRaw = doc.statusOverride;
     const statusOverride =
       overrideRaw && isAnnotationStatus(overrideRaw) ? overrideRaw : null;

--- a/tests/unit/services/calibration/corpus-status.service.test.ts
+++ b/tests/unit/services/calibration/corpus-status.service.test.ts
@@ -325,6 +325,49 @@ describe('listCorpusStatus', () => {
     expect(result.rows[0].status).toBe('IN_PROGRESS');
   });
 
+  it('falls back to verified-zone count when the LATEST completed run is missing pagesReviewed even if an older run has it', async () => {
+    // Regression: don't let a stale pagesReviewed from an older run mask
+    // the latest reality (e.g. legacy/partial-bodied Mark Complete client).
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'multi-run.pdf',
+        pageCount: 295,
+        uploadedAt: new Date('2026-02-01'),
+        statusNote: null,
+        statusOverride: null,
+        statusUpdatedAt: null,
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([
+      {
+        id: 'run-old',
+        documentId: 'doc1',
+        pagesReviewed: 100,
+        completedAt: new Date('2026-04-01T10:00:00Z'),
+      },
+      {
+        id: 'run-new',
+        documentId: 'doc1',
+        pagesReviewed: null,
+        completedAt: new Date('2026-05-01T10:00:00Z'),
+      },
+    ]);
+    mQueryRaw.mockResolvedValue([
+      { calibrationRunId: 'run-old', pagesAnnotated: BigInt(80) },
+      { calibrationRunId: 'run-new', pagesAnnotated: BigInt(200) },
+    ]);
+    mSessionGroupBy.mockResolvedValue([]);
+    mZoneGroupBy.mockResolvedValue([]);
+    mUserFindMany.mockResolvedValue([]);
+
+    const result = await listCorpusStatus();
+    // Must not pick up the stale 100 from run-old; falls back to the
+    // verified-zone aggregate across runs (80 + 200 = 280).
+    expect(result.rows[0].pagesAnnotated).toBe(280);
+    expect(result.rows[0].status).toBe('IN_PROGRESS');
+  });
+
   it('falls back to verified-zone count when run has pagesReviewed but no completedAt (defensive)', async () => {
     mDocFindMany.mockResolvedValue([
       {

--- a/tests/unit/services/calibration/corpus-status.service.test.ts
+++ b/tests/unit/services/calibration/corpus-status.service.test.ts
@@ -223,6 +223,158 @@ describe('listCorpusStatus', () => {
     const result = await listCorpusStatus();
     expect(result.rows[0].status).toBe('COMPLETED');
   });
+
+  it('uses pagesReviewed from the most recent completed run when both signals exist', async () => {
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'aulakh.pdf',
+        pageCount: 295,
+        uploadedAt: new Date('2026-03-01'),
+        statusNote: null,
+        statusOverride: null,
+        statusUpdatedAt: null,
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([
+      {
+        id: 'run1',
+        documentId: 'doc1',
+        pagesReviewed: 295,
+        completedAt: new Date('2026-05-01T12:00:00Z'),
+      },
+    ]);
+    // The verified-zone heuristic would say 50, but pagesReviewed wins.
+    mQueryRaw.mockResolvedValue([
+      { calibrationRunId: 'run1', pagesAnnotated: BigInt(50) },
+    ]);
+    mSessionGroupBy.mockResolvedValue([]);
+    mZoneGroupBy.mockResolvedValue([]);
+    mUserFindMany.mockResolvedValue([]);
+
+    const result = await listCorpusStatus();
+    expect(result.rows[0].pagesAnnotated).toBe(295);
+    expect(result.rows[0].status).toBe('COMPLETED');
+  });
+
+  it('most-recent-completed run wins when there are multiple completed runs', async () => {
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'multi-run.pdf',
+        pageCount: 295,
+        uploadedAt: new Date('2026-02-01'),
+        statusNote: null,
+        statusOverride: null,
+        statusUpdatedAt: null,
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([
+      {
+        id: 'run-old',
+        documentId: 'doc1',
+        pagesReviewed: 100,
+        completedAt: new Date('2026-04-01T10:00:00Z'),
+      },
+      {
+        id: 'run-new',
+        documentId: 'doc1',
+        pagesReviewed: 295,
+        completedAt: new Date('2026-05-01T10:00:00Z'),
+      },
+    ]);
+    mQueryRaw.mockResolvedValue([]);
+    mSessionGroupBy.mockResolvedValue([]);
+    mZoneGroupBy.mockResolvedValue([]);
+    mUserFindMany.mockResolvedValue([]);
+
+    const result = await listCorpusStatus();
+    expect(result.rows[0].pagesAnnotated).toBe(295);
+    expect(result.rows[0].status).toBe('COMPLETED');
+  });
+
+  it('falls back to verified-zone count when no run has pagesReviewed', async () => {
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'inflight.pdf',
+        pageCount: 200,
+        uploadedAt: new Date('2026-04-15'),
+        statusNote: null,
+        statusOverride: null,
+        statusUpdatedAt: null,
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([
+      {
+        id: 'run1',
+        documentId: 'doc1',
+        pagesReviewed: null,
+        completedAt: null,
+      },
+    ]);
+    mQueryRaw.mockResolvedValue([
+      { calibrationRunId: 'run1', pagesAnnotated: BigInt(50) },
+    ]);
+    mSessionGroupBy.mockResolvedValue([]);
+    mZoneGroupBy.mockResolvedValue([]);
+    mUserFindMany.mockResolvedValue([]);
+
+    const result = await listCorpusStatus();
+    expect(result.rows[0].pagesAnnotated).toBe(50);
+    expect(result.rows[0].status).toBe('IN_PROGRESS');
+  });
+
+  it('falls back to verified-zone count when run has pagesReviewed but no completedAt (defensive)', async () => {
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'half-marked.pdf',
+        pageCount: 200,
+        uploadedAt: new Date('2026-04-15'),
+        statusNote: null,
+        statusOverride: null,
+        statusUpdatedAt: null,
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([
+      {
+        id: 'run1',
+        documentId: 'doc1',
+        pagesReviewed: 295,
+        completedAt: null,
+      },
+    ]);
+    mQueryRaw.mockResolvedValue([
+      { calibrationRunId: 'run1', pagesAnnotated: BigInt(75) },
+    ]);
+    mSessionGroupBy.mockResolvedValue([]);
+    mZoneGroupBy.mockResolvedValue([]);
+    mUserFindMany.mockResolvedValue([]);
+
+    const result = await listCorpusStatus();
+    expect(result.rows[0].pagesAnnotated).toBe(75);
+    expect(result.rows[0].status).toBe('IN_PROGRESS');
+  });
+
+  it('document with no runs at all stays NOT_STARTED', async () => {
+    mDocFindMany.mockResolvedValue([
+      {
+        id: 'doc1',
+        filename: 'fresh.pdf',
+        pageCount: 100,
+        uploadedAt: new Date('2026-05-08'),
+        statusNote: null,
+        statusOverride: null,
+        statusUpdatedAt: null,
+      },
+    ]);
+    mRunFindMany.mockResolvedValue([]);
+
+    const result = await listCorpusStatus();
+    expect(result.rows[0].pagesAnnotated).toBe(0);
+    expect(result.rows[0].status).toBe('NOT_STARTED');
+  });
 });
 
 describe('updateDocumentStatus', () => {


### PR DESCRIPTION
## Summary

The Status Tracker tab was leaving 16 of 17 production runs on "In Progress" — even after annotators completed them — forcing the calibration team to apply manual status overrides on almost every row.

**Root cause:** `listCorpusStatus()` derived `pagesAnnotated` solely from a `COUNT(DISTINCT pageNumber)` query against `Zone` rows where `operatorVerified = true`. But annotators only flip `operatorVerified` when they correct an AI label — pages where they agreed with every AI decision (especially AI-rejected artifact pages) leave no verified zone behind, so those pages did not count.

**Fix:** Promote `CalibrationRun.pagesReviewed` (the operator-stated page count submitted via Mark Complete) to the canonical signal:

1. Augmented the existing `prisma.calibrationRun.findMany` select to also pull `pagesReviewed` + `completedAt`.
2. Built `pagesReviewedByDoc: Map<string, number>` keyed on the **most recently completed run** per document, with guards (`completedAt != null`, `pagesReviewed != null`, `pagesReviewed >= 0`).
3. In the row build, use the new map first; fall back to the existing verified-zone count for runs that haven't hit Mark Complete yet.

Read the inline code comments for the precedence ordering.

## What did NOT change

- ✅ **No schema change**, no migration, no Prisma client regenerate
- ✅ **No API contract change** — same response shape
- ✅ **No frontend change** — Status Tracker tab consumes the same field
- ✅ **`deriveStatus()` untouched** — once `pagesAnnotated` reflects the real total, the existing `pagesAnnotated >= pageCount` branch returns `COMPLETED`
- ✅ **Primary-annotator pill** still derives from operatorVerified zone counts (unchanged) — that's attribution, not coverage
- ✅ **Manual override** (`PUT /admin/corpus/documents/:id/status`) still works unchanged as the escape hatch

## Test plan

- [x] 5 new unit tests in `tests/unit/services/calibration/corpus-status.service.test.ts`:
  - `pagesReviewed` from the most recent completed run takes precedence even when the verified-zone count is lower
  - Most-recent-completed wins when there are multiple completed runs (older `pagesReviewed=100`, newer `pagesReviewed=295` → 295)
  - Falls back to verified-zone count when `pagesReviewed`/`completedAt` are null (in-flight run)
  - Defensive fallback when `pagesReviewed` is set but `completedAt` is null
  - Regression: doc with no runs at all still returns `pagesAnnotated=0` / `NOT_STARTED`
- [x] 32 corpus-status tests pass (5 new + 27 existing)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean on changed files
- [x] Full test suite: 1025 passing (was 1020), same 7 pre-existing integration-test failures in `workflow-config.integration.test.ts` / `workflow-websocket.test.ts` that exist on main (verified). Zero regressions introduced.

## Verification on staging (after merge + deploy)

1. Hit `GET /api/v1/calibration/corpus-status` with admin auth.
2. Confirm rows for runs that have been Mark-Complete'd show `pagesAnnotated == pageCount` and `status == "COMPLETED"`.
3. Calibration team should be able to clear most of the existing `BLOCKED`/`COMPLETED` overrides via `PUT /admin/corpus/documents/:id/status` with `{ statusOverride: null }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Corpus status metrics now prioritize operator-reported page counts from the most recent completed calibration run, giving more accurate document completion progress.
  * Falls back to previous verification-derived counts or zero when operator data is missing, keeping status reporting consistent.
* **Tests**
  * Added unit tests covering multi-run selection, fallback behavior, and edge cases for status and page-count computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->