### PR TITLE
feat(epub): PRH UK metadata + spine validators (PR2/5)

### DIFF
--- a/src/constants/fix-classification.ts
+++ b/src/constants/fix-classification.ts
@@ -20,6 +20,15 @@ const BASE_AUTO_FIXABLE_CODES = new Set([
   'METADATA-ACCESSIBILITYFEATURE',
   'METADATA-ACCESSIBILITYHAZARD',
   'METADATA-ACCESSIBILITYSUMMARY',
+  // PRH UK profile metadata — publisher-specific literal-string rewrites
+  'PRH-META-CONFORMS-TO',
+  'PRH-META-CERTIFIED-BY',
+  'PRH-META-CERTIFIER-CRED',
+  'PRH-META-CERTIFIER-LINK',
+  'PRH-META-TDM-RESERVATION',
+  'PRH-META-A11Y-SUMMARY-URL',
+  // PRH-SPINE-* codes are detect-only in PR2 — spine reordering is risky
+  // enough that we want operator review before mutating spine entries.
 ]);
 
 export function getAutoFixableCodes(): Set<string> {

--- a/src/services/acr/wcag-issue-mapper.service.ts
+++ b/src/services/acr/wcag-issue-mapper.service.ts
@@ -48,6 +48,18 @@ export const RULE_TO_CRITERIA_MAP: Record<string, string[]> = {
   // EPUBCheck resource errors
   'RSC-003': [],
 
+  // ============= PRH UK PROFILE RULES =============
+  // Metadata (publisher-specific; see prh-issue-codes.ts registry)
+  'PRH-META-CONFORMS-TO': ['4.1.2'],
+  'PRH-META-CERTIFIED-BY': ['4.1.2'],
+  'PRH-META-CERTIFIER-CRED': ['4.1.2'],
+  'PRH-META-CERTIFIER-LINK': ['4.1.2'],
+  'PRH-META-TDM-RESERVATION': [],
+  'PRH-META-A11Y-SUMMARY-URL': ['4.1.2'],
+  // Spine (publisher-specific; no direct WCAG analogue)
+  'PRH-SPINE-COVER-LINEAR': [],
+  'PRH-SPINE-FOOTNOTES-LAST': [],
+
   // ============= STANDARD ACE RULES =============
   // Images and Non-text Content
   'img-alt': ['1.1.1'],

--- a/src/services/epub/auto-remediation.service.ts
+++ b/src/services/epub/auto-remediation.service.ts
@@ -5,6 +5,14 @@ import prisma from '../../lib/prisma';
 import JSZip from 'jszip';
 import { isAutoFixable } from '../../constants/fix-classification';
 import { ComparisonService, mapFixTypeToChangeType, extractWcagCriteria, extractWcagLevel } from '../comparison';
+import {
+  fixConformsTo,
+  fixCertifiedBy,
+  fixCertifierCredential,
+  fixCertifierLink,
+  fixTdmReservation,
+  fixA11ySummaryUrl,
+} from './profiles/prh-uk';
 
 const comparisonService = new ComparisonService(prisma);
 
@@ -136,6 +144,16 @@ class AutoRemediationService {
       }
       return epubModifier.fixColorContrast(_zip, contrastIssues);
     },
+    // ── PRH UK profile metadata fixes ────────────────────────────────────
+    // Each writes a single literal PRH-required metadata field back into
+    // the OPF. They're independently re-runnable; calling one twice is a
+    // no-op once the value matches.
+    'PRH-META-CONFORMS-TO': async (zip) => fixConformsTo(zip),
+    'PRH-META-CERTIFIED-BY': async (zip) => fixCertifiedBy(zip),
+    'PRH-META-CERTIFIER-CRED': async (zip) => fixCertifierCredential(zip),
+    'PRH-META-CERTIFIER-LINK': async (zip) => fixCertifierLink(zip),
+    'PRH-META-TDM-RESERVATION': async (zip) => fixTdmReservation(zip),
+    'PRH-META-A11Y-SUMMARY-URL': async (zip) => fixA11ySummaryUrl(zip),
   };
 
   async runAutoRemediation(

--- a/src/services/epub/epub-audit.service.ts
+++ b/src/services/epub/epub-audit.service.ts
@@ -10,7 +10,7 @@ import config from '../../config/index';
 import { epubJSAuditor } from './epub-js-auditor.service';
 import { callAceMicroservice } from './ace-client.service';
 import { detectPublisherProfile } from './profiles/profile-detector.service';
-import type { PublisherProfile } from './profiles/types';
+import { NO_PROFILE, type PublisherProfile } from './profiles/types';
 import { runPrhUkValidators } from './profiles/prh-uk';
 import { captureIssueSnapshot, compareSnapshots, clearSnapshots } from '../../utils/issue-flow-logger';
 import { getFixType } from '../../constants/fix-classification';
@@ -286,10 +286,20 @@ class EpubAuditService {
       // profile is attached to the audit result regardless of confidence,
       // but validators only run on `medium` or `high` confidence to avoid
       // false-positive PRH issues on incidental signal matches.
-      const publisherProfile = await detectPublisherProfile(buffer);
-      if (publisherProfile.publisher) {
-        logger.info(
-          `[Profile] Detected ${publisherProfile.publisher} (imprint=${publisherProfile.imprint}, confidence=${publisherProfile.confidence}, signals=${publisherProfile.signals.length})`,
+      // Defensive try/catch: detectPublisherProfile catches its own errors
+      // internally, but we belt-and-braces it here so any unforeseen throw
+      // (e.g. logger failure, weird buffer shape) cannot break the audit.
+      let publisherProfile: PublisherProfile = NO_PROFILE;
+      try {
+        publisherProfile = await detectPublisherProfile(buffer);
+        if (publisherProfile.publisher) {
+          logger.info(
+            `[Profile] Detected ${publisherProfile.publisher} (imprint=${publisherProfile.imprint}, confidence=${publisherProfile.confidence}, signals=${publisherProfile.signals.length})`,
+          );
+        }
+      } catch (profileErr) {
+        logger.warn(
+          `[Profile] detection threw: ${profileErr instanceof Error ? profileErr.message : 'Unknown error'} — falling back to NO_PROFILE`,
         );
       }
       if (publisherProfile.publisher === 'PRH-UK' && publisherProfile.confidence !== 'low') {

--- a/src/services/epub/epub-audit.service.ts
+++ b/src/services/epub/epub-audit.service.ts
@@ -11,6 +11,7 @@ import { epubJSAuditor } from './epub-js-auditor.service';
 import { callAceMicroservice } from './ace-client.service';
 import { detectPublisherProfile } from './profiles/profile-detector.service';
 import type { PublisherProfile } from './profiles/types';
+import { runPrhUkValidators } from './profiles/prh-uk';
 import { captureIssueSnapshot, compareSnapshots, clearSnapshots } from '../../utils/issue-flow-logger';
 import { getFixType } from '../../constants/fix-classification';
 import { s3Service } from '../s3.service';
@@ -64,7 +65,7 @@ interface AceResult {
 
 interface AccessibilityIssue {
   id: string;
-  source: 'epubcheck' | 'ace' | 'js-auditor';
+  source: 'epubcheck' | 'ace' | 'js-auditor' | 'prh-uk';
   severity: 'critical' | 'serious' | 'moderate' | 'minor';
   code: string;
   message: string;
@@ -112,6 +113,7 @@ interface EpubAuditResult {
     epubcheck: { critical: number; serious: number; moderate: number; minor: number; total: number };
     ace: { critical: number; serious: number; moderate: number; minor: number; total: number };
     'js-auditor': { critical: number; serious: number; moderate: number; minor: number; total: number; autoFixable: number };
+    'prh-uk': { critical: number; serious: number; moderate: number; minor: number; total: number; autoFixable: number };
   };
   classificationStats: {
     autoFixable: number;
@@ -278,6 +280,40 @@ class EpubAuditService {
         logger.warn(`JS audit failed: ${jsError instanceof Error ? jsError.message : 'Unknown error'}`);
       }
 
+      // Detect publisher profile and run profile-gated validators (e.g.
+      // PRH UK metadata + spine). Profile detection itself is best-effort —
+      // failures fall back to NO_PROFILE without breaking the audit. The
+      // profile is attached to the audit result regardless of confidence,
+      // but validators only run on `medium` or `high` confidence to avoid
+      // false-positive PRH issues on incidental signal matches.
+      const publisherProfile = await detectPublisherProfile(buffer);
+      if (publisherProfile.publisher) {
+        logger.info(
+          `[Profile] Detected ${publisherProfile.publisher} (imprint=${publisherProfile.imprint}, confidence=${publisherProfile.confidence}, signals=${publisherProfile.signals.length})`,
+        );
+      }
+      if (publisherProfile.publisher === 'PRH-UK' && publisherProfile.confidence !== 'low') {
+        try {
+          const prhIssues = await runPrhUkValidators(buffer);
+          logger.info(`[PRH] validators emitted ${prhIssues.length} issues`);
+          for (const v of prhIssues) {
+            combinedIssues.push({
+              id: `prh-${this.issueCounter++}`,
+              source: 'prh-uk',
+              severity: v.severity,
+              code: v.code,
+              message: v.message,
+              wcagCriteria: v.wcag.length > 0 ? v.wcag : undefined,
+              location: v.location,
+              suggestion: v.suggestion,
+              category: 'publisher-profile',
+            });
+          }
+        } catch (prhErr) {
+          logger.warn(`PRH validators failed: ${prhErr instanceof Error ? prhErr.message : 'Unknown error'}`);
+        }
+      }
+
       captureIssueSnapshot('3_BEFORE_DEDUPLICATION', combinedIssues as unknown as Record<string, unknown>[], true);
 
       logger.info('\nFINAL DEDUPLICATION:');
@@ -349,6 +385,14 @@ class EpubAuditService {
           total: deduplicatedIssues.filter(i => i.source === 'js-auditor').length,
           autoFixable: deduplicatedIssues.filter(i => i.source === 'js-auditor' && getFixType(i.code) === 'auto').length,
         },
+        'prh-uk': {
+          critical: deduplicatedIssues.filter(i => i.source === 'prh-uk' && i.severity === 'critical').length,
+          serious: deduplicatedIssues.filter(i => i.source === 'prh-uk' && i.severity === 'serious').length,
+          moderate: deduplicatedIssues.filter(i => i.source === 'prh-uk' && i.severity === 'moderate').length,
+          minor: deduplicatedIssues.filter(i => i.source === 'prh-uk' && i.severity === 'minor').length,
+          total: deduplicatedIssues.filter(i => i.source === 'prh-uk').length,
+          autoFixable: deduplicatedIssues.filter(i => i.source === 'prh-uk' && getFixType(i.code) === 'auto').length,
+        },
       };
 
       const classificationStats = {
@@ -361,15 +405,6 @@ class EpubAuditService {
       logger.info(`  Auto-fixable: ${classificationStats.autoFixable}`);
       logger.info(`  Quick-fixable: ${classificationStats.quickFixable}`);
       logger.info(`  Manual required: ${classificationStats.manualRequired}`);
-
-      // Detect publisher profile (e.g. PRH UK + imprint). Best-effort —
-      // detection failures fall back to NO_PROFILE without breaking the audit.
-      const publisherProfile = await detectPublisherProfile(buffer);
-      if (publisherProfile.publisher) {
-        logger.info(
-          `[Profile] Detected ${publisherProfile.publisher} (imprint=${publisherProfile.imprint}, confidence=${publisherProfile.confidence}, signals=${publisherProfile.signals.length})`,
-        );
-      }
 
       // Calculate coverage
       const coverage = this.calculateCoverage(buffer);

--- a/src/services/epub/profiles/prh-uk/index.ts
+++ b/src/services/epub/profiles/prh-uk/index.ts
@@ -1,9 +1,21 @@
 /**
  * PRH UK profile module.
  *
- * PR1 (foundation): exposes the imprint detector only. Validators (metadata,
- * spine, nav, per-XHTML, image) and remediators land in PR2-PR4.
+ * PR1 (foundation) added the imprint detector. PR2 adds the metadata and
+ * spine validators plus their auto-fix remediators. PR3+ will add nav,
+ * per-XHTML, and image validators.
  */
 
 export { detectPrhImprint } from './imprint-detector';
 export type { ImprintDetectionInput, ImprintDetectionResult } from './imprint-detector';
+
+export { runPrhUkValidators } from './run-validators';
+export type { PrhValidatorIssue } from './validators/types';
+export {
+  fixConformsTo,
+  fixCertifiedBy,
+  fixCertifierCredential,
+  fixCertifierLink,
+  fixTdmReservation,
+  fixA11ySummaryUrl,
+} from './remediators/metadata-remediator';

--- a/src/services/epub/profiles/prh-uk/remediators/metadata-remediator.ts
+++ b/src/services/epub/profiles/prh-uk/remediators/metadata-remediator.ts
@@ -82,8 +82,10 @@ export async function fixTdmReservation(zip: JSZip): Promise<ChangeResult[]> {
     let working = opf;
     let changed = false;
 
-    // 1. Ensure the tdm: prefix is declared on <package>.
-    const tdmPrefix = 'tdm: http://www.w3.org/ns/tdmrep#';
+    // 1. Ensure the tdm: prefix is declared on <package> AND maps to the
+    //    correct URI (an existing `tdm:` mapped to a wrong URI must be
+    //    rewritten — not silently kept).
+    const tdmUri = 'http://www.w3.org/ns/tdmrep#';
     const packageOpenRe = /<package\b([^>]*)>/i;
     const pkgMatch = working.match(packageOpenRe);
     if (pkgMatch) {
@@ -91,15 +93,27 @@ export async function fixTdmReservation(zip: JSZip): Promise<ChangeResult[]> {
       const prefixAttrRe = /\bprefix\s*=\s*(["'])([^"']*)\1/i;
       const existing = attrs.match(prefixAttrRe);
       if (existing) {
-        if (!existing[2].toLowerCase().includes('tdm:')) {
-          const newPrefix = `${existing[2].trim()} ${tdmPrefix}`.trim();
-          const newAttrs = attrs.replace(prefixAttrRe, `prefix="${newPrefix}"`);
+        const pairs = parsePrefixPairs(existing[2]);
+        const tdmIdx = pairs.findIndex(([k]) => k.toLowerCase() === 'tdm:');
+        if (tdmIdx === -1) {
+          pairs.push(['tdm:', tdmUri]);
+        } else if (pairs[tdmIdx][1] !== tdmUri) {
+          pairs[tdmIdx] = ['tdm:', tdmUri];
+        } else {
+          // Already correct — don't touch.
+          // (skip the rewrite to keep the OPF byte-identical)
+          // This path leaves `changed` to be set only by step 2.
+          // Continue.
+        }
+        const serialised = pairs.map(([k, v]) => `${k} ${v}`).join(' ');
+        if (serialised !== existing[2].trim()) {
+          const newAttrs = attrs.replace(prefixAttrRe, `prefix="${serialised}"`);
           working = working.replace(packageOpenRe, `<package${newAttrs}>`);
           changed = true;
         }
       } else {
         // No prefix attribute at all — add one.
-        const newAttrs = `${attrs.trimEnd()} prefix="${tdmPrefix}"`;
+        const newAttrs = `${attrs.trimEnd()} prefix="tdm: ${tdmUri}"`;
         working = working.replace(packageOpenRe, `<package${newAttrs}>`);
         changed = true;
       }
@@ -256,6 +270,20 @@ function insertIntoMetadata(opf: string, fragment: string): string | null {
   const closeRe = /<\/metadata>/i;
   if (!closeRe.test(opf)) return null;
   return opf.replace(closeRe, `  ${fragment}\n</metadata>`);
+}
+
+/**
+ * Parse the value of a `prefix=` attribute on `<package>` into [name, uri]
+ * pairs. The attribute is a space-separated stream of `name: uri` tokens
+ * (e.g. `schema: http://schema.org/ tdm: http://www.w3.org/ns/tdmrep#`).
+ */
+function parsePrefixPairs(prefixValue: string): [string, string][] {
+  const tokens = prefixValue.trim().split(/\s+/).filter((t) => t.length > 0);
+  const pairs: [string, string][] = [];
+  for (let i = 0; i + 1 < tokens.length; i += 2) {
+    pairs.push([tokens[i], tokens[i + 1]]);
+  }
+  return pairs;
 }
 
 /** Pull out a short excerpt of the metadata block for change-log diffing. */

--- a/src/services/epub/profiles/prh-uk/remediators/metadata-remediator.ts
+++ b/src/services/epub/profiles/prh-uk/remediators/metadata-remediator.ts
@@ -1,0 +1,267 @@
+/**
+ * PRH UK metadata remediators.
+ *
+ * Each function takes a `JSZip` (already loaded EPUB), reads the OPF,
+ * mutates only the metadata field that PRH requires, and writes the OPF
+ * back. Designed to plug into `auto-remediation.service.ts`'s handler
+ * registry — each function returns the same `{success, description,
+ * before?, after?}` shape the existing handlers use.
+ *
+ * The fixes are intentionally narrow: each one asserts a single PRH
+ * literal string. We deliberately do NOT compose them into a "fix all
+ * metadata" mega-fix because the auto-remediation pipeline tracks
+ * per-issue success/failure and we want each PRH-META-* code to be
+ * independently re-run-able.
+ */
+
+import JSZip from 'jszip';
+import { logger } from '../../../../../lib/logger';
+import { PRH_METADATA_EXPECTED } from '../validators/metadata-validator';
+
+interface ChangeResult {
+  success: boolean;
+  description: string;
+  before?: string;
+  after?: string;
+}
+
+interface OpfHandle {
+  path: string;
+  content: string;
+}
+
+// ── Public handlers ────────────────────────────────────────────────────────
+
+export async function fixConformsTo(zip: JSZip): Promise<ChangeResult[]> {
+  return runFix(zip, 'PRH-META-CONFORMS-TO', (opf) =>
+    upsertMetaProperty(opf, {
+      property: 'dcterms:conformsTo',
+      value: PRH_METADATA_EXPECTED.conformsTo,
+      // Pin id so a11y:certifiedBy can refine #conf.
+      idAttr: 'conf',
+    }),
+  );
+}
+
+export async function fixCertifiedBy(zip: JSZip): Promise<ChangeResult[]> {
+  return runFix(zip, 'PRH-META-CERTIFIED-BY', (opf) =>
+    upsertMetaProperty(opf, {
+      property: 'a11y:certifiedBy',
+      value: PRH_METADATA_EXPECTED.certifiedBy,
+      idAttr: 'certifier',
+      refines: '#conf',
+    }),
+  );
+}
+
+export async function fixCertifierCredential(zip: JSZip): Promise<ChangeResult[]> {
+  return runFix(zip, 'PRH-META-CERTIFIER-CRED', (opf) =>
+    upsertMetaProperty(opf, {
+      property: 'a11y:certifierCredential',
+      value: PRH_METADATA_EXPECTED.certifierCredential,
+      refines: '#certifier',
+    }),
+  );
+}
+
+export async function fixCertifierLink(zip: JSZip): Promise<ChangeResult[]> {
+  return runFix(zip, 'PRH-META-CERTIFIER-LINK', (opf) => {
+    const linkRe = /<link\b[^>]*\brel\s*=\s*["']a11y:certifierCredential["'][^>]*\/?>/i;
+    const expected = `<link rel="a11y:certifierCredential" href="${PRH_METADATA_EXPECTED.certifierLinkHref}"/>`;
+    if (linkRe.test(opf)) {
+      // Replace any existing link to ensure href is correct.
+      const updated = opf.replace(linkRe, expected);
+      return updated === opf ? null : updated;
+    }
+    return insertIntoMetadata(opf, expected);
+  });
+}
+
+export async function fixTdmReservation(zip: JSZip): Promise<ChangeResult[]> {
+  return runFix(zip, 'PRH-META-TDM-RESERVATION', (opf) => {
+    let working = opf;
+    let changed = false;
+
+    // 1. Ensure the tdm: prefix is declared on <package>.
+    const tdmPrefix = 'tdm: http://www.w3.org/ns/tdmrep#';
+    const packageOpenRe = /<package\b([^>]*)>/i;
+    const pkgMatch = working.match(packageOpenRe);
+    if (pkgMatch) {
+      const attrs = pkgMatch[1];
+      const prefixAttrRe = /\bprefix\s*=\s*(["'])([^"']*)\1/i;
+      const existing = attrs.match(prefixAttrRe);
+      if (existing) {
+        if (!existing[2].toLowerCase().includes('tdm:')) {
+          const newPrefix = `${existing[2].trim()} ${tdmPrefix}`.trim();
+          const newAttrs = attrs.replace(prefixAttrRe, `prefix="${newPrefix}"`);
+          working = working.replace(packageOpenRe, `<package${newAttrs}>`);
+          changed = true;
+        }
+      } else {
+        // No prefix attribute at all — add one.
+        const newAttrs = `${attrs.trimEnd()} prefix="${tdmPrefix}"`;
+        working = working.replace(packageOpenRe, `<package${newAttrs}>`);
+        changed = true;
+      }
+    }
+
+    // 2. Ensure the tdm:reservation meta value is "1".
+    const next = upsertMetaProperty(working, {
+      property: 'tdm:reservation',
+      value: PRH_METADATA_EXPECTED.tdmReservationValue,
+    });
+    if (next != null) {
+      working = next;
+      changed = true;
+    }
+
+    return changed ? working : null;
+  });
+}
+
+export async function fixA11ySummaryUrl(zip: JSZip): Promise<ChangeResult[]> {
+  return runFix(zip, 'PRH-META-A11Y-SUMMARY-URL', (opf) => {
+    // Find the existing schema:accessibilitySummary meta and append the URL
+    // if it doesn't already reference penguin.co.uk/accessibility.
+    const re = /(<meta\b[^>]*\bproperty\s*=\s*["']schema:accessibilitySummary["'][^>]*>)([\s\S]*?)(<\/meta>)/i;
+    const m = opf.match(re);
+    const url = 'https://www.penguin.co.uk/accessibility';
+    if (m) {
+      const inner = m[2];
+      if (inner.toLowerCase().includes('penguin.co.uk/accessibility')) return null;
+      const trimmed = inner.trim();
+      const sep = trimmed.endsWith('.') ? ' ' : '. ';
+      const newInner = `${trimmed}${sep}For more information visit ${url}`;
+      return opf.replace(re, `${m[1]}${newInner}${m[3]}`);
+    }
+    // No existing meta — insert a minimal one.
+    const inserted = insertIntoMetadata(
+      opf,
+      `<meta property="schema:accessibilitySummary">For more information visit ${url}</meta>`,
+    );
+    return inserted;
+  });
+}
+
+// ── Internals ────────────────────────────────────────────────────────────
+
+/**
+ * Skeleton that reads the OPF, applies the supplied transform, writes it back
+ * if it changed, and returns a uniform `ChangeResult[]`.
+ */
+async function runFix(
+  zip: JSZip,
+  code: string,
+  transform: (opfContent: string) => string | null | Promise<string | null>,
+): Promise<ChangeResult[]> {
+  const opf = await loadOpf(zip);
+  if (!opf) {
+    return [
+      {
+        success: false,
+        description: `${code}: OPF not found in EPUB`,
+      },
+    ];
+  }
+
+  let updated: string | null;
+  try {
+    updated = await transform(opf.content);
+  } catch (err) {
+    logger.warn(`[${code}] transform failed: ${err instanceof Error ? err.message : 'unknown error'}`);
+    return [
+      {
+        success: false,
+        description: `${code}: transform failed (${err instanceof Error ? err.message : 'unknown error'})`,
+      },
+    ];
+  }
+
+  if (!updated || updated === opf.content) {
+    return [
+      {
+        success: true,
+        description: `${code}: already compliant; no change`,
+      },
+    ];
+  }
+
+  zip.file(opf.path, updated);
+  return [
+    {
+      success: true,
+      description: `${code}: rewrote OPF metadata`,
+      before: extractMetadataExcerpt(opf.content),
+      after: extractMetadataExcerpt(updated),
+    },
+  ];
+}
+
+async function loadOpf(zip: JSZip): Promise<OpfHandle | null> {
+  const containerXml = await zip.file('META-INF/container.xml')?.async('text');
+  if (!containerXml) return null;
+  const m = containerXml.match(/rootfile[^>]+full-path\s*=\s*(?:"([^"]+)"|'([^']+)')/);
+  const opfPath = m?.[1] ?? m?.[2];
+  if (!opfPath) return null;
+  const content = await zip.file(opfPath)?.async('text');
+  if (!content) return null;
+  return { path: opfPath, content };
+}
+
+interface UpsertOptions {
+  property: string;
+  value: string;
+  /** Optional id attribute on the meta element. */
+  idAttr?: string;
+  /** Optional refines attribute (#anchor). */
+  refines?: string;
+}
+
+/**
+ * Insert or replace a `<meta property="X">value</meta>` element. Returns
+ * the updated OPF on change, or null if no change was needed.
+ */
+function upsertMetaProperty(opf: string, opts: UpsertOptions): string | null {
+  const escaped = opts.property.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(
+    `<meta\\b[^>]*\\bproperty\\s*=\\s*["']${escaped}["'][^>]*>([\\s\\S]*?)</meta>`,
+    'i',
+  );
+  const desiredAttrs = [`property="${opts.property}"`];
+  if (opts.refines) desiredAttrs.push(`refines="${opts.refines}"`);
+  if (opts.idAttr) desiredAttrs.push(`id="${opts.idAttr}"`);
+  const desiredElement = `<meta ${desiredAttrs.join(' ')}>${opts.value}</meta>`;
+
+  const existing = opf.match(re);
+  if (existing) {
+    if (existing[1].trim() === opts.value) {
+      // Value already matches — but check that the attributes (id/refines)
+      // we want are present. Cheap check: if id is requested, ensure it's there.
+      const hasId = !opts.idAttr || new RegExp(`\\bid\\s*=\\s*["']${opts.idAttr}["']`, 'i').test(existing[0]);
+      const hasRefines =
+        !opts.refines || new RegExp(`\\brefines\\s*=\\s*["']${opts.refines}["']`, 'i').test(existing[0]);
+      if (hasId && hasRefines) return null;
+    }
+    return opf.replace(re, desiredElement);
+  }
+
+  return insertIntoMetadata(opf, desiredElement);
+}
+
+/**
+ * Insert a fragment immediately before `</metadata>`. If no metadata block
+ * exists, returns null (caller handles).
+ */
+function insertIntoMetadata(opf: string, fragment: string): string | null {
+  const closeRe = /<\/metadata>/i;
+  if (!closeRe.test(opf)) return null;
+  return opf.replace(closeRe, `  ${fragment}\n</metadata>`);
+}
+
+/** Pull out a short excerpt of the metadata block for change-log diffing. */
+function extractMetadataExcerpt(opf: string): string {
+  const m = opf.match(/<metadata\b[^>]*>([\s\S]*?)<\/metadata>/i);
+  if (!m) return '<no metadata block>';
+  const inner = m[1].replace(/\s+/g, ' ').trim();
+  return inner.length > 600 ? inner.slice(0, 600) + '…' : inner;
+}

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -1,0 +1,47 @@
+/**
+ * Orchestrator for PRH UK validators. Loads the OPF once via JSZip, runs
+ * each validator, and returns a flat list of `PrhValidatorIssue` objects
+ * for the audit pipeline to translate into `AccessibilityIssue` records.
+ *
+ * Best-effort: if the EPUB can't be parsed we return an empty list rather
+ * than throwing — a validator failure must never break the surrounding
+ * audit. Same defensive posture as the publisher-profile detector.
+ */
+
+import JSZip from 'jszip';
+import { logger } from '../../../../lib/logger';
+import { validatePrhMetadata } from './validators/metadata-validator';
+import { validatePrhSpine } from './validators/spine-validator';
+import type { PrhValidatorIssue } from './validators/types';
+
+export async function runPrhUkValidators(buffer: Buffer): Promise<PrhValidatorIssue[]> {
+  try {
+    const zip = await JSZip.loadAsync(buffer);
+    const opf = await readOpf(zip);
+    if (!opf) {
+      logger.warn('[PRH validators] OPF not found; skipping');
+      return [];
+    }
+    const input = { opfContent: opf.content, opfPath: opf.path };
+    return [
+      ...validatePrhMetadata(input),
+      ...validatePrhSpine(input),
+    ];
+  } catch (err) {
+    logger.warn(
+      `[PRH validators] run failed; returning no issues: ${err instanceof Error ? err.message : 'unknown error'}`,
+    );
+    return [];
+  }
+}
+
+async function readOpf(zip: JSZip): Promise<{ path: string; content: string } | null> {
+  const containerXml = await zip.file('META-INF/container.xml')?.async('text');
+  if (!containerXml) return null;
+  const m = containerXml.match(/rootfile[^>]+full-path\s*=\s*(?:"([^"]+)"|'([^']+)')/);
+  const opfPath = m?.[1] ?? m?.[2];
+  if (!opfPath) return null;
+  const content = await zip.file(opfPath)?.async('text');
+  if (!content) return null;
+  return { path: opfPath, content };
+}

--- a/src/services/epub/profiles/prh-uk/validators/metadata-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/metadata-validator.ts
@@ -157,17 +157,22 @@ function readDcMetaValue(opf: string, name: string): string | null {
 }
 
 function hasCertifierLink(opf: string, expectedHref: string): boolean {
-  // Find <link rel="a11y:certifierCredential" ... href="..."/>
+  // Find <link rel="a11y:certifierCredential" ... href="..."/>. Exact-match
+  // the href (after normalising trailing slash + case) so we don't accept
+  // values like "https://example.com/?next=https://daisy.github.io/ace".
   const re = /<link\b[^>]*\brel\s*=\s*["']a11y:certifierCredential["'][^>]*\bhref\s*=\s*["']([^"']+)["']/i;
-  const m = opf.match(re);
+  let m = opf.match(re);
   if (!m) {
     // Try with attribute order reversed (href before rel).
     const re2 = /<link\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*\brel\s*=\s*["']a11y:certifierCredential["']/i;
-    const m2 = opf.match(re2);
-    if (!m2) return false;
-    return m2[1].toLowerCase().includes(expectedHref.toLowerCase());
+    m = opf.match(re2);
+    if (!m) return false;
   }
-  return m[1].toLowerCase().includes(expectedHref.toLowerCase());
+  return normaliseHref(m[1]) === normaliseHref(expectedHref);
+}
+
+function normaliseHref(href: string): string {
+  return href.trim().toLowerCase().replace(/\/+$/, '');
 }
 
 function buildIssue(

--- a/src/services/epub/profiles/prh-uk/validators/metadata-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/metadata-validator.ts
@@ -1,0 +1,187 @@
+/**
+ * PRH UK metadata validator.
+ *
+ * Checks the OPF for the 6 publisher-specific metadata strings PRH UK
+ * requires (per `accessibility_meta_boilerplates.txt` in the Technical
+ * Guide). Pure function — no I/O — so it's cheap to test against fixture
+ * OPF strings.
+ *
+ * Mapped issue codes (registered in `src/constants/prh-issue-codes.ts`):
+ *   PRH-META-CONFORMS-TO       — dcterms:conformsTo value
+ *   PRH-META-CERTIFIED-BY      — a11y:certifiedBy value
+ *   PRH-META-CERTIFIER-CRED    — a11y:certifierCredential value
+ *   PRH-META-CERTIFIER-LINK    — link rel="a11y:certifierCredential" presence
+ *   PRH-META-TDM-RESERVATION   — tdm:reservation meta + prefix
+ *   PRH-META-A11Y-SUMMARY-URL  — accessibilitySummary references PRH URL
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorInput, PrhValidatorIssue } from './types';
+
+/** Literal expected values from PRH spec. */
+export const PRH_METADATA_EXPECTED = {
+  conformsTo: 'EPUB Accessibility 1.1 - WCAG 2.2 Level AA',
+  certifiedBy: 'Penguin Random House UK',
+  certifierCredential: 'Ace by DAISY OK',
+  certifierLinkHref: 'https://daisy.github.io/ace',
+  tdmReservationValue: '1',
+  /** Substring expected in the accessibilitySummary value. */
+  a11ySummaryUrlSubstring: 'penguin.co.uk/accessibility',
+} as const;
+
+export function validatePrhMetadata(input: PrhValidatorInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+  const opf = input.opfContent;
+  const location = input.opfPath || 'package.opf';
+
+  // ── 1. dcterms:conformsTo ──────────────────────────────────────────────
+  const conformsToValue = readMetaValue(opf, 'dcterms:conformsTo');
+  if (conformsToValue !== PRH_METADATA_EXPECTED.conformsTo) {
+    issues.push(
+      buildIssue('PRH-META-CONFORMS-TO', location, {
+        message: conformsToValue == null
+          ? 'OPF is missing dcterms:conformsTo metadata'
+          : `OPF dcterms:conformsTo is "${conformsToValue}", not "${PRH_METADATA_EXPECTED.conformsTo}"`,
+        suggestion: `Add or replace the conformsTo meta with: <meta property="dcterms:conformsTo" id="conf">${PRH_METADATA_EXPECTED.conformsTo}</meta>`,
+      }),
+    );
+  }
+
+  // ── 2. a11y:certifiedBy ────────────────────────────────────────────────
+  const certifiedByValue = readMetaValue(opf, 'a11y:certifiedBy');
+  if (certifiedByValue !== PRH_METADATA_EXPECTED.certifiedBy) {
+    issues.push(
+      buildIssue('PRH-META-CERTIFIED-BY', location, {
+        message: certifiedByValue == null
+          ? 'OPF is missing a11y:certifiedBy metadata'
+          : `OPF a11y:certifiedBy is "${certifiedByValue}", not "${PRH_METADATA_EXPECTED.certifiedBy}"`,
+        suggestion: `Add or replace the certifiedBy meta with: <meta property="a11y:certifiedBy" refines="#conf" id="certifier">${PRH_METADATA_EXPECTED.certifiedBy}</meta>`,
+      }),
+    );
+  }
+
+  // ── 3. a11y:certifierCredential (meta value) ───────────────────────────
+  const credValue = readMetaValue(opf, 'a11y:certifierCredential');
+  if (credValue !== PRH_METADATA_EXPECTED.certifierCredential) {
+    issues.push(
+      buildIssue('PRH-META-CERTIFIER-CRED', location, {
+        message: credValue == null
+          ? 'OPF is missing a11y:certifierCredential meta'
+          : `OPF a11y:certifierCredential is "${credValue}", not "${PRH_METADATA_EXPECTED.certifierCredential}"`,
+        suggestion: `Add or replace the certifierCredential meta with: <meta property="a11y:certifierCredential" refines="#certifier">${PRH_METADATA_EXPECTED.certifierCredential}</meta>`,
+      }),
+    );
+  }
+
+  // ── 4. <link rel="a11y:certifierCredential" href="..."> ────────────────
+  if (!hasCertifierLink(opf, PRH_METADATA_EXPECTED.certifierLinkHref)) {
+    issues.push(
+      buildIssue('PRH-META-CERTIFIER-LINK', location, {
+        message: 'OPF is missing <link rel="a11y:certifierCredential" href="https://daisy.github.io/ace"/>',
+        suggestion: 'Add: <link rel="a11y:certifierCredential" href="https://daisy.github.io/ace"/>',
+      }),
+    );
+  }
+
+  // ── 5. tdm:reservation ─────────────────────────────────────────────────
+  const tdmValue = readMetaValue(opf, 'tdm:reservation');
+  const hasTdmPrefix = /\btdm\s*:\s*http:\/\/www\.w3\.org\/ns\/tdmrep#/i.test(opf)
+    // Or declared on the package element via prefix attribute:
+    || /\bprefix\s*=\s*["'][^"']*tdm:\s*http:\/\/www\.w3\.org\/ns\/tdmrep#[^"']*["']/i.test(opf);
+  if (tdmValue !== PRH_METADATA_EXPECTED.tdmReservationValue || !hasTdmPrefix) {
+    const reasons: string[] = [];
+    if (tdmValue !== PRH_METADATA_EXPECTED.tdmReservationValue) {
+      reasons.push(
+        tdmValue == null
+          ? 'tdm:reservation meta is missing'
+          : `tdm:reservation is "${tdmValue}", expected "1"`,
+      );
+    }
+    if (!hasTdmPrefix) {
+      reasons.push('tdm: prefix is not declared on the <package> element');
+    }
+    issues.push(
+      buildIssue('PRH-META-TDM-RESERVATION', location, {
+        message: `Text-and-data-mining reservation is incomplete: ${reasons.join('; ')}`,
+        suggestion: 'On <package>: add prefix="tdm: http://www.w3.org/ns/tdmrep#". In <metadata>: add <meta property="tdm:reservation">1</meta>',
+      }),
+    );
+  }
+
+  // ── 6. accessibilitySummary references penguin.co.uk/accessibility ─────
+  const summaryValue =
+    readMetaValue(opf, 'schema:accessibilitySummary')
+    ?? readDcMetaValue(opf, 'accessibilitySummary');
+  if (
+    summaryValue == null
+    || !summaryValue.toLowerCase().includes(PRH_METADATA_EXPECTED.a11ySummaryUrlSubstring)
+  ) {
+    issues.push(
+      buildIssue('PRH-META-A11Y-SUMMARY-URL', location, {
+        message: summaryValue == null
+          ? 'OPF accessibilitySummary is missing'
+          : `accessibilitySummary does not reference ${PRH_METADATA_EXPECTED.a11ySummaryUrlSubstring}`,
+        suggestion: 'Update accessibilitySummary to end with the PRH accessibility URL: https://www.penguin.co.uk/accessibility',
+      }),
+    );
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Read a `<meta property="...">value</meta>` from the OPF. Tolerant of
+ * either quote style and arbitrary attribute order on the element. Returns
+ * the trimmed inner text, or null if not found.
+ */
+function readMetaValue(opf: string, propertyName: string): string | null {
+  // Escape any regex specials in the property name.
+  const escaped = propertyName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(
+    `<meta\\b[^>]*\\bproperty\\s*=\\s*["']${escaped}["'][^>]*>([\\s\\S]*?)</meta>`,
+    'i',
+  );
+  const m = opf.match(re);
+  if (!m) return null;
+  return m[1].trim();
+}
+
+/** Read a `<dc:foo>value</dc:foo>` from the OPF (Dublin Core fallback). */
+function readDcMetaValue(opf: string, name: string): string | null {
+  const re = new RegExp(`<dc:${name}\\b[^>]*>([\\s\\S]*?)</dc:${name}>`, 'i');
+  const m = opf.match(re);
+  if (!m) return null;
+  return m[1].trim();
+}
+
+function hasCertifierLink(opf: string, expectedHref: string): boolean {
+  // Find <link rel="a11y:certifierCredential" ... href="..."/>
+  const re = /<link\b[^>]*\brel\s*=\s*["']a11y:certifierCredential["'][^>]*\bhref\s*=\s*["']([^"']+)["']/i;
+  const m = opf.match(re);
+  if (!m) {
+    // Try with attribute order reversed (href before rel).
+    const re2 = /<link\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*\brel\s*=\s*["']a11y:certifierCredential["']/i;
+    const m2 = opf.match(re2);
+    if (!m2) return false;
+    return m2[1].toLowerCase().includes(expectedHref.toLowerCase());
+  }
+  return m[1].toLowerCase().includes(expectedHref.toLowerCase());
+}
+
+function buildIssue(
+  code: keyof typeof PRH_ISSUE_CODES,
+  location: string,
+  parts: { message: string; suggestion: string },
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: parts.message,
+    suggestion: parts.suggestion,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/spine-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/spine-validator.ts
@@ -1,0 +1,171 @@
+/**
+ * PRH UK spine validator.
+ *
+ * Two checks (both publisher-specific, no direct WCAG mapping):
+ *
+ *   PRH-SPINE-COVER-LINEAR   — the cover spine entry must have linear="no"
+ *                              so reading systems don't render it twice.
+ *   PRH-SPINE-FOOTNOTES-LAST — when a footnotes file is present it must be
+ *                              the last entry in the spine AND be marked
+ *                              linear="no" (it's reached only via in-text
+ *                              footnote anchors, never linearly).
+ *
+ * Both are detect-only in PR2 — spine reordering is risky enough that we
+ * want operator review before mutating spine entries.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorInput, PrhValidatorIssue } from './types';
+
+interface ManifestItem {
+  id: string;
+  href: string;
+  properties: string;
+}
+
+interface SpineItemRef {
+  idref: string;
+  linear: string | null;
+}
+
+export function validatePrhSpine(input: PrhValidatorInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+  const opf = input.opfContent;
+  const location = input.opfPath || 'package.opf';
+
+  if (!opf) return issues;
+
+  const manifest = parseManifest(opf);
+  const spine = parseSpine(opf);
+
+  if (spine.length === 0) return issues;
+
+  // ── 1. Cover spine entry must have linear="no" ─────────────────────────
+  const coverItem = findCoverManifestItem(manifest);
+  if (coverItem) {
+    const coverSpine = spine.find((s) => s.idref === coverItem.id);
+    if (coverSpine && coverSpine.linear !== 'no') {
+      issues.push(
+        buildIssue('PRH-SPINE-COVER-LINEAR', location, {
+          message: coverSpine.linear == null
+            ? `Cover spine entry (idref="${coverItem.id}") is missing linear="no"`
+            : `Cover spine entry (idref="${coverItem.id}") has linear="${coverSpine.linear}"; PRH requires linear="no"`,
+          suggestion: `Update <itemref idref="${coverItem.id}"> to include linear="no"`,
+        }),
+      );
+    }
+  }
+
+  // ── 2. Footnotes file must be last in spine and linear="no" ────────────
+  const footnotesItems = findFootnotesManifestItems(manifest);
+  if (footnotesItems.length > 0) {
+    const lastSpine = spine[spine.length - 1];
+    const lastItem = manifest.find((m) => m.id === lastSpine.idref);
+
+    const isFootnotes = lastItem && hrefLooksLikeFootnotes(lastItem.href);
+
+    if (!isFootnotes) {
+      issues.push(
+        buildIssue('PRH-SPINE-FOOTNOTES-LAST', location, {
+          message: `A footnotes file is present (${footnotesItems.map((f) => f.href).join(', ')}) but is not the last entry in the spine; PRH requires footnotes to come last`,
+          suggestion: 'Reorder the spine so the footnotes itemref is the final entry, and add linear="no" to it',
+        }),
+      );
+    } else if (lastSpine.linear !== 'no') {
+      issues.push(
+        buildIssue('PRH-SPINE-FOOTNOTES-LAST', location, {
+          message: `Footnotes spine entry is last but ${lastSpine.linear == null ? 'is missing linear="no"' : `has linear="${lastSpine.linear}"`}`,
+          suggestion: `Add linear="no" to <itemref idref="${lastSpine.idref}">`,
+        }),
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function parseManifest(opf: string): ManifestItem[] {
+  const manifestMatch = opf.match(/<manifest\b[^>]*>([\s\S]*?)<\/manifest>/i);
+  if (!manifestMatch) return [];
+  const block = manifestMatch[1];
+  const items: ManifestItem[] = [];
+  const itemRe = /<item\b([^>]*)\/?>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = itemRe.exec(block)) !== null) {
+    const attrs = m[1];
+    const id = readAttr(attrs, 'id');
+    const href = readAttr(attrs, 'href');
+    const properties = readAttr(attrs, 'properties');
+    if (id && href != null) {
+      items.push({ id, href, properties: properties ?? '' });
+    }
+  }
+  return items;
+}
+
+function parseSpine(opf: string): SpineItemRef[] {
+  const spineMatch = opf.match(/<spine\b[^>]*>([\s\S]*?)<\/spine>/i);
+  if (!spineMatch) return [];
+  const block = spineMatch[1];
+  const refs: SpineItemRef[] = [];
+  const refRe = /<itemref\b([^>]*)\/?>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = refRe.exec(block)) !== null) {
+    const attrs = m[1];
+    const idref = readAttr(attrs, 'idref');
+    const linear = readAttr(attrs, 'linear');
+    if (idref) refs.push({ idref, linear });
+  }
+  return refs;
+}
+
+function readAttr(attrs: string, name: string): string | null {
+  // `name="value"` or `name='value'`, with optional whitespace around `=`.
+  const re = new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, 'i');
+  const m = attrs.match(re);
+  if (!m) return null;
+  return (m[1] ?? m[2]) ?? null;
+}
+
+function findCoverManifestItem(manifest: ManifestItem[]): ManifestItem | null {
+  // Most reliable: an item explicitly carrying properties="cover-image" is
+  // the cover IMAGE; the cover XHTML is usually id="cover" or has cover in
+  // its href. We want the cover XHTML (the spine entry), not the image.
+  // Heuristic: prefer XHTML/HTML entries where id or href matches /cover/i.
+  const candidates = manifest.filter(
+    (m) => /\.(x?html?)$/i.test(m.href) && /cover/i.test(m.id + ' ' + m.href),
+  );
+  if (candidates.length === 0) return null;
+  // Prefer id=cover exact, then anything with "cover" in href.
+  const exactId = candidates.find((c) => c.id.toLowerCase() === 'cover');
+  if (exactId) return exactId;
+  return candidates[0];
+}
+
+function findFootnotesManifestItems(manifest: ManifestItem[]): ManifestItem[] {
+  return manifest.filter((m) => hrefLooksLikeFootnotes(m.href));
+}
+
+function hrefLooksLikeFootnotes(href: string): boolean {
+  // PRH convention: footnotes externalised into a file named `footnotes.xhtml`
+  // (sometimes split as footnotes1/2 in the Technical Guide example).
+  return /(?:^|\/)footnotes?\d*\.x?html?$/i.test(href);
+}
+
+function buildIssue(
+  code: keyof typeof PRH_ISSUE_CODES,
+  location: string,
+  parts: { message: string; suggestion: string },
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: parts.message,
+    suggestion: parts.suggestion,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/spine-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/spine-validator.ts
@@ -56,26 +56,51 @@ export function validatePrhSpine(input: PrhValidatorInput): PrhValidatorIssue[] 
     }
   }
 
-  // ── 2. Footnotes file must be last in spine and linear="no" ────────────
+  // ── 2. Every footnotes file must be in the trailing block of the spine
+  //      AND marked linear="no". A spine like
+  //      [..., footnotes1.xhtml, appendix.xhtml, footnotes2.xhtml] is
+  //      non-conforming because footnotes1 is interrupted by a non-footnotes
+  //      item (appendix), even if footnotes2 is correctly at the end.
   const footnotesItems = findFootnotesManifestItems(manifest);
   if (footnotesItems.length > 0) {
-    const lastSpine = spine[spine.length - 1];
-    const lastItem = manifest.find((m) => m.id === lastSpine.idref);
+    const footnoteIds = new Set(footnotesItems.map((m) => m.id));
 
-    const isFootnotes = lastItem && hrefLooksLikeFootnotes(lastItem.href);
+    // Trailing block: walk back from the end, collecting consecutive
+    // footnote-only itemrefs.
+    let trailingStart = spine.length;
+    while (trailingStart > 0 && footnoteIds.has(spine[trailingStart - 1].idref)) {
+      trailingStart--;
+    }
 
-    if (!isFootnotes) {
+    const misplaced: string[] = [];
+    const missingLinear: string[] = [];
+
+    for (let i = 0; i < spine.length; i++) {
+      const ref = spine[i];
+      if (!footnoteIds.has(ref.idref)) continue;
+      // Position must be inside the trailing footnote-only block.
+      if (i < trailingStart) {
+        misplaced.push(ref.idref);
+      }
+      // Each footnote itemref must be linear="no".
+      if (ref.linear !== 'no') {
+        missingLinear.push(ref.idref);
+      }
+    }
+
+    if (misplaced.length > 0) {
       issues.push(
         buildIssue('PRH-SPINE-FOOTNOTES-LAST', location, {
-          message: `A footnotes file is present (${footnotesItems.map((f) => f.href).join(', ')}) but is not the last entry in the spine; PRH requires footnotes to come last`,
-          suggestion: 'Reorder the spine so the footnotes itemref is the final entry, and add linear="no" to it',
+          message: `Footnotes itemref(s) [${misplaced.join(', ')}] are not in the trailing block of the spine; PRH requires every footnotes file to come at the end`,
+          suggestion: `Reorder the spine so all footnotes itemrefs (${footnotesItems.map((m) => m.id).join(', ')}) form the final contiguous block, each with linear="no"`,
         }),
       );
-    } else if (lastSpine.linear !== 'no') {
+    }
+    if (missingLinear.length > 0) {
       issues.push(
         buildIssue('PRH-SPINE-FOOTNOTES-LAST', location, {
-          message: `Footnotes spine entry is last but ${lastSpine.linear == null ? 'is missing linear="no"' : `has linear="${lastSpine.linear}"`}`,
-          suggestion: `Add linear="no" to <itemref idref="${lastSpine.idref}">`,
+          message: `Footnotes itemref(s) [${missingLinear.join(', ')}] are missing linear="no"`,
+          suggestion: `Add linear="no" to each: ${missingLinear.map((id) => `<itemref idref="${id}">`).join(', ')}`,
         }),
       );
     }
@@ -132,13 +157,16 @@ function readAttr(attrs: string, name: string): string | null {
 function findCoverManifestItem(manifest: ManifestItem[]): ManifestItem | null {
   // Most reliable: an item explicitly carrying properties="cover-image" is
   // the cover IMAGE; the cover XHTML is usually id="cover" or has cover in
-  // its href. We want the cover XHTML (the spine entry), not the image.
-  // Heuristic: prefer XHTML/HTML entries where id or href matches /cover/i.
+  // its href basename. Use a token-aware regex so unrelated names like
+  // `discover.xhtml` or `covers.xhtml` are not mistaken for the cover.
+  // The pattern requires "cover" to be flanked by a separator on both sides
+  // (start-of-string, `/`, `_`, `-`, `.` or end-of-string).
+  const COVER_TOKEN = /(?:^|[/_-])cover(?:[/._-]|$)/i;
   const candidates = manifest.filter(
-    (m) => /\.(x?html?)$/i.test(m.href) && /cover/i.test(m.id + ' ' + m.href),
+    (m) => /\.(x?html?)$/i.test(m.href) && (COVER_TOKEN.test(m.id) || COVER_TOKEN.test(m.href)),
   );
   if (candidates.length === 0) return null;
-  // Prefer id=cover exact, then anything with "cover" in href.
+  // Prefer id=cover exact, then anything with "cover" token in href.
   const exactId = candidates.find((c) => c.id.toLowerCase() === 'cover');
   if (exactId) return exactId;
   return candidates[0];

--- a/src/services/epub/profiles/prh-uk/validators/types.ts
+++ b/src/services/epub/profiles/prh-uk/validators/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared types for PRH UK validators. Validators are pure functions over
+ * pre-parsed EPUB inputs and return a list of `PrhValidatorIssue` objects
+ * that the orchestrator translates into the audit pipeline's
+ * `AccessibilityIssue` shape.
+ */
+
+import type { PrhIssueSeverity } from '../../../../../constants/prh-issue-codes';
+
+export interface PrhValidatorIssue {
+  /** PRH-* code from prh-issue-codes.ts. */
+  code: string;
+  severity: PrhIssueSeverity;
+  /** WCAG criteria this maps to (may be empty for publisher-specific rules). */
+  wcag: string[];
+  /** Human-readable message shown in the UI. */
+  message: string;
+  /** Concrete remediation hint shown in the UI. */
+  suggestion: string;
+  /** File or location the issue applies to (e.g. 'package.opf'). */
+  location: string;
+}
+
+/**
+ * Inputs every PRH validator can read. Parsed once in the orchestrator so
+ * each validator is cheap and pure.
+ */
+export interface PrhValidatorInput {
+  /** Full OPF (package.opf) content as string. */
+  opfContent: string;
+  /** Path of the OPF inside the zip (e.g. 'EPUB/package.opf'). */
+  opfPath: string;
+}

--- a/src/services/epub/remediation.service.ts
+++ b/src/services/epub/remediation.service.ts
@@ -23,6 +23,34 @@ import {
   findMissingIssues,
 } from '../../utils/issue-debugger';
 import type { ModificationResult } from './epub-modifier.service';
+import {
+  fixConformsTo,
+  fixCertifiedBy,
+  fixCertifierCredential,
+  fixCertifierLink,
+  fixTdmReservation,
+  fixA11ySummaryUrl,
+} from './profiles/prh-uk';
+
+/**
+ * PRH metadata fix functions return a slim {success, description, before?,
+ * after?} shape; this autoApplyHighConfidenceFixes pipeline expects the
+ * full ModificationResult shape with filePath + modificationType. Adapt
+ * the slim results into the expected shape so the caller's success/failure
+ * accounting and change-log code paths work unchanged.
+ */
+function adaptPrhResults(
+  results: Array<{ success: boolean; description: string; before?: string; after?: string }>,
+): ModificationResult[] {
+  return results.map((r) => ({
+    success: r.success,
+    filePath: 'package.opf',
+    modificationType: 'metadata',
+    description: r.description,
+    before: r.before,
+    after: r.after,
+  }));
+}
 
 type RemediationStatus = 'pending' | 'in_progress' | 'completed' | 'skipped' | 'failed';
 type RemediationPriority = 'critical' | 'high' | 'medium' | 'low';
@@ -1653,6 +1681,27 @@ class RemediationService {
               .map(t => t.location)
               .filter((loc): loc is string => !!loc);
             fixResults = await epubModifier.addAriaLandmarks(zip, targetLocations);
+            break;
+          // ── PRH UK profile metadata auto-fixes ────────────────────────
+          // Each handler rewrites a single literal PRH-required field in
+          // the OPF. Idempotent: re-running on a compliant OPF is a no-op.
+          case 'PRH-META-CONFORMS-TO':
+            fixResults = adaptPrhResults(await fixConformsTo(zip));
+            break;
+          case 'PRH-META-CERTIFIED-BY':
+            fixResults = adaptPrhResults(await fixCertifiedBy(zip));
+            break;
+          case 'PRH-META-CERTIFIER-CRED':
+            fixResults = adaptPrhResults(await fixCertifierCredential(zip));
+            break;
+          case 'PRH-META-CERTIFIER-LINK':
+            fixResults = adaptPrhResults(await fixCertifierLink(zip));
+            break;
+          case 'PRH-META-TDM-RESERVATION':
+            fixResults = adaptPrhResults(await fixTdmReservation(zip));
+            break;
+          case 'PRH-META-A11Y-SUMMARY-URL':
+            fixResults = adaptPrhResults(await fixA11ySummaryUrl(zip));
             break;
           default:
             logger.debug(`[AutoFix] No auto-fix handler for ${code}, skipping`);

--- a/tests/unit/services/epub/profiles/prh-uk/remediators/metadata-remediator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/remediators/metadata-remediator.test.ts
@@ -161,6 +161,22 @@ describe('PRH metadata remediators', () => {
     expect(result2[0].description).toMatch(/already compliant/i);
   });
 
+  it('fixTdmReservation rewrites a wrong tdm: URI mapping (regression)', async () => {
+    // Regression for CodeRabbit major: previously the prefix-attribute
+    // check only verified that `tdm:` existed, so a wrong URI mapping
+    // (e.g. a stale older URI) was silently kept.
+    const opf0 = await readOpf(zip);
+    const opfWithWrongTdm = opf0.replace(
+      '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">',
+      '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" prefix="tdm: http://wrong.example.com/tdm/">',
+    );
+    zip.file('EPUB/package.opf', opfWithWrongTdm);
+    await fixTdmReservation(zip);
+    const after = await readOpf(zip);
+    expect(after).toContain('tdm: http://www.w3.org/ns/tdmrep#');
+    expect(after).not.toContain('http://wrong.example.com/tdm/');
+  });
+
   it('returns success:false when OPF is missing', async () => {
     const broken = new JSZip();
     broken.file('META-INF/container.xml', CONTAINER_XML);

--- a/tests/unit/services/epub/profiles/prh-uk/remediators/metadata-remediator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/remediators/metadata-remediator.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import JSZip from 'jszip';
+import {
+  fixConformsTo,
+  fixCertifiedBy,
+  fixCertifierCredential,
+  fixCertifierLink,
+  fixTdmReservation,
+  fixA11ySummaryUrl,
+} from '../../../../../../../src/services/epub/profiles/prh-uk/remediators/metadata-remediator';
+import { validatePrhMetadata } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/metadata-validator';
+
+const CONTAINER_XML = `<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`;
+
+/** Build a JSZip with a non-compliant OPF for the remediators to fix. */
+async function bareEpubZip(): Promise<JSZip> {
+  const zip = new JSZip();
+  zip.file('META-INF/container.xml', CONTAINER_XML);
+  zip.file(
+    'EPUB/package.opf',
+    `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Bare Book</dc:title>
+  </metadata>
+</package>`,
+  );
+  return zip;
+}
+
+async function readOpf(zip: JSZip): Promise<string> {
+  const content = await zip.file('EPUB/package.opf')?.async('text');
+  if (!content) throw new Error('OPF missing');
+  return content;
+}
+
+describe('PRH metadata remediators', () => {
+  let zip: JSZip;
+  beforeEach(async () => {
+    zip = await bareEpubZip();
+  });
+
+  it('fixConformsTo writes the literal PRH-required string', async () => {
+    const result = await fixConformsTo(zip);
+    expect(result[0].success).toBe(true);
+    const opf = await readOpf(zip);
+    expect(opf).toContain('EPUB Accessibility 1.1 - WCAG 2.2 Level AA');
+    expect(opf).toContain('id="conf"');
+  });
+
+  it('fixCertifiedBy writes the literal PRH-required string with refines', async () => {
+    await fixConformsTo(zip);
+    const result = await fixCertifiedBy(zip);
+    expect(result[0].success).toBe(true);
+    const opf = await readOpf(zip);
+    expect(opf).toContain('property="a11y:certifiedBy"');
+    expect(opf).toContain('Penguin Random House UK');
+    expect(opf).toContain('refines="#conf"');
+    expect(opf).toContain('id="certifier"');
+  });
+
+  it('fixCertifierCredential writes "Ace by DAISY OK"', async () => {
+    await fixConformsTo(zip);
+    await fixCertifiedBy(zip);
+    const result = await fixCertifierCredential(zip);
+    expect(result[0].success).toBe(true);
+    const opf = await readOpf(zip);
+    expect(opf).toContain('Ace by DAISY OK');
+    expect(opf).toContain('refines="#certifier"');
+  });
+
+  it('fixCertifierLink inserts the daisy.github.io/ace link', async () => {
+    const result = await fixCertifierLink(zip);
+    expect(result[0].success).toBe(true);
+    const opf = await readOpf(zip);
+    expect(opf).toContain('rel="a11y:certifierCredential"');
+    expect(opf).toContain('https://daisy.github.io/ace');
+  });
+
+  it('fixCertifierLink replaces an existing link with a different href', async () => {
+    // Insert a wrong link first.
+    const opf0 = await readOpf(zip);
+    const opfWithWrongLink = opf0.replace(
+      '</metadata>',
+      '  <link rel="a11y:certifierCredential" href="https://example.com/wrong"/>\n</metadata>',
+    );
+    zip.file('EPUB/package.opf', opfWithWrongLink);
+    await fixCertifierLink(zip);
+    const after = await readOpf(zip);
+    expect(after).toContain('https://daisy.github.io/ace');
+    expect(after).not.toContain('example.com/wrong');
+  });
+
+  it('fixTdmReservation declares the prefix on <package> and writes the meta', async () => {
+    const result = await fixTdmReservation(zip);
+    expect(result[0].success).toBe(true);
+    const opf = await readOpf(zip);
+    expect(opf).toContain('tdm: http://www.w3.org/ns/tdmrep#');
+    expect(opf).toContain('<meta property="tdm:reservation"');
+    expect(opf).toContain('>1</meta>');
+  });
+
+  it('fixTdmReservation appends to an existing prefix attribute without clobbering', async () => {
+    const opf0 = await readOpf(zip);
+    const opfWithSchema = opf0.replace(
+      '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">',
+      '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" prefix="schema: http://schema.org/">',
+    );
+    zip.file('EPUB/package.opf', opfWithSchema);
+    await fixTdmReservation(zip);
+    const after = await readOpf(zip);
+    expect(after).toContain('schema: http://schema.org/');
+    expect(after).toContain('tdm: http://www.w3.org/ns/tdmrep#');
+  });
+
+  it('fixA11ySummaryUrl appends the PRH URL to an existing summary', async () => {
+    const opf0 = await readOpf(zip);
+    const opfWithSummary = opf0.replace(
+      '</metadata>',
+      '  <meta property="schema:accessibilitySummary">This ebook has been audited.</meta>\n</metadata>',
+    );
+    zip.file('EPUB/package.opf', opfWithSummary);
+    await fixA11ySummaryUrl(zip);
+    const after = await readOpf(zip);
+    expect(after).toContain('penguin.co.uk/accessibility');
+    expect(after).toContain('This ebook has been audited');
+  });
+
+  it('fixA11ySummaryUrl inserts a new summary when none exists', async () => {
+    const result = await fixA11ySummaryUrl(zip);
+    expect(result[0].success).toBe(true);
+    const opf = await readOpf(zip);
+    expect(opf).toContain('schema:accessibilitySummary');
+    expect(opf).toContain('penguin.co.uk/accessibility');
+  });
+
+  it('end-to-end: applying all 6 fixes produces an OPF the validator accepts', async () => {
+    await fixConformsTo(zip);
+    await fixCertifiedBy(zip);
+    await fixCertifierCredential(zip);
+    await fixCertifierLink(zip);
+    await fixTdmReservation(zip);
+    await fixA11ySummaryUrl(zip);
+
+    const opf = await readOpf(zip);
+    const issues = validatePrhMetadata({ opfContent: opf, opfPath: 'EPUB/package.opf' });
+    expect(issues).toEqual([]);
+  });
+
+  it('a fix is idempotent — running it twice does not re-write', async () => {
+    await fixConformsTo(zip);
+    const opfAfter1 = await readOpf(zip);
+    const result2 = await fixConformsTo(zip);
+    const opfAfter2 = await readOpf(zip);
+    expect(opfAfter1).toBe(opfAfter2);
+    expect(result2[0].description).toMatch(/already compliant/i);
+  });
+
+  it('returns success:false when OPF is missing', async () => {
+    const broken = new JSZip();
+    broken.file('META-INF/container.xml', CONTAINER_XML);
+    // No EPUB/package.opf file.
+    const result = await fixConformsTo(broken);
+    expect(result[0].success).toBe(false);
+    expect(result[0].description).toMatch(/OPF not found/i);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/metadata-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/metadata-validator.test.ts
@@ -161,6 +161,26 @@ describe('validatePrhMetadata', () => {
     }
   });
 
+  it('rejects a phishing-style certifier link href (substring impostor)', () => {
+    // Regression for CodeRabbit major: previously hasCertifierLink used
+    // includes() which would accept this attacker-controlled redirect URL.
+    const opf = compliantOpf().replace(
+      'href="https://daisy.github.io/ace"',
+      'href="https://example.com/?next=https://daisy.github.io/ace"',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-META-CERTIFIER-LINK')).toBeDefined();
+  });
+
+  it('accepts a certifier link href that differs only by trailing slash', () => {
+    const opf = compliantOpf().replace(
+      'href="https://daisy.github.io/ace"',
+      'href="https://daisy.github.io/ace/"',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-META-CERTIFIER-LINK')).toBeUndefined();
+  });
+
   it('handles single-quoted attributes', () => {
     const opf = compliantOpf().replaceAll('"', "'");
     const issues = validatePrhMetadata(INPUT(opf));

--- a/tests/unit/services/epub/profiles/prh-uk/validators/metadata-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/metadata-validator.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhMetadata } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/metadata-validator';
+
+/** Build an OPF with a complete, PRH-compliant metadata block. */
+function compliantOpf(): string {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0"
+         prefix="schema: http://schema.org/ tdm: http://www.w3.org/ns/tdmrep#">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Book</dc:title>
+    <dc:publisher>Penguin Random House UK</dc:publisher>
+    <meta property="dcterms:conformsTo" id="conf">EPUB Accessibility 1.1 - WCAG 2.2 Level AA</meta>
+    <meta property="a11y:certifiedBy" refines="#conf" id="certifier">Penguin Random House UK</meta>
+    <meta property="a11y:certifierCredential" refines="#certifier">Ace by DAISY OK</meta>
+    <link rel="a11y:certifierCredential" href="https://daisy.github.io/ace"/>
+    <meta property="tdm:reservation">1</meta>
+    <meta property="schema:accessibilitySummary">For more information visit https://www.penguin.co.uk/accessibility</meta>
+  </metadata>
+</package>`;
+}
+
+const INPUT = (opfContent: string) => ({ opfContent, opfPath: 'EPUB/package.opf' });
+
+describe('validatePrhMetadata', () => {
+  it('emits zero issues for a fully compliant OPF', () => {
+    expect(validatePrhMetadata(INPUT(compliantOpf()))).toEqual([]);
+  });
+
+  it('flags missing dcterms:conformsTo', () => {
+    const opf = compliantOpf().replace(
+      /<meta property="dcterms:conformsTo"[^>]*>[^<]*<\/meta>/,
+      '',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-META-CONFORMS-TO')).toBeDefined();
+  });
+
+  it('flags wrong dcterms:conformsTo value (e.g. WCAG 2.1 instead of 2.2)', () => {
+    const opf = compliantOpf().replace(
+      'EPUB Accessibility 1.1 - WCAG 2.2 Level AA',
+      'EPUB Accessibility 1.0 - WCAG 2.1 Level AA',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    const issue = issues.find((i) => i.code === 'PRH-META-CONFORMS-TO');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/WCAG 2\.1/);
+  });
+
+  it('flags missing a11y:certifiedBy', () => {
+    const opf = compliantOpf().replace(
+      /<meta property="a11y:certifiedBy"[^>]*>[^<]*<\/meta>/,
+      '',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-META-CERTIFIED-BY')).toBeDefined();
+  });
+
+  it('flags wrong a11y:certifiedBy value', () => {
+    const opf = compliantOpf().replace(
+      '>Penguin Random House UK</meta>',
+      '>Other Publisher</meta>',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-META-CERTIFIED-BY')).toBeDefined();
+  });
+
+  it('flags missing a11y:certifierCredential meta', () => {
+    const opf = compliantOpf().replace(
+      /<meta property="a11y:certifierCredential"[^>]*>[^<]*<\/meta>/,
+      '',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-META-CERTIFIER-CRED')).toBeDefined();
+  });
+
+  it('flags missing certifier <link>', () => {
+    const opf = compliantOpf().replace(
+      /<link rel="a11y:certifierCredential"[^>]*\/?>/,
+      '',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-META-CERTIFIER-LINK')).toBeDefined();
+  });
+
+  it('accepts the certifier <link> when href and rel attribute order is reversed', () => {
+    const opf = compliantOpf().replace(
+      '<link rel="a11y:certifierCredential" href="https://daisy.github.io/ace"/>',
+      '<link href="https://daisy.github.io/ace" rel="a11y:certifierCredential"/>',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-META-CERTIFIER-LINK')).toBeUndefined();
+  });
+
+  it('flags missing tdm:reservation meta', () => {
+    const opf = compliantOpf().replace(
+      /<meta property="tdm:reservation">[^<]*<\/meta>/,
+      '',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    const issue = issues.find((i) => i.code === 'PRH-META-TDM-RESERVATION');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/missing/i);
+  });
+
+  it('flags tdm:reservation when prefix declaration is absent', () => {
+    const opf = compliantOpf().replace(
+      ' prefix="schema: http://schema.org/ tdm: http://www.w3.org/ns/tdmrep#"',
+      '',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    const issue = issues.find((i) => i.code === 'PRH-META-TDM-RESERVATION');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/prefix/i);
+  });
+
+  it('flags missing accessibilitySummary', () => {
+    const opf = compliantOpf().replace(
+      /<meta property="schema:accessibilitySummary">[^<]*<\/meta>/,
+      '',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-META-A11Y-SUMMARY-URL')).toBeDefined();
+  });
+
+  it('flags accessibilitySummary that does not reference the PRH URL', () => {
+    const opf = compliantOpf().replace(
+      'For more information visit https://www.penguin.co.uk/accessibility',
+      'This ebook has been audited.',
+    );
+    const issues = validatePrhMetadata(INPUT(opf));
+    const issue = issues.find((i) => i.code === 'PRH-META-A11Y-SUMMARY-URL');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/penguin\.co\.uk\/accessibility/);
+  });
+
+  it('emits exactly one issue per missing field (no double-counting)', () => {
+    // Strip everything PRH expects.
+    const opf = `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Bare Book</dc:title>
+  </metadata>
+</package>`;
+    const issues = validatePrhMetadata(INPUT(opf));
+    const codes = issues.map((i) => i.code).sort();
+    expect(codes).toEqual([
+      'PRH-META-A11Y-SUMMARY-URL',
+      'PRH-META-CERTIFIED-BY',
+      'PRH-META-CERTIFIER-CRED',
+      'PRH-META-CERTIFIER-LINK',
+      'PRH-META-CONFORMS-TO',
+      'PRH-META-TDM-RESERVATION',
+    ]);
+    // Each issue carries severity, wcag, message, suggestion, location.
+    for (const i of issues) {
+      expect(i.severity).toBeDefined();
+      expect(Array.isArray(i.wcag)).toBe(true);
+      expect(i.message).toBeTruthy();
+      expect(i.suggestion).toBeTruthy();
+      expect(i.location).toBe('EPUB/package.opf');
+    }
+  });
+
+  it('handles single-quoted attributes', () => {
+    const opf = compliantOpf().replaceAll('"', "'");
+    const issues = validatePrhMetadata(INPUT(opf));
+    expect(issues).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/spine-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/spine-validator.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhSpine } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/spine-validator';
+
+const INPUT = (opfContent: string) => ({ opfContent, opfPath: 'EPUB/package.opf' });
+
+function buildOpf(opts: {
+  manifest: string;
+  spine: string;
+}): string {
+  return `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata><dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">x</dc:title></metadata>
+  <manifest>
+    ${opts.manifest}
+  </manifest>
+  <spine>
+    ${opts.spine}
+  </spine>
+</package>`;
+}
+
+describe('validatePrhSpine', () => {
+  it('emits zero issues for a compliant spine (cover linear=no, footnotes last + linear=no)', () => {
+    const opf = buildOpf({
+      manifest: `
+        <item id="cover" href="xhtml/cover.xhtml" media-type="application/xhtml+xml"/>
+        <item id="ch1" href="xhtml/chapter001.xhtml" media-type="application/xhtml+xml"/>
+        <item id="footnotes" href="xhtml/footnotes.xhtml" media-type="application/xhtml+xml"/>
+      `,
+      spine: `
+        <itemref idref="cover" linear="no"/>
+        <itemref idref="ch1"/>
+        <itemref idref="footnotes" linear="no"/>
+      `,
+    });
+    expect(validatePrhSpine(INPUT(opf))).toEqual([]);
+  });
+
+  it('flags cover spine entry without linear="no"', () => {
+    const opf = buildOpf({
+      manifest: `
+        <item id="cover" href="xhtml/cover.xhtml" media-type="application/xhtml+xml"/>
+        <item id="ch1" href="xhtml/chapter001.xhtml" media-type="application/xhtml+xml"/>
+      `,
+      spine: `
+        <itemref idref="cover"/>
+        <itemref idref="ch1"/>
+      `,
+    });
+    const issues = validatePrhSpine(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-SPINE-COVER-LINEAR')).toBeDefined();
+  });
+
+  it('flags cover spine entry with explicit linear="yes"', () => {
+    const opf = buildOpf({
+      manifest: `<item id="cover" href="xhtml/cover.xhtml" media-type="application/xhtml+xml"/>`,
+      spine: `<itemref idref="cover" linear="yes"/>`,
+    });
+    const issues = validatePrhSpine(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-SPINE-COVER-LINEAR')).toBeDefined();
+  });
+
+  it('does NOT flag cover-linear when no cover XHTML is present (e.g. Kindle FXL)', () => {
+    const opf = buildOpf({
+      manifest: `<item id="ch1" href="xhtml/chapter001.xhtml" media-type="application/xhtml+xml"/>`,
+      spine: `<itemref idref="ch1"/>`,
+    });
+    expect(validatePrhSpine(INPUT(opf)).find((i) => i.code === 'PRH-SPINE-COVER-LINEAR')).toBeUndefined();
+  });
+
+  it('flags footnotes file that is not the last entry in the spine', () => {
+    const opf = buildOpf({
+      manifest: `
+        <item id="cover" href="xhtml/cover.xhtml" media-type="application/xhtml+xml"/>
+        <item id="footnotes" href="xhtml/footnotes.xhtml" media-type="application/xhtml+xml"/>
+        <item id="appendix" href="xhtml/appendix.xhtml" media-type="application/xhtml+xml"/>
+      `,
+      spine: `
+        <itemref idref="cover" linear="no"/>
+        <itemref idref="footnotes" linear="no"/>
+        <itemref idref="appendix"/>
+      `,
+    });
+    const issues = validatePrhSpine(INPUT(opf));
+    const issue = issues.find((i) => i.code === 'PRH-SPINE-FOOTNOTES-LAST');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/last entry/i);
+  });
+
+  it('flags footnotes file that is last but missing linear="no"', () => {
+    const opf = buildOpf({
+      manifest: `
+        <item id="cover" href="xhtml/cover.xhtml" media-type="application/xhtml+xml"/>
+        <item id="footnotes" href="xhtml/footnotes.xhtml" media-type="application/xhtml+xml"/>
+      `,
+      spine: `
+        <itemref idref="cover" linear="no"/>
+        <itemref idref="footnotes"/>
+      `,
+    });
+    const issues = validatePrhSpine(INPUT(opf));
+    const issue = issues.find((i) => i.code === 'PRH-SPINE-FOOTNOTES-LAST');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/linear="no"/);
+  });
+
+  it('does NOT flag footnotes-last when no footnotes file exists', () => {
+    const opf = buildOpf({
+      manifest: `
+        <item id="cover" href="xhtml/cover.xhtml" media-type="application/xhtml+xml"/>
+        <item id="ch1" href="xhtml/chapter001.xhtml" media-type="application/xhtml+xml"/>
+      `,
+      spine: `
+        <itemref idref="cover" linear="no"/>
+        <itemref idref="ch1"/>
+      `,
+    });
+    const issues = validatePrhSpine(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-SPINE-FOOTNOTES-LAST')).toBeUndefined();
+  });
+
+  it('returns empty when OPF has no spine block', () => {
+    const opf = `<?xml version="1.0"?><package><manifest></manifest></package>`;
+    expect(validatePrhSpine(INPUT(opf))).toEqual([]);
+  });
+
+  it('handles single-quoted attribute values', () => {
+    const opf = `<?xml version="1.0"?>
+<package version='3.0'>
+  <manifest>
+    <item id='cover' href='xhtml/cover.xhtml' media-type='application/xhtml+xml'/>
+  </manifest>
+  <spine>
+    <itemref idref='cover'/>
+  </spine>
+</package>`;
+    const issues = validatePrhSpine(INPUT(opf));
+    expect(issues.find((i) => i.code === 'PRH-SPINE-COVER-LINEAR')).toBeDefined();
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/spine-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/spine-validator.test.ts
@@ -84,7 +84,7 @@ describe('validatePrhSpine', () => {
     const issues = validatePrhSpine(INPUT(opf));
     const issue = issues.find((i) => i.code === 'PRH-SPINE-FOOTNOTES-LAST');
     expect(issue).toBeDefined();
-    expect(issue?.message).toMatch(/last entry/i);
+    expect(issue?.message).toMatch(/trailing block/i);
   });
 
   it('flags footnotes file that is last but missing linear="no"', () => {
@@ -121,6 +121,65 @@ describe('validatePrhSpine', () => {
 
   it('returns empty when OPF has no spine block', () => {
     const opf = `<?xml version="1.0"?><package><manifest></manifest></package>`;
+    expect(validatePrhSpine(INPUT(opf))).toEqual([]);
+  });
+
+  it('does NOT misclassify discover.xhtml as the cover (regression)', () => {
+    // Regression for CodeRabbit P2: /cover/i matched inside "discover".
+    // The token-aware regex requires "cover" to be flanked by separators.
+    const opf = buildOpf({
+      manifest: `
+        <item id="discover" href="xhtml/discover.xhtml" media-type="application/xhtml+xml"/>
+        <item id="ch1" href="xhtml/chapter001.xhtml" media-type="application/xhtml+xml"/>
+      `,
+      spine: `
+        <itemref idref="discover"/>
+        <itemref idref="ch1"/>
+      `,
+    });
+    expect(validatePrhSpine(INPUT(opf)).find((i) => i.code === 'PRH-SPINE-COVER-LINEAR')).toBeUndefined();
+  });
+
+  it('flags an interrupted footnotes block: footnotes1, appendix, footnotes2 (regression)', () => {
+    // Regression for CodeRabbit P2: previously only the final spine entry
+    // was inspected, so a layout where footnotes1.xhtml sits earlier in
+    // the spine with non-footnotes between it and footnotes2.xhtml passed
+    // when only footnotes2 was correctly placed.
+    const opf = buildOpf({
+      manifest: `
+        <item id="cover" href="xhtml/cover.xhtml" media-type="application/xhtml+xml"/>
+        <item id="footnotes1" href="xhtml/footnotes1.xhtml" media-type="application/xhtml+xml"/>
+        <item id="appendix" href="xhtml/appendix.xhtml" media-type="application/xhtml+xml"/>
+        <item id="footnotes2" href="xhtml/footnotes2.xhtml" media-type="application/xhtml+xml"/>
+      `,
+      spine: `
+        <itemref idref="cover" linear="no"/>
+        <itemref idref="footnotes1"/>
+        <itemref idref="appendix"/>
+        <itemref idref="footnotes2" linear="no"/>
+      `,
+    });
+    const issues = validatePrhSpine(INPUT(opf));
+    // Should flag footnotes1 as misplaced AND footnotes1 as missing linear="no".
+    const footnoteIssues = issues.filter((i) => i.code === 'PRH-SPINE-FOOTNOTES-LAST');
+    expect(footnoteIssues.length).toBeGreaterThanOrEqual(1);
+    const combinedMsgs = footnoteIssues.map((i) => i.message).join(' | ');
+    expect(combinedMsgs).toMatch(/footnotes1/);
+  });
+
+  it('passes when both split footnotes files form the trailing block', () => {
+    const opf = buildOpf({
+      manifest: `
+        <item id="cover" href="xhtml/cover.xhtml" media-type="application/xhtml+xml"/>
+        <item id="footnotes1" href="xhtml/footnotes1.xhtml" media-type="application/xhtml+xml"/>
+        <item id="footnotes2" href="xhtml/footnotes2.xhtml" media-type="application/xhtml+xml"/>
+      `,
+      spine: `
+        <itemref idref="cover" linear="no"/>
+        <itemref idref="footnotes1" linear="no"/>
+        <itemref idref="footnotes2" linear="no"/>
+      `,
+    });
     expect(validatePrhSpine(INPUT(opf))).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Builds on PR #356 / #357 (publisher-profile detector). When the detector returns PRH-UK at `medium` or `high` confidence, the audit pipeline now runs the new metadata + spine validators and merges their findings into the combined-issues stream. Six of the eight new issue codes have auto-fix handlers that write the literal PRH-required strings into the OPF.

This is **PR2 of 5** in the P1 PRH UK validation plan (`Ninja-Documentation/PRH-Analysis/plans/P1-Implementation-Plan.md`).

## Issue codes emitted

| Code | Severity | WCAG | Auto-fix? |
|---|---|---|---|
| `PRH-META-CONFORMS-TO` | moderate | 4.1.2 | ✅ |
| `PRH-META-CERTIFIED-BY` | moderate | 4.1.2 | ✅ |
| `PRH-META-CERTIFIER-CRED` | moderate | 4.1.2 | ✅ |
| `PRH-META-CERTIFIER-LINK` | moderate | 4.1.2 | ✅ |
| `PRH-META-TDM-RESERVATION` | moderate | — | ✅ |
| `PRH-META-A11Y-SUMMARY-URL` | minor | 4.1.2 | ✅ |
| `PRH-SPINE-COVER-LINEAR` | minor | — | manual |
| `PRH-SPINE-FOOTNOTES-LAST` | minor | — | manual |

`PRH-SPINE-*` are intentionally detect-only — spine reordering is risky enough that we want operator review before mutating spine entries.

## What this PR adds

| Path | Purpose |
|---|---|
| `src/services/epub/profiles/prh-uk/validators/metadata-validator.ts` | Pure function over OPF content. Six checks against PRH spec literals. |
| `src/services/epub/profiles/prh-uk/validators/spine-validator.ts` | Detect-only spine structure checks (cover linear=no; footnotes-must-be-last). |
| `src/services/epub/profiles/prh-uk/remediators/metadata-remediator.ts` | Six idempotent OPF rewriters; uses regex-based upsert-meta helper. |
| `src/services/epub/profiles/prh-uk/run-validators.ts` | Orchestrator that loads OPF once and runs both validators. Best-effort. |
| `src/services/epub/profiles/prh-uk/validators/types.ts` | Shared validator types. |

## What this PR modifies

- `src/services/epub/epub-audit.service.ts` — moved profile detection earlier in `runAudit()` so PRH issues join `combinedIssues` before dedup/scoring; extended `AccessibilityIssue.source` union with `'prh-uk'`; added `'prh-uk'` bucket to `summaryBySource`.
- `src/services/epub/auto-remediation.service.ts` — registered the six `PRH-META-*` fix handlers.
- `src/constants/fix-classification.ts` — added the six `PRH-META-*` codes to `BASE_AUTO_FIXABLE_CODES`.
- `src/services/acr/wcag-issue-mapper.service.ts` — added WCAG mappings for all eight new codes so VPAT generation classifies them.
- `src/services/epub/profiles/prh-uk/index.ts` — re-exports validators and remediators.

## Design notes worth your eye

1. **Validator gating.** PRH validators run only when `publisherProfile.publisher === 'PRH-UK' && publisherProfile.confidence !== 'low'`. Non-PRH and `low`-confidence detections see no behaviour change.
2. **Idempotent fixes.** Each remediator is a no-op when the OPF already matches the expected literal. Running fixConformsTo twice doesn't re-write the file.
3. **TDM-prefix handling.** `fixTdmReservation` appends `tdm: ...` to an existing `prefix=` attribute when present; adds a fresh `prefix=` attribute otherwise. Tested.
4. **Regex tolerance.** Validators and remediators accept either quote style (`"` or `'`) and tolerate optional whitespace around `=`. Tested via dedicated cases.
5. **Source = `'prh-uk'`.** New literal in the `AccessibilityIssue.source` union so attribution is explicit. `summaryBySource['prh-uk']` carries the same fields as `'js-auditor'` (severity counts + `autoFixable` count).
6. **No schema change.** Issues persist through the existing `Issue` table. Profile remains in-memory on `EpubAuditResult`.

## Test plan

- [x] **35 new Vitest unit tests** across 3 suites:
  - `metadata-validator`: 13 cases — all six fields covered (missing + wrong-value), single-quote handling, attribute-order tolerance, no-double-counting check
  - `spine-validator`: 9 cases — cover linear=no detection, footnotes-not-last, footnotes-last-but-not-linear-no, no-footnotes pass, no-spine pass, single-quote handling
  - `metadata-remediator`: 13 cases — each fix individually + end-to-end (apply all six → validator returns zero issues), idempotency, missing-OPF safety, prefix-append-without-clobber, link-href-replacement
- [x] PR1's 27 PRH tests still pass — combined PR1+PR2 PRH suite **62/62**
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean on all touched files
- [x] Full vitest suite: **1088 passing** (was 1053 after PR1+hot-fix), same 7 pre-existing failures in `workflow-config.integration.test.ts` / `workflow-websocket.test.ts`. Zero regressions.

## Smoke-test plan after merge + deploy

1. Re-upload `PRH EPUB Technical Guide 2.0.3.epub` to staging. Expect `combinedIssues` to now contain `PRH-META-*` and possibly `PRH-SPINE-*` entries (the Technical Guide is itself a compliant EPUB so the count should be small — mostly zero or one or two minor).
2. Upload an EPUB known to be missing certifier metadata. Expect `PRH-META-CERTIFIED-BY`, `PRH-META-CERTIFIER-CRED`, etc. to flag, with severity `moderate`.
3. Trigger an auto-fix on one of the `PRH-META-*` issues; re-audit; verify it disappears.
4. Upload a non-PRH EPUB. Expect zero `PRH-*` issues (gating works).

## Out of scope (PR3-5)

- PR3: nav landmarks + per-XHTML lang/title validators
- PR4: cover-alt-non-empty + decorative-`role="presentation"` validators
- PR5: `VPAT2.5-PRH-UK` edition pinned to WCAG 2.2 AA + PRH certifier metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PRH UK publisher profile support: validators detect PRH-specific metadata and spine issues and are included in audit summaries.
  * Audit reporting now attributes PRH-UK issues and counts auto-fixable items.
  * Automatic remediation can apply PRH UK metadata fixes to EPUBs.

* **Tests**
  * Added comprehensive unit tests for PRH validators and remediators.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/358)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->