### PR TITLE
fix(epub): exclude prh_core_assets/ from imprint scoring + add score threshold

### DIFF
--- a/src/services/epub/profiles/prh-uk/imprint-detector.ts
+++ b/src/services/epub/profiles/prh-uk/imprint-detector.ts
@@ -107,6 +107,15 @@ const PRH_CORE_ASSETS_PATH_FRAGMENT = 'prh_core_assets';
 const PRH_UK_LOGO_PATH_FRAGMENT = 'prh_uk_logo';
 
 /**
+ * Minimum imprint score required to actually pin an imprint. A single weak
+ * signal (e.g. one CSS reference to a font filename also present in shared
+ * brand assets) shouldn't override the safer 'unknown' default. Real PRH
+ * books with imprint-specific cover/title paths score >= 4 from path
+ * matches alone; multi-imprint demo docs score 0–1.
+ */
+const IMPRINT_SCORE_THRESHOLD = 2;
+
+/**
  * Detect whether an EPUB carries PRH-UK profile signals. Pure function over
  * the inputs — no I/O.
  */
@@ -150,6 +159,14 @@ export function detectPrhImprint(
 
   // ── Imprint-level signals ────────────────────────────────────────────
   // Score each imprint independently so the caller can pick the strongest.
+  // Paths under prh_core_assets/ are excluded from imprint scoring because
+  // that subtree is shared brand infrastructure (fonts, the PRH UK logo)
+  // rather than imprint-specific content. The Technical Guide ships every
+  // imprint's brand fonts in prh_core_assets/fonts/ as a markup-demo doc;
+  // a real PRH book ships only its own imprint's fonts in EPUB/fonts/.
+  const imprintPaths = paths.filter(
+    (p) => !p.toLowerCase().includes(PRH_CORE_ASSETS_PATH_FRAGMENT),
+  );
   const imprintScores = new Map<PrhImprint, number>();
 
   for (const [imprintRaw, patterns] of Object.entries(IMPRINT_PATTERNS)) {
@@ -159,7 +176,7 @@ export function detectPrhImprint(
     let score = 0;
 
     for (const fragment of patterns.filePathFragments) {
-      if (paths.some((p) => p.toLowerCase().includes(fragment.toLowerCase()))) {
+      if (imprintPaths.some((p) => p.toLowerCase().includes(fragment.toLowerCase()))) {
         score += 2;
         signals.push({
           id: `imprint-path-${imprint}`,
@@ -195,7 +212,9 @@ export function detectPrhImprint(
   }
 
   // Pick the imprint with the highest score; ties resolve by first-seen
-  // (Object.entries preserves insertion order in modern engines).
+  // (Object.entries preserves insertion order in modern engines). A score
+  // below IMPRINT_SCORE_THRESHOLD is treated as 'unknown' rather than the
+  // top imprint — a single weak text/CSS reference shouldn't pin a doc.
   let topImprint: PrhImprint | null = null;
   let topScore = 0;
   for (const [imprint, score] of imprintScores) {
@@ -204,6 +223,8 @@ export function detectPrhImprint(
       topImprint = imprint;
     }
   }
+  const selectedImprint: PrhImprint | null =
+    topScore >= IMPRINT_SCORE_THRESHOLD ? topImprint : null;
 
   const isPrhUk = signals.length > 0;
 
@@ -211,7 +232,7 @@ export function detectPrhImprint(
   // the imprint as 'unknown' so callers know we recognised PRH but couldn't
   // pin down the line.
   const imprint: PrhImprint | null = isPrhUk
-    ? topImprint ?? 'unknown'
+    ? selectedImprint ?? 'unknown'
     : null;
 
   return { isPrhUk, imprint, signals };

--- a/tests/unit/services/epub/profiles/prh-uk/imprint-detector.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/imprint-detector.test.ts
@@ -150,6 +150,46 @@ describe('detectPrhImprint', () => {
     expect(result.imprint).toBe('unknown');
   });
 
+  it('does NOT pin imprint to font files inside prh_core_assets/ (multi-imprint demo doc)', () => {
+    // Regression for the staging smoke test: the PRH Technical Guide ships
+    // every PRH imprint's brand fonts in prh_core_assets/fonts/ as a
+    // markup-demo doc. Those font filenames are shared brand infrastructure,
+    // not imprint-specific evidence. A real PRH book ships only its own
+    // imprint's fonts in EPUB/fonts/. The detector must therefore exclude
+    // prh_core_assets/ paths from imprint scoring.
+    const result = detectPrhImprint({
+      opfContent: PRH_PUBLISHER_OPF,
+      filePaths: [
+        'EPUB/prh_core_assets/fonts/ladybird563-regular.otf',
+        'EPUB/prh_core_assets/fonts/ladybird563-bold.otf',
+        'EPUB/prh_core_assets/fonts/PufBkyR.otf',
+        'EPUB/prh_core_assets/images/prh_uk_logo.jpg',
+        'EPUB/xhtml/cover.xhtml',
+      ],
+      contentSample: '',
+    });
+    expect(result.isPrhUk).toBe(true);
+    expect(result.imprint).toBe('unknown');
+    // The publisher-level signals should still fire (logo, OPF text).
+    expect(result.signals.find((s) => s.id === 'publisher-text-opf')).toBeDefined();
+    expect(result.signals.find((s) => s.id === 'prh-core-assets-path')).toBeDefined();
+    // Crucially, NO imprint-path signals for ladybird from the font files.
+    expect(result.signals.find((s) => s.id === 'imprint-path-ladybird')).toBeUndefined();
+  });
+
+  it('does NOT pin imprint when only a single weak text reference matches (sub-threshold)', () => {
+    // Regression: a passing CSS reference to "puffinBeaky" in shared styles
+    // (text match, score=1) should not pin to puffin without corroborating
+    // path/URL evidence reaching the threshold (>= 2).
+    const result = detectPrhImprint({
+      opfContent: PRH_PUBLISHER_OPF,
+      filePaths: ['EPUB/xhtml/cover.xhtml'],
+      contentSample: '@font-face { src: url("puffinBeaky.otf"); }',
+    });
+    expect(result.isPrhUk).toBe(true);
+    expect(result.imprint).toBe('unknown');
+  });
+
   it('handles empty input without throwing', () => {
     const result = detectPrhImprint({
       opfContent: '',


### PR DESCRIPTION
## Summary

Hot-fix on top of PR #356 (PRH profile foundation) caught by the smoke-test runbook against the real PRH Technical Guide 2.0.3 EPUB on staging.

**The bug:** detector pinned the Technical Guide as `imprint: 'ladybird'` because it ships every PRH imprint's brand fonts in `prh_core_assets/fonts/` as a markup-demo doc, and the detector treated those font filenames as imprint-specific evidence.

**Why it matters:** the Technical Guide is the canonical "real PRH EPUB" used to validate detection. The runbook expected `imprint: 'penguin'` or `'unknown'` — `'ladybird'` is a clear false-positive. A real publishable PRH book wouldn't trigger this (real books ship only their own imprint's fonts in `EPUB/fonts/`, not in `prh_core_assets/`), so it doesn't affect production audits — but it's still a real bug worth fixing before PR2 builds on top of the detector.

## What changed

`src/services/epub/profiles/prh-uk/imprint-detector.ts`:

1. **Exclude `prh_core_assets/` paths from imprint scoring.** That subtree is shared brand infrastructure by definition. The publisher-level `prh-core-assets-path` signal still fires, so we don't lose detection; we just stop attributing those font filenames to specific imprints.
2. **Require imprint score `>= 2` to pin an imprint** (`IMPRINT_SCORE_THRESHOLD`). Below the threshold → `'unknown'`. A single weak signal (e.g. one CSS reference to a font filename) shouldn't override the safer default.

## Effect

| EPUB | Before | After |
|---|---|---|
| PRH Technical Guide (multi-imprint demo) | `imprint='ladybird'` ❌ | `imprint='unknown'` ✓ |
| PRH Branding Guide (multi-imprint demo) | `imprint='puffin'` (still acceptable) | `imprint='unknown'` ✓ |
| Real Penguin book | `imprint='penguin'` (score 8+) | `imprint='penguin'` ✓ |
| Real Puffin / Vintage / Ladybird book | correct | correct ✓ |

Real publishable PRH books score >= 4 from cover/path matches alone, well clear of the new threshold of 2.

## Test plan

- [x] 2 new regression tests in `imprint-detector.test.ts`:
  - `prh_core_assets/` font files don't pin imprint (the exact Technical Guide scenario)
  - Single sub-threshold text match doesn't pin imprint (defensive)
- [x] All 25 existing profile-detector tests still pass — real-book detection unaffected
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean on touched files
- [x] Full vitest suite: **1053 passing** (was 1050), same 7 pre-existing failures in `workflow-config.integration.test.ts` / `workflow-websocket.test.ts`. Zero regressions.

## Verification on staging (after merge + deploy)

Re-run the smoke test for the Technical Guide — should now return `imprint: 'unknown'`.

Reference: `Ninja-Documentation/PRH-Analysis/plans/PR1-Smoke-Test.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced imprint detection accuracy through a new quality-based scoring threshold. The system now ensures only high-confidence matches are assigned as imprints; marginal or shared-asset-based matches are correctly classified as unidentified, preventing false positives.

* **Tests**
  * Added regression test coverage for edge cases in imprint detection, including scenarios below the confidence threshold and exclusion of shared asset paths from scoring logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/357)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->