### PR TITLE
feat(epub): publisher-profile detector foundation (PRH UK)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -1,0 +1,175 @@
+/**
+ * Registry of PRH UK profile-specific issue codes.
+ *
+ * PR1 (this file) defines the codes only. Validators that emit them land in
+ * PR2 (metadata + spine), PR3 (nav + per-XHTML), and PR4 (image specifics).
+ *
+ * Convention: `PRH-<AREA>-<CHECK>`. Severities use the same vocabulary as the
+ * existing audit pipeline (`critical | serious | moderate | minor`). WCAG
+ * mappings are merged into `wcag-issue-mapper.service.ts` in the PR that
+ * actually starts emitting the code, so this file is the single source of
+ * truth for downstream consumers.
+ */
+
+import type { FixType } from './fix-classification';
+
+export type PrhIssueSeverity = 'critical' | 'serious' | 'moderate' | 'minor';
+
+export interface PrhIssueDefinition {
+  code: string;
+  severity: PrhIssueSeverity;
+  /** WCAG criteria this maps to. Empty when the rule is publisher-specific (no WCAG analogue). */
+  wcag: string[];
+  /** Fix mode the auto-remediation pipeline should treat this as. */
+  fixType: FixType;
+  /** Short human-readable summary used in the UI / logs. */
+  summary: string;
+}
+
+export const PRH_ISSUE_CODES = {
+  // ── Metadata (PR2) ─────────────────────────────────────────────────────
+  'PRH-META-CONFORMS-TO': {
+    code: 'PRH-META-CONFORMS-TO',
+    severity: 'moderate',
+    wcag: ['4.1.2'],
+    fixType: 'auto',
+    summary: 'OPF dcterms:conformsTo must be "EPUB Accessibility 1.1 - WCAG 2.2 Level AA"',
+  },
+  'PRH-META-CERTIFIED-BY': {
+    code: 'PRH-META-CERTIFIED-BY',
+    severity: 'moderate',
+    wcag: ['4.1.2'],
+    fixType: 'auto',
+    summary: 'OPF a11y:certifiedBy must be "Penguin Random House UK"',
+  },
+  'PRH-META-CERTIFIER-CRED': {
+    code: 'PRH-META-CERTIFIER-CRED',
+    severity: 'moderate',
+    wcag: ['4.1.2'],
+    fixType: 'auto',
+    summary: 'OPF a11y:certifierCredential must be "Ace by DAISY OK"',
+  },
+  'PRH-META-CERTIFIER-LINK': {
+    code: 'PRH-META-CERTIFIER-LINK',
+    severity: 'moderate',
+    wcag: ['4.1.2'],
+    fixType: 'auto',
+    summary: 'OPF must include <link rel="a11y:certifierCredential" href="https://daisy.github.io/ace"/>',
+  },
+  'PRH-META-TDM-RESERVATION': {
+    code: 'PRH-META-TDM-RESERVATION',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'auto',
+    summary: 'OPF must declare <meta property="tdm:reservation">1</meta> with the tdm: prefix',
+  },
+  'PRH-META-A11Y-SUMMARY-URL': {
+    code: 'PRH-META-A11Y-SUMMARY-URL',
+    severity: 'minor',
+    wcag: ['4.1.2'],
+    fixType: 'auto',
+    summary: 'OPF accessibilitySummary must reference penguin.co.uk/accessibility',
+  },
+
+  // ── Spine (PR2) ────────────────────────────────────────────────────────
+  'PRH-SPINE-COVER-LINEAR': {
+    code: 'PRH-SPINE-COVER-LINEAR',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Cover spine entry must have linear="no"',
+  },
+  'PRH-SPINE-FOOTNOTES-LAST': {
+    code: 'PRH-SPINE-FOOTNOTES-LAST',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Footnotes file must be the last entry in the spine and marked linear="no"',
+  },
+
+  // ── Nav (PR3) ──────────────────────────────────────────────────────────
+  'PRH-NAV-MISSING-PAGELIST': {
+    code: 'PRH-NAV-MISSING-PAGELIST',
+    severity: 'moderate',
+    wcag: ['2.4.5'],
+    fixType: 'manual',
+    summary: 'nav.xhtml must include a <nav epub:type="page-list"> block',
+  },
+  'PRH-NAV-PAGELIST-NOT-HIDDEN': {
+    code: 'PRH-NAV-PAGELIST-NOT-HIDDEN',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'page-list nav must be hidden via hidden="hidden" AND class="hidden_content"',
+  },
+  'PRH-NAV-LANDMARKS-MISSING-COVER': {
+    code: 'PRH-NAV-LANDMARKS-MISSING-COVER',
+    severity: 'minor',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'landmarks nav must include an entry with epub:type="cover"',
+  },
+  'PRH-NAV-LANDMARKS-MISSING-FRONTMATTER': {
+    code: 'PRH-NAV-LANDMARKS-MISSING-FRONTMATTER',
+    severity: 'minor',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'landmarks nav must include an entry with epub:type="frontmatter"',
+  },
+  'PRH-NAV-LANDMARKS-MISSING-TOC': {
+    code: 'PRH-NAV-LANDMARKS-MISSING-TOC',
+    severity: 'minor',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'landmarks nav must include an entry with epub:type="toc"',
+  },
+  'PRH-NAV-LANDMARKS-MISSING-BODYMATTER': {
+    code: 'PRH-NAV-LANDMARKS-MISSING-BODYMATTER',
+    severity: 'minor',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'landmarks nav must include an entry with epub:type="bodymatter"',
+  },
+
+  // ── Per-XHTML (PR3) ────────────────────────────────────────────────────
+  'PRH-XHTML-XML-LANG': {
+    code: 'PRH-XHTML-XML-LANG',
+    severity: 'moderate',
+    wcag: ['3.1.1'],
+    fixType: 'auto',
+    summary: 'Every XHTML <html> must carry both lang and xml:lang attributes',
+  },
+  'PRH-XHTML-TITLE-EMPTY-OR-GENERIC': {
+    code: 'PRH-XHTML-TITLE-EMPTY-OR-GENERIC',
+    severity: 'minor',
+    wcag: ['2.4.2'],
+    fixType: 'manual',
+    summary: '<head><title> must include a chapter or section identifier, not just the book title',
+  },
+
+  // ── Image (PR4) ────────────────────────────────────────────────────────
+  'PRH-COVER-ALT-EMPTY': {
+    code: 'PRH-COVER-ALT-EMPTY',
+    severity: 'serious',
+    wcag: ['1.1.1'],
+    fixType: 'quickfix',
+    summary: 'Cover image alt must be non-empty (e.g. "Cover for [Book Title]")',
+  },
+  'PRH-DECORATIVE-MISSING-PRESENTATION-ROLE': {
+    code: 'PRH-DECORATIVE-MISSING-PRESENTATION-ROLE',
+    severity: 'minor',
+    wcag: ['4.1.2'],
+    fixType: 'auto',
+    summary: 'Decorative images must declare role="presentation" alongside alt=""',
+  },
+} satisfies Record<string, PrhIssueDefinition>;
+
+export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;
+
+/** Type-safe lookup. Returns undefined if `code` is not a registered PRH code. */
+export function getPrhIssueDefinition(code: string): PrhIssueDefinition | undefined {
+  return (PRH_ISSUE_CODES as Record<string, PrhIssueDefinition>)[code];
+}
+
+/** All codes as a string list, useful for batch operations. */
+export const ALL_PRH_ISSUE_CODES: string[] = Object.keys(PRH_ISSUE_CODES);

--- a/src/services/epub/epub-audit.service.ts
+++ b/src/services/epub/epub-audit.service.ts
@@ -9,6 +9,8 @@ import prisma from '../../lib/prisma';
 import config from '../../config/index';
 import { epubJSAuditor } from './epub-js-auditor.service';
 import { callAceMicroservice } from './ace-client.service';
+import { detectPublisherProfile } from './profiles/profile-detector.service';
+import type { PublisherProfile } from './profiles/types';
 import { captureIssueSnapshot, compareSnapshots, clearSnapshots } from '../../utils/issue-flow-logger';
 import { getFixType } from '../../constants/fix-classification';
 import { s3Service } from '../s3.service';
@@ -117,6 +119,12 @@ interface EpubAuditResult {
     manualRequired: number;
   };
   accessibilityMetadata: AceResult['metadata'] | null;
+  /**
+   * Publisher profile detected for this EPUB (e.g. PRH UK + Penguin imprint).
+   * `publisher: null` means no profile matched — downstream PRH validators
+   * (PR2+) should be skipped in that case.
+   */
+  publisherProfile: PublisherProfile;
   coverage: {
     totalFiles: number;
     filesScanned: number;
@@ -354,6 +362,15 @@ class EpubAuditService {
       logger.info(`  Quick-fixable: ${classificationStats.quickFixable}`);
       logger.info(`  Manual required: ${classificationStats.manualRequired}`);
 
+      // Detect publisher profile (e.g. PRH UK + imprint). Best-effort —
+      // detection failures fall back to NO_PROFILE without breaking the audit.
+      const publisherProfile = await detectPublisherProfile(buffer);
+      if (publisherProfile.publisher) {
+        logger.info(
+          `[Profile] Detected ${publisherProfile.publisher} (imprint=${publisherProfile.imprint}, confidence=${publisherProfile.confidence}, signals=${publisherProfile.signals.length})`,
+        );
+      }
+
       // Calculate coverage
       const coverage = this.calculateCoverage(buffer);
       logger.info(`📊 Audit Coverage: ${coverage.filesScanned}/${coverage.totalFiles} files (${coverage.percentage}%)`);
@@ -380,6 +397,7 @@ class EpubAuditService {
         summaryBySource,
         classificationStats,
         accessibilityMetadata: aceResult?.metadata || null,
+        publisherProfile,
         coverage,
         auditedAt: new Date(),
       };

--- a/src/services/epub/profiles/prh-uk/imprint-detector.ts
+++ b/src/services/epub/profiles/prh-uk/imprint-detector.ts
@@ -1,0 +1,212 @@
+/**
+ * PRH UK imprint detector.
+ *
+ * Decides whether an EPUB looks like a PRH-UK deliverable, and if so which
+ * imprint (Penguin / Puffin / Vintage / Pelican / Ladybird / #Merky /
+ * Cornerstone Saga). The detection is signal-aggregating: each match adds to
+ * the result, and the caller (profile-detector) translates the strongest set
+ * of signals into a `PublisherProfile` with `confidence`.
+ *
+ * Inputs are deliberately decoupled from the EPUB pipeline: the function
+ * accepts the parsed OPF text, the list of file paths in the zip, and an
+ * optional sample of XHTML content. This keeps the detector unit-testable
+ * without spinning up JSZip.
+ */
+
+import type { PrhImprint, ProfileSignal } from '../types';
+
+export interface ImprintDetectionInput {
+  /** Raw OPF (`package.opf`) content, as string. May be empty if absent. */
+  opfContent: string;
+  /** Every file path inside the EPUB zip (e.g. `EPUB/xhtml/cover.xhtml`). */
+  filePaths: string[];
+  /**
+   * Optional small sample of XHTML body content concatenated together. Used
+   * to look for imprint URLs (`penguin.co.uk`, etc.). The detector itself is
+   * cheap; the caller decides how much content to provide.
+   */
+  contentSample?: string;
+}
+
+export interface ImprintDetectionResult {
+  /** True if any PRH-UK signal matched at all. */
+  isPrhUk: boolean;
+  /** Best-guess imprint, or 'unknown' if PRH-UK matched but no imprint did. */
+  imprint: PrhImprint | null;
+  /** Every signal that contributed, in detection order. */
+  signals: ProfileSignal[];
+}
+
+const PUBLISHER_PATTERNS = {
+  /** dc:publisher or dc:creator strings indicating PRH-UK ownership. */
+  publisherText: [
+    /penguin random house/i,
+    /penguin books/i,
+    /penguin random house uk/i,
+  ],
+};
+
+const IMPRINT_PATTERNS: Record<PrhImprint, {
+  /** File-name fragments that identify the imprint (e.g. cover assets). */
+  filePathFragments: string[];
+  /** Body / OPF text fragments that identify the imprint. */
+  textFragments: RegExp[];
+  /** URL fragments unique to this imprint. */
+  urlFragments: string[];
+}> = {
+  penguin: {
+    filePathFragments: ['penguin-cover', 'penguin/title', 'penguin/brand'],
+    // "Penguin" alone matches inside "Penguin Random House", which is the
+    // publisher, not the imprint — every PRH-UK book carries that string in
+    // dc:publisher regardless of which line published it. Use negative
+    // lookahead so we don't pin "penguin" the imprint to that phrase.
+    textFragments: [/\bpenguin\b(?!\s+random\s+house)/i, /font-penguin/i],
+    urlFragments: ['penguin.co.uk', 'penguinukbooks'],
+  },
+  puffin: {
+    filePathFragments: ['puffin-cover', 'puffin/', 'puffin_logo'],
+    textFragments: [/\bpuffin\b/i, /font-puffin/i, /puffinBeaky/i],
+    urlFragments: ['puffin.co.uk', 'puffinbooks'],
+  },
+  vintage: {
+    filePathFragments: ['vintage-cover', 'vintage/', 'font-vintage'],
+    textFragments: [/\bvintage books\b/i, /font-vintage/i],
+    urlFragments: ['vintage-books.co.uk', 'penguin.co.uk/vintage', 'vintagebooks'],
+  },
+  pelican: {
+    filePathFragments: ['pelican-cover', 'pelican/', 'font-pelican'],
+    textFragments: [/\bpelican books\b/i, /pelican_chapterheader/i],
+    urlFragments: [],
+  },
+  ladybird: {
+    filePathFragments: ['ladybird-cover', 'ladybird/', 'ladybird563'],
+    textFragments: [/\bladybird books\b/i, /ladybird563/i],
+    urlFragments: ['ladybird.co.uk'],
+  },
+  merky: {
+    filePathFragments: ['merkybooks/', 'merky_'],
+    textFragments: [/#merky books/i, /merky books/i],
+    urlFragments: [],
+  },
+  'cornerstone-saga': {
+    filePathFragments: ['cornerstone-saga/', 'penny_street', 'pennylogo'],
+    textFragments: [/penny street/i, /welcome to penny street/i],
+    urlFragments: ['penguin.co.uk/pennystreet', 'welcometopennystreet'],
+  },
+  unknown: { filePathFragments: [], textFragments: [], urlFragments: [] },
+};
+
+/** PRH-shared assets — finding `prh_core_assets/` is a strong PRH signal. */
+const PRH_CORE_ASSETS_PATH_FRAGMENT = 'prh_core_assets';
+const PRH_UK_LOGO_PATH_FRAGMENT = 'prh_uk_logo';
+
+/**
+ * Detect whether an EPUB carries PRH-UK profile signals. Pure function over
+ * the inputs — no I/O.
+ */
+export function detectPrhImprint(
+  input: ImprintDetectionInput,
+): ImprintDetectionResult {
+  const signals: ProfileSignal[] = [];
+  const opf = input.opfContent ?? '';
+  const sample = input.contentSample ?? '';
+  const paths = input.filePaths ?? [];
+
+  // ── Publisher-level signals ──────────────────────────────────────────
+  for (const re of PUBLISHER_PATTERNS.publisherText) {
+    if (re.test(opf)) {
+      signals.push({
+        id: 'publisher-text-opf',
+        description: `OPF contains publisher text matching ${re}`,
+        strength: 'strong',
+      });
+      break;
+    }
+  }
+
+  // prh_core_assets directory anywhere in the zip — a near-certain PRH signal.
+  if (paths.some((p) => p.toLowerCase().includes(PRH_CORE_ASSETS_PATH_FRAGMENT))) {
+    signals.push({
+      id: 'prh-core-assets-path',
+      description: `Zip contains ${PRH_CORE_ASSETS_PATH_FRAGMENT}/ directory`,
+      strength: 'strong',
+    });
+  }
+
+  // PRH UK logo asset.
+  if (paths.some((p) => p.toLowerCase().includes(PRH_UK_LOGO_PATH_FRAGMENT))) {
+    signals.push({
+      id: 'prh-uk-logo-asset',
+      description: 'Zip contains a prh_uk_logo asset',
+      strength: 'moderate',
+    });
+  }
+
+  // ── Imprint-level signals ────────────────────────────────────────────
+  // Score each imprint independently so the caller can pick the strongest.
+  const imprintScores = new Map<PrhImprint, number>();
+
+  for (const [imprintRaw, patterns] of Object.entries(IMPRINT_PATTERNS)) {
+    const imprint = imprintRaw as PrhImprint;
+    if (imprint === 'unknown') continue;
+
+    let score = 0;
+
+    for (const fragment of patterns.filePathFragments) {
+      if (paths.some((p) => p.toLowerCase().includes(fragment.toLowerCase()))) {
+        score += 2;
+        signals.push({
+          id: `imprint-path-${imprint}`,
+          description: `File path contains "${fragment}" (${imprint})`,
+          strength: 'strong',
+        });
+      }
+    }
+
+    for (const re of patterns.textFragments) {
+      if (re.test(opf) || re.test(sample)) {
+        score += 1;
+        signals.push({
+          id: `imprint-text-${imprint}-${re.source.slice(0, 12)}`,
+          description: `Content matches "${re}" (${imprint})`,
+          strength: 'moderate',
+        });
+      }
+    }
+
+    for (const url of patterns.urlFragments) {
+      if (opf.toLowerCase().includes(url) || sample.toLowerCase().includes(url)) {
+        score += 1;
+        signals.push({
+          id: `imprint-url-${imprint}-${url.replace(/[^a-z0-9]/gi, '-')}`,
+          description: `Content references ${url} (${imprint})`,
+          strength: 'weak',
+        });
+      }
+    }
+
+    if (score > 0) imprintScores.set(imprint, score);
+  }
+
+  // Pick the imprint with the highest score; ties resolve by first-seen
+  // (Object.entries preserves insertion order in modern engines).
+  let topImprint: PrhImprint | null = null;
+  let topScore = 0;
+  for (const [imprint, score] of imprintScores) {
+    if (score > topScore) {
+      topScore = score;
+      topImprint = imprint;
+    }
+  }
+
+  const isPrhUk = signals.length > 0;
+
+  // If we have publisher-level evidence but no imprint matched cleanly, mark
+  // the imprint as 'unknown' so callers know we recognised PRH but couldn't
+  // pin down the line.
+  const imprint: PrhImprint | null = isPrhUk
+    ? topImprint ?? 'unknown'
+    : null;
+
+  return { isPrhUk, imprint, signals };
+}

--- a/src/services/epub/profiles/prh-uk/imprint-detector.ts
+++ b/src/services/epub/profiles/prh-uk/imprint-detector.ts
@@ -56,12 +56,18 @@ const IMPRINT_PATTERNS: Record<PrhImprint, {
 }> = {
   penguin: {
     filePathFragments: ['penguin-cover', 'penguin/title', 'penguin/brand'],
-    // "Penguin" alone matches inside "Penguin Random House", which is the
-    // publisher, not the imprint — every PRH-UK book carries that string in
-    // dc:publisher regardless of which line published it. Use negative
-    // lookahead so we don't pin "penguin" the imprint to that phrase.
-    textFragments: [/\bpenguin\b(?!\s+random\s+house)/i, /font-penguin/i],
-    urlFragments: ['penguin.co.uk', 'penguinukbooks'],
+    // Match the actual imprint name "Penguin Books" (used as the [DIVISION]
+    // value in PRH adult copyright pages) and the imprint-specific CSS font
+    // family. Bare "penguin" is too noisy — it appears inside both
+    // "Penguin Random House" (the publisher, on every PRH EPUB) and the
+    // shared `penguin.co.uk` URL (used in the standard accessibility-summary
+    // metadata across all imprints).
+    textFragments: [/\bpenguin\s+books\b/i, /font-penguin/i],
+    // Bare `penguin.co.uk` is shared across PRH-UK (every PRH book's standard
+    // accessibility-summary points to penguin.co.uk/accessibility) — it is
+    // NOT a Penguin-imprint-only signal. The unique social handle is what
+    // distinguishes Penguin from sibling imprints.
+    urlFragments: ['penguinukbooks'],
   },
   puffin: {
     filePathFragments: ['puffin-cover', 'puffin/', 'puffin_logo'],

--- a/src/services/epub/profiles/prh-uk/index.ts
+++ b/src/services/epub/profiles/prh-uk/index.ts
@@ -1,0 +1,9 @@
+/**
+ * PRH UK profile module.
+ *
+ * PR1 (foundation): exposes the imprint detector only. Validators (metadata,
+ * spine, nav, per-XHTML, image) and remediators land in PR2-PR4.
+ */
+
+export { detectPrhImprint } from './imprint-detector';
+export type { ImprintDetectionInput, ImprintDetectionResult } from './imprint-detector';

--- a/src/services/epub/profiles/profile-detector.service.ts
+++ b/src/services/epub/profiles/profile-detector.service.ts
@@ -58,9 +58,11 @@ export async function detectPublisherProfile(
 async function readOpf(zip: JSZip): Promise<string> {
   const containerXml = await zip.file('META-INF/container.xml')?.async('text');
   if (!containerXml) return '';
-  const match = containerXml.match(/rootfile[^>]+full-path="([^"]+)"/);
+  // XML allows either quote style around attribute values; accept both.
+  const match = containerXml.match(/rootfile[^>]+full-path=(?:"([^"]+)"|'([^']+)')/);
   if (!match) return '';
-  const opfPath = match[1];
+  const opfPath = match[1] ?? match[2];
+  if (!opfPath) return '';
   return (await zip.file(opfPath)?.async('text')) ?? '';
 }
 

--- a/src/services/epub/profiles/profile-detector.service.ts
+++ b/src/services/epub/profiles/profile-detector.service.ts
@@ -58,8 +58,9 @@ export async function detectPublisherProfile(
 async function readOpf(zip: JSZip): Promise<string> {
   const containerXml = await zip.file('META-INF/container.xml')?.async('text');
   if (!containerXml) return '';
-  // XML allows either quote style around attribute values; accept both.
-  const match = containerXml.match(/rootfile[^>]+full-path=(?:"([^"]+)"|'([^']+)')/);
+  // XML allows either quote style around attribute values AND optional
+  // whitespace around the `=` sign — accept both.
+  const match = containerXml.match(/rootfile[^>]+full-path\s*=\s*(?:"([^"]+)"|'([^']+)')/);
   if (!match) return '';
   const opfPath = match[1] ?? match[2];
   if (!opfPath) return '';

--- a/src/services/epub/profiles/profile-detector.service.ts
+++ b/src/services/epub/profiles/profile-detector.service.ts
@@ -1,0 +1,115 @@
+/**
+ * Publisher profile detector — runs after the JS auditor, before validators
+ * downstream of the existing audit pipeline. Reads the EPUB once via JSZip
+ * (the JS auditor uses the same library) and dispatches to per-publisher
+ * sub-detectors. Today: PRH UK only.
+ *
+ * Returned profile attaches to `EpubAuditResult.publisherProfile` so the
+ * frontend (and PR2+ validators) can read it. When no profile is detected the
+ * function returns `NO_PROFILE` rather than null, so callers don't need to
+ * branch on undefined.
+ */
+
+import JSZip from 'jszip';
+import { logger } from '../../../lib/logger';
+import { NO_PROFILE, type DetectionConfidence, type ProfileSignal, type PublisherProfile } from './types';
+import { detectPrhImprint } from './prh-uk';
+
+/** How many bytes of body content to feed the detectors. Capped to keep this fast. */
+const CONTENT_SAMPLE_BYTES = 32 * 1024;
+
+/**
+ * Best-effort detection. Failures (corrupt zip, missing OPF, etc.) are caught
+ * and logged; the function returns `NO_PROFILE` rather than throwing so that
+ * a detection bug never breaks the surrounding audit.
+ */
+export async function detectPublisherProfile(
+  buffer: Buffer,
+): Promise<PublisherProfile> {
+  try {
+    const zip = await JSZip.loadAsync(buffer);
+
+    const opfContent = await readOpf(zip);
+    const filePaths = Object.keys(zip.files);
+    const contentSample = await readContentSample(zip);
+
+    // Today only one sub-detector. Future: dispatch to others and pick the
+    // strongest match.
+    const prh = detectPrhImprint({ opfContent, filePaths, contentSample });
+
+    if (!prh.isPrhUk) return NO_PROFILE;
+
+    const confidence = aggregateConfidence(prh.signals);
+
+    return {
+      publisher: 'PRH-UK',
+      imprint: prh.imprint,
+      confidence,
+      signals: prh.signals,
+    };
+  } catch (err) {
+    logger.warn(
+      `[profile-detector] detection failed; treating as no-profile: ${err instanceof Error ? err.message : 'unknown error'}`,
+    );
+    return NO_PROFILE;
+  }
+}
+
+async function readOpf(zip: JSZip): Promise<string> {
+  const containerXml = await zip.file('META-INF/container.xml')?.async('text');
+  if (!containerXml) return '';
+  const match = containerXml.match(/rootfile[^>]+full-path="([^"]+)"/);
+  if (!match) return '';
+  const opfPath = match[1];
+  return (await zip.file(opfPath)?.async('text')) ?? '';
+}
+
+async function readContentSample(zip: JSZip): Promise<string> {
+  const xhtmlPaths = Object.keys(zip.files)
+    .filter((p) => /\.(xhtml|html)$/i.test(p))
+    // Prefer cover/title/copyright/nav — those carry the strongest imprint
+    // signals for branded EPUBs.
+    .sort((a, b) => priority(a) - priority(b));
+
+  let collected = '';
+  for (const p of xhtmlPaths) {
+    if (collected.length >= CONTENT_SAMPLE_BYTES) break;
+    const content = await zip.file(p)?.async('text');
+    if (!content) continue;
+    collected += content;
+  }
+  return collected.slice(0, CONTENT_SAMPLE_BYTES);
+}
+
+function priority(path: string): number {
+  const lower = path.toLowerCase();
+  if (lower.includes('cover')) return 0;
+  if (lower.includes('title')) return 1;
+  if (lower.includes('copyright')) return 2;
+  if (lower.includes('nav')) return 3;
+  if (lower.includes('brand')) return 4;
+  return 5;
+}
+
+/**
+ * Translate the bag of per-signal strengths into a single confidence band.
+ *
+ * - **high**: at least one strong signal AND any second signal of any
+ *   strength. Mitigates false positives where a single mention of
+ *   "penguin.co.uk" would otherwise tip an EPUB into PRH territory.
+ * - **medium**: any single strong signal, OR multiple moderate signals.
+ * - **low**: any other detection (single moderate / single weak).
+ *
+ * Validators in PR2+ should treat `low` as advisory-only and only emit
+ * issues for `medium` or `high`.
+ */
+export function aggregateConfidence(signals: ProfileSignal[]): DetectionConfidence {
+  if (signals.length === 0) return 'low';
+  const strongCount = signals.filter((s) => s.strength === 'strong').length;
+  const moderateCount = signals.filter((s) => s.strength === 'moderate').length;
+
+  if (strongCount >= 1 && signals.length >= 2) return 'high';
+  if (strongCount >= 1) return 'medium';
+  if (moderateCount >= 2) return 'medium';
+  return 'low';
+}

--- a/src/services/epub/profiles/types.ts
+++ b/src/services/epub/profiles/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Publisher-profile types for the EPUB audit pipeline.
+ *
+ * A "publisher profile" identifies that an uploaded EPUB was prepared for a
+ * specific publisher (today: PRH UK; the shape generalises to others). When a
+ * profile is detected, downstream PRH-specific validators run alongside the
+ * standards-based audit (EPUBCheck + ACE + JS auditor); when no profile is
+ * detected, behaviour is unchanged.
+ */
+
+/** Known publisher identifiers. Open-ended — extend as profiles are added. */
+export type PublisherId = 'PRH-UK';
+
+/** PRH UK imprint identifiers. Extend as PRH adds imprints. */
+export type PrhImprint =
+  | 'penguin'
+  | 'puffin'
+  | 'vintage'
+  | 'pelican'
+  | 'ladybird'
+  | 'merky'
+  | 'cornerstone-saga'
+  | 'unknown';
+
+/**
+ * Detection confidence. `high` means multiple corroborating signals matched;
+ * `medium` is one strong signal; `low` is a single weak hint. Validators only
+ * run on `medium` or `high` to avoid false positives on EPUBs that incidentally
+ * mention a publisher URL.
+ */
+export type DetectionConfidence = 'high' | 'medium' | 'low';
+
+/**
+ * One observation that contributed to a detection result. Surfaced in the
+ * audit response so a reviewer can see WHY we believe the profile applies.
+ */
+export interface ProfileSignal {
+  /** Short kebab-case identifier — useful in logs and tests. */
+  id: string;
+  /** Human-readable description shown in the UI (e.g. "OPF dc:publisher matches Penguin Random House UK"). */
+  description: string;
+  /**
+   * Strength of this single signal. The detector aggregates strengths into the
+   * overall confidence.
+   */
+  strength: 'strong' | 'moderate' | 'weak';
+}
+
+export interface PublisherProfile {
+  /** `null` when no profile was detected with at least `low` confidence. */
+  publisher: PublisherId | null;
+  /** Imprint within the publisher; `'unknown'` when only the publisher matched. */
+  imprint: PrhImprint | null;
+  /** Aggregate confidence across all matched signals. */
+  confidence: DetectionConfidence;
+  /** Every signal that contributed to the result, in detection order. */
+  signals: ProfileSignal[];
+}
+
+/** Convenience: the "no profile detected" result. */
+export const NO_PROFILE: PublisherProfile = {
+  publisher: null,
+  imprint: null,
+  confidence: 'low',
+  signals: [],
+};

--- a/src/services/epub/profiles/types.ts
+++ b/src/services/epub/profiles/types.ts
@@ -57,10 +57,14 @@ export interface PublisherProfile {
   signals: ProfileSignal[];
 }
 
-/** Convenience: the "no profile detected" result. */
-export const NO_PROFILE: PublisherProfile = {
+/**
+ * Convenience: the "no profile detected" result. Frozen so accidental
+ * `NO_PROFILE.signals.push(...)` or property reassignment doesn't corrupt
+ * the shared constant for subsequent callers.
+ */
+export const NO_PROFILE: PublisherProfile = Object.freeze({
   publisher: null,
   imprint: null,
   confidence: 'low',
-  signals: [],
-};
+  signals: Object.freeze([] as ProfileSignal[]),
+}) as PublisherProfile;

--- a/tests/unit/services/epub/profiles/prh-uk/imprint-detector.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/imprint-detector.test.ts
@@ -115,6 +115,41 @@ describe('detectPrhImprint', () => {
     expect(result.imprint).toBe('penguin');
   });
 
+  it('does NOT pin a Vintage book as Penguin just because it carries the shared penguin.co.uk a11y URL', () => {
+    // Regression: every PRH-UK EPUB's accessibility-summary metadata
+    // references penguin.co.uk/accessibility regardless of imprint. That
+    // bare URL must not count as Penguin-imprint evidence — the
+    // imprint-specific signal here is `vintage-books.co.uk`.
+    const result = detectPrhImprint({
+      opfContent: `${PRH_PUBLISHER_OPF}
+        <meta property="schema:accessibilitySummary">
+          ... visit us at penguin.co.uk/accessibility ...
+        </meta>`,
+      filePaths: [
+        'EPUB/vintage/copyright.xhtml',
+        'EPUB/vintage/title.xhtml',
+      ],
+      contentSample: 'Find more at www.vintage-books.co.uk',
+    });
+    expect(result.imprint).toBe('vintage');
+  });
+
+  it('does NOT pin a generic PRH book as Penguin just because of the shared penguin.co.uk a11y URL', () => {
+    // No imprint-specific path/text/url evidence — only the publisher-level
+    // signal plus the shared accessibility URL. Should resolve to 'unknown',
+    // not 'penguin'.
+    const result = detectPrhImprint({
+      opfContent: `${PRH_PUBLISHER_OPF}
+        <meta property="schema:accessibilitySummary">
+          ... penguin.co.uk/accessibility ...
+        </meta>`,
+      filePaths: ['EPUB/xhtml/cover.xhtml'],
+      contentSample: '',
+    });
+    expect(result.isPrhUk).toBe(true);
+    expect(result.imprint).toBe('unknown');
+  });
+
   it('handles empty input without throwing', () => {
     const result = detectPrhImprint({
       opfContent: '',

--- a/tests/unit/services/epub/profiles/prh-uk/imprint-detector.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/imprint-detector.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { detectPrhImprint } from '../../../../../../src/services/epub/profiles/prh-uk/imprint-detector';
+
+const PRH_PUBLISHER_OPF = `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:publisher>Penguin Random House UK</dc:publisher>
+    <dc:title>Test Book</dc:title>
+  </metadata>
+</package>`;
+
+describe('detectPrhImprint', () => {
+  it('returns no PRH signals for a non-PRH EPUB', () => {
+    const result = detectPrhImprint({
+      opfContent: '<?xml version="1.0"?><package><metadata><dc:title>Random Book</dc:title></metadata></package>',
+      filePaths: ['EPUB/xhtml/cover.xhtml', 'EPUB/xhtml/chapter001.xhtml'],
+      contentSample: '<p>Just regular content with no publisher hints.</p>',
+    });
+    expect(result.isPrhUk).toBe(false);
+    expect(result.imprint).toBeNull();
+    expect(result.signals).toEqual([]);
+  });
+
+  it('detects PRH UK from a dc:publisher field alone', () => {
+    const result = detectPrhImprint({
+      opfContent: PRH_PUBLISHER_OPF,
+      filePaths: ['EPUB/xhtml/cover.xhtml'],
+      contentSample: '',
+    });
+    expect(result.isPrhUk).toBe(true);
+    expect(result.signals.find((s) => s.id === 'publisher-text-opf')).toBeDefined();
+    // Publisher matched but no imprint pinned → 'unknown'
+    expect(result.imprint).toBe('unknown');
+  });
+
+  it('treats a prh_core_assets/ path as a strong signal', () => {
+    const result = detectPrhImprint({
+      opfContent: '',
+      filePaths: ['EPUB/prh_core_assets/images/prh_uk_logo.jpg', 'EPUB/xhtml/cover.xhtml'],
+      contentSample: '',
+    });
+    expect(result.isPrhUk).toBe(true);
+    expect(result.signals.find((s) => s.id === 'prh-core-assets-path')).toBeDefined();
+  });
+
+  it('detects Penguin imprint via cover-asset filename', () => {
+    const result = detectPrhImprint({
+      opfContent: PRH_PUBLISHER_OPF,
+      filePaths: ['EPUB/images/penguin-cover.jpg', 'EPUB/Penguin/title.xhtml'],
+      contentSample: '',
+    });
+    expect(result.isPrhUk).toBe(true);
+    expect(result.imprint).toBe('penguin');
+  });
+
+  it('detects Puffin imprint via puffin/ path', () => {
+    const result = detectPrhImprint({
+      opfContent: PRH_PUBLISHER_OPF,
+      filePaths: ['EPUB/Puffin/title.xhtml', 'EPUB/images/puffin_logo.png'],
+      contentSample: '',
+    });
+    expect(result.isPrhUk).toBe(true);
+    expect(result.imprint).toBe('puffin');
+  });
+
+  it('detects Vintage imprint from text + URL combined', () => {
+    const result = detectPrhImprint({
+      opfContent: '<dc:publisher>Vintage Books</dc:publisher>',
+      filePaths: ['EPUB/vintage/copyright.xhtml'],
+      contentSample: 'Read Boldly. Visit penguin.co.uk/vintage for more.',
+    });
+    expect(result.isPrhUk).toBe(true);
+    expect(result.imprint).toBe('vintage');
+  });
+
+  it('detects Cornerstone Saga via Penny Street URL', () => {
+    const result = detectPrhImprint({
+      opfContent: '',
+      filePaths: ['EPUB/Cornerstone-saga/saga_socials.xhtml'],
+      contentSample: 'Sign up at penguin.co.uk/pennystreet',
+    });
+    expect(result.isPrhUk).toBe(true);
+    expect(result.imprint).toBe('cornerstone-saga');
+  });
+
+  it('picks the imprint with the highest score when multiple match weakly', () => {
+    // Stronger Puffin signals (file path = score 2 each, repeated) should
+    // win over a single weak Penguin URL match.
+    const result = detectPrhImprint({
+      opfContent: PRH_PUBLISHER_OPF,
+      filePaths: [
+        'EPUB/Puffin/title.xhtml',
+        'EPUB/Puffin/brand_page.xhtml',
+        'EPUB/images/puffin_logo.png',
+      ],
+      contentSample: 'A passing mention of penguin.co.uk',
+    });
+    expect(result.isPrhUk).toBe(true);
+    expect(result.imprint).toBe('puffin');
+  });
+
+  it('records a signal for every matched pattern (auditable trail)', () => {
+    const result = detectPrhImprint({
+      opfContent: PRH_PUBLISHER_OPF,
+      filePaths: [
+        'EPUB/prh_core_assets/images/prh_uk_logo.jpg',
+        'EPUB/Penguin/title.xhtml',
+        'EPUB/images/penguin-cover.jpg',
+      ],
+      contentSample: 'Visit twitter.com/penguinukbooks',
+    });
+    // Should have: publisher-text-opf + prh-core-assets-path + prh-uk-logo-asset
+    // + at least one imprint-path-penguin signal + url signal.
+    expect(result.signals.length).toBeGreaterThanOrEqual(4);
+    expect(result.imprint).toBe('penguin');
+  });
+
+  it('handles empty input without throwing', () => {
+    const result = detectPrhImprint({
+      opfContent: '',
+      filePaths: [],
+      contentSample: '',
+    });
+    expect(result.isPrhUk).toBe(false);
+    expect(result.imprint).toBeNull();
+    expect(result.signals).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/profile-detector.test.ts
+++ b/tests/unit/services/epub/profiles/profile-detector.test.ts
@@ -106,6 +106,26 @@ describe('detectPublisherProfile', () => {
     expect(profile.publisher).toBe('PRH-UK');
   });
 
+  it('parses container.xml with whitespace around the = sign', async () => {
+    // Regression: XML permits whitespace around attribute `=`. Detection
+    // must still succeed.
+    const zip = new JSZip();
+    zip.file(
+      'META-INF/container.xml',
+      `<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path = "EPUB/package.opf" media-type = "application/oebps-package+xml"/>
+  </rootfiles>
+</container>`,
+    );
+    zip.file('EPUB/package.opf', PENGUIN_OPF);
+    zip.file('EPUB/prh_core_assets/styles/basestyles.css', 'body { }');
+    const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+    const profile = await detectPublisherProfile(buffer);
+    expect(profile.publisher).toBe('PRH-UK');
+  });
+
   it('handles a missing OPF gracefully', async () => {
     // Build a zip with only the container.xml — no OPF file at the referenced path.
     const zip = new JSZip();

--- a/tests/unit/services/epub/profiles/profile-detector.test.ts
+++ b/tests/unit/services/epub/profiles/profile-detector.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import {
+  aggregateConfidence,
+  detectPublisherProfile,
+} from '../../../../../src/services/epub/profiles/profile-detector.service';
+import type { ProfileSignal } from '../../../../../src/services/epub/profiles/types';
+
+/** Build an in-memory EPUB zip buffer for a given fixture set. */
+async function buildEpub(files: Record<string, string>): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file(
+    'META-INF/container.xml',
+    `<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`,
+  );
+  for (const [path, content] of Object.entries(files)) {
+    zip.file(path, content);
+  }
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+const PENGUIN_OPF = `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Penguin Test</dc:title>
+    <dc:publisher>Penguin Random House UK</dc:publisher>
+  </metadata>
+</package>`;
+
+const NEUTRAL_OPF = `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Independent Book</dc:title>
+    <dc:publisher>Independent Press</dc:publisher>
+  </metadata>
+</package>`;
+
+describe('detectPublisherProfile', () => {
+  it('returns NO_PROFILE for an EPUB with no publisher signals', async () => {
+    const buffer = await buildEpub({
+      'EPUB/package.opf': NEUTRAL_OPF,
+      'EPUB/xhtml/cover.xhtml': '<html><body><h1>Cover</h1></body></html>',
+    });
+    const profile = await detectPublisherProfile(buffer);
+    expect(profile.publisher).toBeNull();
+    expect(profile.imprint).toBeNull();
+    expect(profile.signals).toEqual([]);
+  });
+
+  it('detects PRH UK + penguin imprint at high confidence with multiple signals', async () => {
+    const buffer = await buildEpub({
+      'EPUB/package.opf': PENGUIN_OPF,
+      'EPUB/prh_core_assets/images/prh_uk_logo.jpg': 'binary',
+      'EPUB/images/penguin-cover.jpg': 'binary',
+      'EPUB/Penguin/title.xhtml': '<html><body><h2>Author</h2></body></html>',
+      'EPUB/xhtml/cover.xhtml': '<html><body>Cover</body></html>',
+    });
+    const profile = await detectPublisherProfile(buffer);
+    expect(profile.publisher).toBe('PRH-UK');
+    expect(profile.imprint).toBe('penguin');
+    expect(profile.confidence).toBe('high');
+    expect(profile.signals.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns medium confidence for a single strong signal', async () => {
+    // prh_core_assets/ directory alone (no logo file inside) yields exactly
+    // one strong signal and nothing else — confidence should land on medium.
+    const buffer = await buildEpub({
+      'EPUB/package.opf': NEUTRAL_OPF,
+      'EPUB/prh_core_assets/styles/basestyles.css': 'body { }',
+    });
+    const profile = await detectPublisherProfile(buffer);
+    expect(profile.publisher).toBe('PRH-UK');
+    expect(profile.confidence).toBe('medium');
+  });
+
+  it('returns NO_PROFILE when the zip is corrupt', async () => {
+    const corrupt = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    const profile = await detectPublisherProfile(corrupt);
+    expect(profile.publisher).toBeNull();
+    expect(profile.signals).toEqual([]);
+  });
+
+  it('handles a missing OPF gracefully', async () => {
+    // Build a zip with only the container.xml — no OPF file at the referenced path.
+    const zip = new JSZip();
+    zip.file(
+      'META-INF/container.xml',
+      '<?xml version="1.0"?><container><rootfiles><rootfile full-path="missing.opf"/></rootfiles></container>',
+    );
+    const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+    const profile = await detectPublisherProfile(buffer);
+    expect(profile.publisher).toBeNull();
+  });
+});
+
+describe('aggregateConfidence', () => {
+  const strong = (id: string): ProfileSignal => ({ id, description: id, strength: 'strong' });
+  const moderate = (id: string): ProfileSignal => ({ id, description: id, strength: 'moderate' });
+  const weak = (id: string): ProfileSignal => ({ id, description: id, strength: 'weak' });
+
+  it('returns low for empty signals', () => {
+    expect(aggregateConfidence([])).toBe('low');
+  });
+
+  it('returns low for a single weak signal', () => {
+    expect(aggregateConfidence([weak('a')])).toBe('low');
+  });
+
+  it('returns low for a single moderate signal', () => {
+    expect(aggregateConfidence([moderate('a')])).toBe('low');
+  });
+
+  it('returns medium for a single strong signal', () => {
+    expect(aggregateConfidence([strong('a')])).toBe('medium');
+  });
+
+  it('returns medium for two moderate signals', () => {
+    expect(aggregateConfidence([moderate('a'), moderate('b')])).toBe('medium');
+  });
+
+  it('returns high for a strong signal plus any second signal', () => {
+    expect(aggregateConfidence([strong('a'), weak('b')])).toBe('high');
+    expect(aggregateConfidence([strong('a'), moderate('b')])).toBe('high');
+    expect(aggregateConfidence([strong('a'), strong('b')])).toBe('high');
+  });
+});

--- a/tests/unit/services/epub/profiles/profile-detector.test.ts
+++ b/tests/unit/services/epub/profiles/profile-detector.test.ts
@@ -86,6 +86,26 @@ describe('detectPublisherProfile', () => {
     expect(profile.signals).toEqual([]);
   });
 
+  it('parses container.xml with single-quoted full-path attribute', async () => {
+    // Regression: XML allows either quote style; some authoring tools emit
+    // single quotes. Detection must still succeed.
+    const zip = new JSZip();
+    zip.file(
+      'META-INF/container.xml',
+      `<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path='EPUB/package.opf' media-type='application/oebps-package+xml'/>
+  </rootfiles>
+</container>`,
+    );
+    zip.file('EPUB/package.opf', PENGUIN_OPF);
+    zip.file('EPUB/prh_core_assets/styles/basestyles.css', 'body { }');
+    const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+    const profile = await detectPublisherProfile(buffer);
+    expect(profile.publisher).toBe('PRH-UK');
+  });
+
   it('handles a missing OPF gracefully', async () => {
     // Build a zip with only the container.xml — no OPF file at the referenced path.
     const zip = new JSZip();


### PR DESCRIPTION
## Summary

Foundation PR (1 of 5) for the PRH UK P1 validation work. Adds the imprint-aware publisher detector that runs after the existing JS auditor and attaches a `PublisherProfile` to every audit result. **Detection only** — no PRH validators emit issues yet; PR2 onward fill those in, gated on `profile.confidence` returned here.

Reference plan: `Ninja-Documentation/PRH-Analysis/plans/P1-Implementation-Plan.md`

## What this PR adds

| File | Purpose |
|---|---|
| `src/services/epub/profiles/types.ts` | `PublisherProfile`, `PrhImprint`, `ProfileSignal`, `DetectionConfidence` types + `NO_PROFILE` sentinel |
| `src/services/epub/profiles/prh-uk/imprint-detector.ts` | Pure-function heuristic recognising Penguin / Puffin / Vintage / Pelican / Ladybird / #Merky / Cornerstone Saga from cover filenames, body URLs, `prh_core_assets/` paths, font-family names, and `dc:publisher` matches |
| `src/services/epub/profiles/profile-detector.service.ts` | Orchestrator that loads the EPUB once via JSZip, samples cover/title/copyright/nav XHTML, runs the imprint detector, and aggregates signals into a confidence band. Best-effort — detection failures fall back to `NO_PROFILE` |
| `src/services/epub/profiles/prh-uk/index.ts` | Module barrel for the PRH-UK subtree |
| `src/constants/prh-issue-codes.ts` | Single source of truth for the **18 `PRH-*` codes** that PR2-PR4 will emit, with severities, WCAG mappings, fix-types pre-registered. PR1 emits none of these yet. |

## What this PR modifies

- `src/services/epub/epub-audit.service.ts` — calls `detectPublisherProfile()` after the JS auditor. Adds `publisherProfile: PublisherProfile` to `EpubAuditResult`. Logs detection outcome at info level when a profile matches.

## Design notes worth your eye

1. **Signals carry an audit trail.** Every detection result includes the list of matched signals (kebab-case ids + human descriptions). When a reviewer asks "why does this EPUB show as Vintage?" we have the answer in the response.
2. **Confidence band rule is conservative.** `high` requires at least one *strong* signal AND any second signal — this prevents a passing mention of "penguin.co.uk" tipping an unrelated EPUB into PRH territory. Validators in PR2+ will only run on `medium` or `high`.
3. **Penguin-imprint regex uses negative lookahead** so "Penguin" inside "Penguin Random House" doesn't pin the imprint — every PRH-UK EPUB carries that string in `dc:publisher` regardless of which line published it.
4. **No schema changes.** `publisherProfile` lives in-memory on the audit result and persists through the existing artifact JSON.
5. **Decoupled detector.** The imprint detector is a pure function over `(opfContent, filePaths, contentSample)` so it's unit-testable without spinning up JSZip.

## Test plan

- [x] 21 new Vitest tests across `imprint-detector.test.ts` (10) and `profile-detector.test.ts` (11)
  - Per-imprint matching for Penguin, Puffin, Vintage, Cornerstone Saga
  - Score-based imprint selection when multiple signals overlap
  - Generic PRH-UK detection (`dc:publisher` only) → imprint = `'unknown'` (regression: must not pin to "penguin")
  - Empty input safety
  - Signal-trail completeness
  - Real in-memory zips for happy-path orchestrator
  - Corrupt-zip safety (returns `NO_PROFILE` not throw)
  - Missing-OPF graceful fallback
  - `aggregateConfidence` boundary cases (single weak / single moderate / single strong / strong+other)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean on all touched files
- [x] Full vitest suite: **1047 passing** (was 1027), same 7 pre-existing failures in `workflow-config.integration.test.ts` / `workflow-websocket.test.ts` that exist on `main`. Zero regressions.

## Out of scope (deferred to PR2-PR5)

- PR2: PRH metadata + spine validators (emit `PRH-META-*` and `PRH-SPINE-*` codes; auto-fix metadata)
- PR3: nav landmarks + per-XHTML lang/title validators
- PR4: cover-alt-non-empty + decorative-`role="presentation"` validators
- PR5: `VPAT2.5-PRH-UK` edition pinned to WCAG 2.2 AA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EPUB audits now perform best-effort publisher detection and identify Penguin Random House UK imprints, returning imprint, confidence (low/medium/high) and ordered detection signals included in audit results.
  * Added a standardized registry of PRH issue codes with severity, WCAG mappings, fix types and summaries for consistent issue reporting.

* **Tests**
  * Added unit tests covering imprint detection, publisher-profile detection, confidence aggregation and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/356)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->