### PR TITLE
feat(epub): PRH UK nav + per-XHTML validators (PR3/5)

### DIFF
--- a/src/constants/fix-classification.ts
+++ b/src/constants/fix-classification.ts
@@ -27,8 +27,15 @@ const BASE_AUTO_FIXABLE_CODES = new Set([
   'PRH-META-CERTIFIER-LINK',
   'PRH-META-TDM-RESERVATION',
   'PRH-META-A11Y-SUMMARY-URL',
+  // PRH UK profile per-XHTML — adds both lang AND xml:lang to <html>
+  // (stricter than EPUB-SEM-001 which only requires lang)
+  'PRH-XHTML-XML-LANG',
   // PRH-SPINE-* codes are detect-only in PR2 — spine reordering is risky
   // enough that we want operator review before mutating spine entries.
+  // PRH-NAV-* codes are detect-only in PR3 — nav-doc structure changes
+  // need operator review (rewriting hidden landmarks can confuse readers).
+  // PRH-XHTML-TITLE-EMPTY-OR-GENERIC is detect-only — choosing the right
+  // chapter/section title is an editorial decision, not mechanical.
 ]);
 
 export function getAutoFixableCodes(): Set<string> {

--- a/src/services/epub/auto-remediation.service.ts
+++ b/src/services/epub/auto-remediation.service.ts
@@ -12,6 +12,7 @@ import {
   fixCertifierLink,
   fixTdmReservation,
   fixA11ySummaryUrl,
+  fixXmlLang,
 } from './profiles/prh-uk';
 
 const comparisonService = new ComparisonService(prisma);
@@ -154,6 +155,10 @@ class AutoRemediationService {
     'PRH-META-CERTIFIER-LINK': async (zip) => fixCertifierLink(zip),
     'PRH-META-TDM-RESERVATION': async (zip) => fixTdmReservation(zip),
     'PRH-META-A11Y-SUMMARY-URL': async (zip) => fixA11ySummaryUrl(zip),
+    // ── PRH UK profile per-XHTML fix ─────────────────────────────────────
+    // Walks every XHTML/HTML file ensuring <html> carries BOTH lang and
+    // xml:lang. Stricter than EPUB-SEM-001 (which only requires lang).
+    'PRH-XHTML-XML-LANG': async (zip) => fixXmlLang(zip),
   };
 
   async runAutoRemediation(

--- a/src/services/epub/profiles/prh-uk/index.ts
+++ b/src/services/epub/profiles/prh-uk/index.ts
@@ -19,3 +19,4 @@ export {
   fixTdmReservation,
   fixA11ySummaryUrl,
 } from './remediators/metadata-remediator';
+export { fixXmlLang } from './remediators/xhtml-remediator';

--- a/src/services/epub/profiles/prh-uk/remediators/xhtml-remediator.ts
+++ b/src/services/epub/profiles/prh-uk/remediators/xhtml-remediator.ts
@@ -23,6 +23,32 @@ interface ChangeResult {
 }
 
 /**
+ * Loose BCP 47 sanity check: ASCII letters/digits/hyphens, max 35 chars.
+ * Real BCP 47 is more nuanced but this is enough to reject anything we
+ * could safely call "almost certainly malicious or malformed" before
+ * interpolating back into an XML attribute.
+ */
+const BCP47_LIKE = /^[A-Za-z]{1,8}(?:-[A-Za-z0-9]{1,8})*$/;
+
+function isValidLangToken(value: string | null | undefined): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 35 && BCP47_LIKE.test(value);
+}
+
+/**
+ * Pick the first BCP-47-shaped token from the candidate list, falling
+ * back to the supplied default. Used so we never re-inject an attacker-
+ * crafted or malformed `lang` value back into the XHTML.
+ */
+function pickValidLangToken(...candidates: Array<string | null | undefined>): string {
+  for (const c of candidates.slice(0, -1)) {
+    if (isValidLangToken(c)) return c;
+  }
+  // Last candidate is the safe-default fallback (already validated by caller).
+  const fallback = candidates[candidates.length - 1];
+  return isValidLangToken(fallback) ? fallback : 'en';
+}
+
+/**
  * Walk every XHTML/HTML file in the EPUB, ensuring `<html>` has both
  * `lang` and `xml:lang` attributes. Defaults to `"en"` if neither is
  * present (PRH books are English-language unless explicitly translated;
@@ -70,10 +96,17 @@ export async function fixXmlLang(zip: JSZip, defaultLanguage: string = 'en'): Pr
     }
 
     // Decide the language code: prefer existing non-empty lang, else
-    // existing non-empty xml:lang, else the sanitised default.
-    const language = (hasGoodLang ? langValue : null)
-      ?? (hasGoodXmlLang ? xmlLangValue : null)
-      ?? safeDefault;
+    // existing non-empty xml:lang, else the sanitised default. Each
+    // candidate is validated as a BCP 47-shaped token before use — even
+    // though our regex already rejects quote characters, an upstream
+    // value with `<`, `>`, `&` or control chars would still produce
+    // malformed XML when re-injected. If neither captured value is
+    // valid, fall back to the safe default.
+    const language = pickValidLangToken(
+      hasGoodLang ? langValue : null,
+      hasGoodXmlLang ? xmlLangValue : null,
+      safeDefault,
+    );
 
     let newAttrs = attrs;
     if (!hasGoodLang) {

--- a/src/services/epub/profiles/prh-uk/remediators/xhtml-remediator.ts
+++ b/src/services/epub/profiles/prh-uk/remediators/xhtml-remediator.ts
@@ -48,45 +48,75 @@ export async function fixXmlLang(zip: JSZip, defaultLanguage: string = 'en'): Pr
     const attrs = htmlMatch[1];
     // Same regex caveat as the validator: `\blang` matches inside `xml:lang`
     // because the colon is a word boundary. Require start-of-attrs or
-    // whitespace before `lang` to disambiguate.
+    // whitespace before `lang` to disambiguate. We capture the value to
+    // detect empty attributes (`lang=""`) which need replacement, not
+    // insertion — they're "present but invalid" per the validator.
     const langMatch = attrs.match(/(?:^|\s)lang\s*=\s*(["'])([^"']*)\1/i);
     const xmlLangMatch = attrs.match(/\bxml:lang\s*=\s*(["'])([^"']*)\1/i);
 
     const langValue = langMatch?.[2] ?? null;
     const xmlLangValue = xmlLangMatch?.[2] ?? null;
+    // "Present and non-empty" — anything else (missing or empty string) is
+    // treated as needing a fix.
+    const hasGoodLang = langValue !== null && langValue.length > 0;
+    const hasGoodXmlLang = xmlLangValue !== null && xmlLangValue.length > 0;
 
-    if (langValue && xmlLangValue) {
+    if (hasGoodLang && hasGoodXmlLang) {
       alreadyOk++;
       continue;
     }
 
-    // Decide the language code: prefer existing lang, else xml:lang, else default.
-    const language = langValue ?? xmlLangValue ?? defaultLanguage;
+    // Decide the language code: prefer existing non-empty lang, else
+    // existing non-empty xml:lang, else default.
+    const language = (hasGoodLang ? langValue : null)
+      ?? (hasGoodXmlLang ? xmlLangValue : null)
+      ?? defaultLanguage;
+
     let newAttrs = attrs;
-    if (!langMatch) {
-      newAttrs = `${newAttrs} lang="${language}"`;
+    if (!hasGoodLang) {
+      if (langMatch) {
+        // Replace the existing empty lang="" with the correct value.
+        newAttrs = newAttrs.replace(/(?:^|\s)lang\s*=\s*(["'])([^"']*)\1/i, ` lang="${language}"`);
+      } else {
+        newAttrs = `${newAttrs} lang="${language}"`;
+      }
     }
-    if (!xmlLangMatch) {
-      newAttrs = `${newAttrs} xml:lang="${language}"`;
+    if (!hasGoodXmlLang) {
+      if (xmlLangMatch) {
+        newAttrs = newAttrs.replace(/\bxml:lang\s*=\s*(["'])([^"']*)\1/i, `xml:lang="${language}"`);
+      } else {
+        newAttrs = `${newAttrs} xml:lang="${language}"`;
+      }
     }
     const updated = content.replace(/<html\b[^>]*>/i, `<html${newAttrs}>`);
     if (updated !== content) {
       zip.file(filePath, updated);
       touched++;
-      logger.debug(`[PRH-XHTML-XML-LANG] ${filePath}: added ${[!langMatch && 'lang', !xmlLangMatch && 'xml:lang'].filter(Boolean).join(' + ')}`);
+      const actions: string[] = [];
+      if (!hasGoodLang) actions.push(langMatch ? 'replaced empty lang' : 'added lang');
+      if (!hasGoodXmlLang) actions.push(xmlLangMatch ? 'replaced empty xml:lang' : 'added xml:lang');
+      logger.debug(`[PRH-XHTML-XML-LANG] ${filePath}: ${actions.join(' + ')}`);
+      // Record one ChangeResult per touched file so the caller can map
+      // task completion back to a specific XHTML — important for the
+      // remediation service's per-task completion accounting.
+      results.push({
+        success: true,
+        description: `PRH-XHTML-XML-LANG: ${actions.join(' + ')} in ${filePath}`,
+        before: htmlMatch[0],
+        after: `<html${newAttrs}>`,
+      });
     }
   }
 
-  if (touched === 0) {
+  if (results.length === 0) {
+    // Nothing to fix — emit a single informational entry so the caller's
+    // success/skip accounting still records the no-op.
     results.push({
       success: true,
       description: `PRH-XHTML-XML-LANG: all XHTML files already carry both lang and xml:lang (${alreadyOk} files inspected)`,
     });
-  } else {
-    results.push({
-      success: true,
-      description: `PRH-XHTML-XML-LANG: added missing lang/xml:lang to ${touched} XHTML file(s); ${alreadyOk} were already compliant`,
-    });
   }
+  // Otherwise: one ChangeResult per touched file is already accumulated.
+  void touched;
   return results;
 }

--- a/src/services/epub/profiles/prh-uk/remediators/xhtml-remediator.ts
+++ b/src/services/epub/profiles/prh-uk/remediators/xhtml-remediator.ts
@@ -31,6 +31,9 @@ interface ChangeResult {
  * the existing value is reused so we don't drift the language code.
  */
 export async function fixXmlLang(zip: JSZip, defaultLanguage: string = 'en'): Promise<ChangeResult[]> {
+  // Reject empty / whitespace-only language codes so they can't flow
+  // through and produce `lang=""` (which would re-trigger the validator).
+  const safeDefault = defaultLanguage.trim().length > 0 ? defaultLanguage.trim() : 'en';
   const results: ChangeResult[] = [];
   const filePaths = Object.keys(zip.files);
   let touched = 0;
@@ -67,10 +70,10 @@ export async function fixXmlLang(zip: JSZip, defaultLanguage: string = 'en'): Pr
     }
 
     // Decide the language code: prefer existing non-empty lang, else
-    // existing non-empty xml:lang, else default.
+    // existing non-empty xml:lang, else the sanitised default.
     const language = (hasGoodLang ? langValue : null)
       ?? (hasGoodXmlLang ? xmlLangValue : null)
-      ?? defaultLanguage;
+      ?? safeDefault;
 
     let newAttrs = attrs;
     if (!hasGoodLang) {

--- a/src/services/epub/profiles/prh-uk/remediators/xhtml-remediator.ts
+++ b/src/services/epub/profiles/prh-uk/remediators/xhtml-remediator.ts
@@ -1,0 +1,92 @@
+/**
+ * PRH UK per-XHTML remediators.
+ *
+ * Currently exposes one fix: `fixXmlLang` ensures every `<html>` element
+ * carries BOTH `lang` and `xml:lang`. The existing
+ * `epub-modifier.service.ts:addHtmlLangAttributes` short-circuits whenever
+ * `lang` alone is present, so it cannot upgrade a file from
+ * `<html lang="en">` to `<html lang="en" xml:lang="en">` — which is what
+ * the PRH Technical Guide requires (`<html ... lang="en" xml:lang="en">`).
+ *
+ * The fix is idempotent: when both attributes are already present, the
+ * file is left untouched.
+ */
+
+import JSZip from 'jszip';
+import { logger } from '../../../../../lib/logger';
+
+interface ChangeResult {
+  success: boolean;
+  description: string;
+  before?: string;
+  after?: string;
+}
+
+/**
+ * Walk every XHTML/HTML file in the EPUB, ensuring `<html>` has both
+ * `lang` and `xml:lang` attributes. Defaults to `"en"` if neither is
+ * present (PRH books are English-language unless explicitly translated;
+ * the Style Guide doesn't define a way to derive language from OPF for
+ * this fix). When one attribute is present and the other is missing,
+ * the existing value is reused so we don't drift the language code.
+ */
+export async function fixXmlLang(zip: JSZip, defaultLanguage: string = 'en'): Promise<ChangeResult[]> {
+  const results: ChangeResult[] = [];
+  const filePaths = Object.keys(zip.files);
+  let touched = 0;
+  let alreadyOk = 0;
+
+  for (const filePath of filePaths) {
+    if (!/\.(x?html?)$/i.test(filePath)) continue;
+
+    const content = await zip.file(filePath)?.async('text');
+    if (!content) continue;
+
+    const htmlMatch = content.match(/<html\b([^>]*)>/i);
+    if (!htmlMatch) continue;
+
+    const attrs = htmlMatch[1];
+    // Same regex caveat as the validator: `\blang` matches inside `xml:lang`
+    // because the colon is a word boundary. Require start-of-attrs or
+    // whitespace before `lang` to disambiguate.
+    const langMatch = attrs.match(/(?:^|\s)lang\s*=\s*(["'])([^"']*)\1/i);
+    const xmlLangMatch = attrs.match(/\bxml:lang\s*=\s*(["'])([^"']*)\1/i);
+
+    const langValue = langMatch?.[2] ?? null;
+    const xmlLangValue = xmlLangMatch?.[2] ?? null;
+
+    if (langValue && xmlLangValue) {
+      alreadyOk++;
+      continue;
+    }
+
+    // Decide the language code: prefer existing lang, else xml:lang, else default.
+    const language = langValue ?? xmlLangValue ?? defaultLanguage;
+    let newAttrs = attrs;
+    if (!langMatch) {
+      newAttrs = `${newAttrs} lang="${language}"`;
+    }
+    if (!xmlLangMatch) {
+      newAttrs = `${newAttrs} xml:lang="${language}"`;
+    }
+    const updated = content.replace(/<html\b[^>]*>/i, `<html${newAttrs}>`);
+    if (updated !== content) {
+      zip.file(filePath, updated);
+      touched++;
+      logger.debug(`[PRH-XHTML-XML-LANG] ${filePath}: added ${[!langMatch && 'lang', !xmlLangMatch && 'xml:lang'].filter(Boolean).join(' + ')}`);
+    }
+  }
+
+  if (touched === 0) {
+    results.push({
+      success: true,
+      description: `PRH-XHTML-XML-LANG: all XHTML files already carry both lang and xml:lang (${alreadyOk} files inspected)`,
+    });
+  } else {
+    results.push({
+      success: true,
+      description: `PRH-XHTML-XML-LANG: added missing lang/xml:lang to ${touched} XHTML file(s); ${alreadyOk} were already compliant`,
+    });
+  }
+  return results;
+}

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -132,12 +132,26 @@ function readDcTitle(opfContent: string): string | null {
 
 /**
  * Resolve a manifest href (relative to the OPF directory) into a zip path.
+ *
+ * The OPF lives in the zip at e.g. `EPUB/package.opf`; manifest item hrefs
+ * are relative to that file's directory. We have to normalise `.` and `..`
+ * segments because some valid manifests carry hrefs like
+ * `../text/nav-doc.xhtml` (when the OPF lives in a sub-directory). Plain
+ * concatenation would emit `EPUB/../text/nav-doc.xhtml`, which doesn't
+ * exist as a literal zip entry, so the lookup would silently fail.
  */
 function resolveOpfRelative(opfPath: string, href: string): string {
-  // OPF paths in the zip usually look like `EPUB/package.opf`. The manifest
-  // item href is relative to that file's directory. So `nav.xhtml` from
-  // `EPUB/package.opf` resolves to `EPUB/nav.xhtml`.
-  const dir = opfPath.includes('/') ? opfPath.slice(0, opfPath.lastIndexOf('/') + 1) : '';
-  // Don't normalise `..` segments — uncommon and risky to handle here.
-  return dir + href;
+  const dir = opfPath.includes('/') ? opfPath.slice(0, opfPath.lastIndexOf('/')) : '';
+  const combined = dir.length > 0 ? `${dir}/${href}` : href;
+  const segments = combined.split('/');
+  const out: string[] = [];
+  for (const seg of segments) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      out.pop();
+      continue;
+    }
+    out.push(seg);
+  }
+  return out.join('/');
 }

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -1,7 +1,8 @@
 /**
- * Orchestrator for PRH UK validators. Loads the OPF once via JSZip, runs
- * each validator, and returns a flat list of `PrhValidatorIssue` objects
- * for the audit pipeline to translate into `AccessibilityIssue` records.
+ * Orchestrator for PRH UK validators. Loads the OPF + nav doc + every
+ * XHTML file once via JSZip, then runs each validator against the parsed
+ * inputs. Returns a flat list of `PrhValidatorIssue` objects for the audit
+ * pipeline to translate into `AccessibilityIssue` records.
  *
  * Best-effort: if the EPUB can't be parsed we return an empty list rather
  * than throwing — a validator failure must never break the surrounding
@@ -12,7 +13,9 @@ import JSZip from 'jszip';
 import { logger } from '../../../../lib/logger';
 import { validatePrhMetadata } from './validators/metadata-validator';
 import { validatePrhSpine } from './validators/spine-validator';
-import type { PrhValidatorIssue } from './validators/types';
+import { validatePrhNav } from './validators/nav-validator';
+import { validatePrhPerXhtml } from './validators/xhtml-validator';
+import type { PrhValidatorIssue, PrhXhtmlFile } from './validators/types';
 
 export async function runPrhUkValidators(buffer: Buffer): Promise<PrhValidatorIssue[]> {
   try {
@@ -22,10 +25,28 @@ export async function runPrhUkValidators(buffer: Buffer): Promise<PrhValidatorIs
       logger.warn('[PRH validators] OPF not found; skipping');
       return [];
     }
-    const input = { opfContent: opf.content, opfPath: opf.path };
+
+    const navDoc = await readNavDoc(zip, opf.path, opf.content);
+    const xhtmlFiles = await readAllXhtml(zip);
+    const bookTitle = readDcTitle(opf.content);
+
+    const opfInput = { opfContent: opf.content, opfPath: opf.path };
+    const navInput = {
+      ...opfInput,
+      navContent: navDoc?.content ?? null,
+      navPath: navDoc?.path ?? null,
+    };
+    const perXhtmlInput = {
+      ...opfInput,
+      xhtmlFiles,
+      bookTitle,
+    };
+
     return [
-      ...validatePrhMetadata(input),
-      ...validatePrhSpine(input),
+      ...validatePrhMetadata(opfInput),
+      ...validatePrhSpine(opfInput),
+      ...validatePrhNav(navInput),
+      ...validatePrhPerXhtml(perXhtmlInput),
     ];
   } catch (err) {
     logger.warn(
@@ -34,6 +55,8 @@ export async function runPrhUkValidators(buffer: Buffer): Promise<PrhValidatorIs
     return [];
   }
 }
+
+// ── helpers ──────────────────────────────────────────────────────────────
 
 async function readOpf(zip: JSZip): Promise<{ path: string; content: string } | null> {
   const containerXml = await zip.file('META-INF/container.xml')?.async('text');
@@ -44,4 +67,77 @@ async function readOpf(zip: JSZip): Promise<{ path: string; content: string } | 
   const content = await zip.file(opfPath)?.async('text');
   if (!content) return null;
   return { path: opfPath, content };
+}
+
+/**
+ * Locate the EPUB 3 nav document. Preference order:
+ *   1. The manifest item with `properties="nav"` (canonical EPUB 3 marker).
+ *   2. A file whose path matches `nav.xhtml` / `toc.xhtml` (legacy fallback).
+ */
+async function readNavDoc(
+  zip: JSZip,
+  opfPath: string,
+  opfContent: string,
+): Promise<{ path: string; content: string } | null> {
+  // 1. properties="nav"
+  const manifestMatch = opfContent.match(/<manifest\b[^>]*>([\s\S]*?)<\/manifest>/i);
+  if (manifestMatch) {
+    const items = manifestMatch[1].matchAll(/<item\b([^>]*)\/?>/gi);
+    for (const m of items) {
+      const attrs = m[1];
+      if (/\bproperties\s*=\s*["'][^"']*\bnav\b[^"']*["']/i.test(attrs)) {
+        const hrefMatch = attrs.match(/\bhref\s*=\s*["']([^"']+)["']/i);
+        if (hrefMatch) {
+          const navPath = resolveOpfRelative(opfPath, hrefMatch[1]);
+          const content = await zip.file(navPath)?.async('text');
+          if (content) return { path: navPath, content };
+        }
+      }
+    }
+  }
+
+  // 2. Filename heuristic.
+  for (const filePath of Object.keys(zip.files)) {
+    if (/(?:^|\/)(nav|toc)\.x?html?$/i.test(filePath)) {
+      const content = await zip.file(filePath)?.async('text');
+      if (content) return { path: filePath, content };
+    }
+  }
+  return null;
+}
+
+/**
+ * Read every XHTML/HTML file in the zip. We read all of them rather than
+ * just spine entries because the per-XHTML rules apply universally — even
+ * non-linear pages (long descriptions, footnotes) need lang attributes and
+ * sensible <title>s.
+ */
+async function readAllXhtml(zip: JSZip): Promise<PrhXhtmlFile[]> {
+  const out: PrhXhtmlFile[] = [];
+  for (const filePath of Object.keys(zip.files)) {
+    if (!/\.(x?html?)$/i.test(filePath)) continue;
+    const content = await zip.file(filePath)?.async('text');
+    if (!content) continue;
+    out.push({ path: filePath, content });
+  }
+  return out;
+}
+
+function readDcTitle(opfContent: string): string | null {
+  const m = opfContent.match(/<dc:title\b[^>]*>([\s\S]*?)<\/dc:title>/i);
+  if (!m) return null;
+  const inner = m[1].trim();
+  return inner.length === 0 ? null : inner;
+}
+
+/**
+ * Resolve a manifest href (relative to the OPF directory) into a zip path.
+ */
+function resolveOpfRelative(opfPath: string, href: string): string {
+  // OPF paths in the zip usually look like `EPUB/package.opf`. The manifest
+  // item href is relative to that file's directory. So `nav.xhtml` from
+  // `EPUB/package.opf` resolves to `EPUB/nav.xhtml`.
+  const dir = opfPath.includes('/') ? opfPath.slice(0, opfPath.lastIndexOf('/') + 1) : '';
+  // Don't normalise `..` segments — uncommon and risky to handle here.
+  return dir + href;
 }

--- a/src/services/epub/profiles/prh-uk/validators/nav-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/nav-validator.ts
@@ -1,0 +1,155 @@
+/**
+ * PRH UK navigation-document validator.
+ *
+ * Per the Technical Guide (`nav.xhtml` example), every PRH EPUB must have a
+ * nav document containing three <nav> blocks:
+ *
+ *   1. <nav epub:type="toc" role="doc-toc">           — visible TOC
+ *   2. <nav epub:type="landmarks" class="at_only">    — landmark whitelist
+ *   3. <nav epub:type="page-list" hidden="hidden"
+ *           class="hidden_content">                   — print page-number map
+ *
+ * The page-list MUST be hidden via `hidden="hidden"` AND `class="hidden_content"`
+ * (NOT inline style — reading systems treat the two attributes as canonical).
+ *
+ * The landmarks block must include entries for at least:
+ *   - epub:type="cover"
+ *   - epub:type="frontmatter"
+ *   - epub:type="toc"
+ *   - epub:type="bodymatter"
+ *
+ * (Other landmark entries — `loi`, `glossary`, `bibliography`, `index` — are
+ * conditional on the book containing them, so we don't enforce them here.)
+ *
+ * All findings are detect-only. Auto-fix lands in a later PR.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhNavInput, PrhValidatorIssue } from './types';
+
+export function validatePrhNav(input: PrhNavInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+  const navContent = input.navContent;
+  const location = input.navPath || 'nav.xhtml';
+
+  // No nav doc at all → don't emit nav-specific issues. Detection that the
+  // EPUB is missing a nav document entirely is EPUBCheck's job.
+  if (!navContent) return issues;
+
+  // ── 1. page-list nav ──────────────────────────────────────────────────
+  const pageListBlock = extractNavBlock(navContent, 'page-list');
+  if (!pageListBlock) {
+    issues.push(
+      buildIssue('PRH-NAV-MISSING-PAGELIST', location, {
+        message: 'nav.xhtml is missing a <nav epub:type="page-list"> block',
+        suggestion: 'Add a page-list nav with hidden="hidden" class="hidden_content"; populate from epub:type="pagebreak" anchors',
+      }),
+    );
+  } else {
+    const hasHiddenAttr = /\bhidden\s*=\s*["']hidden["']/i.test(pageListBlock.openTag);
+    const hasHiddenClass = /\bclass\s*=\s*["'][^"']*\bhidden_content\b[^"']*["']/i.test(pageListBlock.openTag);
+    if (!hasHiddenAttr || !hasHiddenClass) {
+      const reasons: string[] = [];
+      if (!hasHiddenAttr) reasons.push('hidden="hidden" attribute is missing');
+      if (!hasHiddenClass) reasons.push('class="hidden_content" is missing');
+      issues.push(
+        buildIssue('PRH-NAV-PAGELIST-NOT-HIDDEN', location, {
+          message: `page-list nav is not hidden as required: ${reasons.join('; ')}`,
+          suggestion: 'Update <nav epub:type="page-list"> to include both hidden="hidden" attribute AND class="hidden_content" (do NOT use inline style="display:none")',
+        }),
+      );
+    }
+  }
+
+  // ── 2. landmarks whitelist ────────────────────────────────────────────
+  const landmarksBlock = extractNavBlock(navContent, 'landmarks');
+  if (landmarksBlock) {
+    // Per the Technical Guide example, landmark anchors carry epub:type
+    // values like "cover", "frontmatter ibooks:reader-start-page" (multiple
+    // tokens), "toc", "bodymatter". Match any anchor whose epub:type
+    // attribute *contains* the required token (whitespace-separated).
+    const requiredLandmarks: Array<{ token: string; code: keyof typeof PRH_ISSUE_CODES }> = [
+      { token: 'cover', code: 'PRH-NAV-LANDMARKS-MISSING-COVER' },
+      { token: 'frontmatter', code: 'PRH-NAV-LANDMARKS-MISSING-FRONTMATTER' },
+      { token: 'toc', code: 'PRH-NAV-LANDMARKS-MISSING-TOC' },
+      { token: 'bodymatter', code: 'PRH-NAV-LANDMARKS-MISSING-BODYMATTER' },
+    ];
+    for (const { token, code } of requiredLandmarks) {
+      if (!landmarkContainsType(landmarksBlock.body, token)) {
+        issues.push(
+          buildIssue(code, location, {
+            message: `landmarks nav is missing an entry with epub:type="${token}"`,
+            suggestion: `Add: <li><a epub:type="${token}" href="...">${capitalise(token)}</a></li>`,
+          }),
+        );
+      }
+    }
+  }
+  // If the landmarks block itself is missing, EPUBCheck will already
+  // complain — we don't double-emit here.
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+interface NavBlock {
+  /** Opening `<nav ...>` tag including all its attributes. */
+  openTag: string;
+  /** Inner content between `<nav>` and `</nav>`. */
+  body: string;
+}
+
+/**
+ * Extract a `<nav epub:type="X">...</nav>` block from the nav doc. Returns
+ * the open tag and inner body separately so callers can inspect both
+ * attributes (on the tag) and content (in the body). Tolerant of whitespace,
+ * either quote style, and additional epub:type tokens.
+ */
+function extractNavBlock(navDoc: string, epubType: string): NavBlock | null {
+  // Match: <nav ... epub:type="...EPUBTYPE..." ...> body </nav>
+  // We accept multi-token epub:type values like "frontmatter ibooks:..." by
+  // matching epub:type as containing the requested token (separated by
+  // whitespace or as the entire value).
+  const escaped = epubType.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(
+    `<nav\\b([^>]*\\bepub:type\\s*=\\s*["'][^"']*\\b${escaped}\\b[^"']*["'][^>]*)>([\\s\\S]*?)</nav>`,
+    'i',
+  );
+  const m = navDoc.match(re);
+  if (!m) return null;
+  return { openTag: m[0].slice(0, m[0].indexOf('>') + 1), body: m[2] };
+}
+
+/**
+ * Check whether the landmarks block contains an anchor whose epub:type
+ * attribute includes the requested token (e.g. "cover", "bodymatter").
+ */
+function landmarkContainsType(landmarksBody: string, token: string): boolean {
+  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(
+    `<a\\b[^>]*\\bepub:type\\s*=\\s*["'][^"']*\\b${escaped}\\b[^"']*["']`,
+    'i',
+  );
+  return re.test(landmarksBody);
+}
+
+function capitalise(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+function buildIssue(
+  code: keyof typeof PRH_ISSUE_CODES,
+  location: string,
+  parts: { message: string; suggestion: string },
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: parts.message,
+    suggestion: parts.suggestion,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/types.ts
+++ b/src/services/epub/profiles/prh-uk/validators/types.ts
@@ -31,3 +31,25 @@ export interface PrhValidatorInput {
   /** Path of the OPF inside the zip (e.g. 'EPUB/package.opf'). */
   opfPath: string;
 }
+
+/** One XHTML file's content + path, surfaced to per-XHTML validators. */
+export interface PrhXhtmlFile {
+  path: string;
+  content: string;
+}
+
+/** Inputs the per-XHTML validator reads — extends the OPF input. */
+export interface PrhPerXhtmlInput extends PrhValidatorInput {
+  /** dc:title from the OPF, if present. Used to flag generic page titles. */
+  bookTitle: string | null;
+  /** Every XHTML/HTML file in the EPUB. */
+  xhtmlFiles: PrhXhtmlFile[];
+}
+
+/** Inputs the nav-doc validator reads — extends the OPF input. */
+export interface PrhNavInput extends PrhValidatorInput {
+  /** Full nav.xhtml content, or null if no nav doc was located. */
+  navContent: string | null;
+  /** Path of the nav doc inside the zip, or null. */
+  navPath: string | null;
+}

--- a/src/services/epub/profiles/prh-uk/validators/xhtml-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/xhtml-validator.ts
@@ -1,0 +1,98 @@
+/**
+ * PRH UK per-XHTML validator.
+ *
+ * Two checks per XHTML file:
+ *
+ *   PRH-XHTML-XML-LANG               — every <html> must carry BOTH `lang`
+ *                                       AND `xml:lang` attributes (existing
+ *                                       EPUB-SEM-001 only requires `lang`).
+ *   PRH-XHTML-TITLE-EMPTY-OR-GENERIC — <head><title> must be present,
+ *                                       non-empty, and not just the book
+ *                                       title (per the Technical Guide
+ *                                       guidance: "Chapter 7, 1Q84
+ *                                       Volume 3" rather than just "1Q84").
+ *
+ * Both checks emit one issue per offending file so the operator can locate
+ * the broken XHTML quickly. The summaryBySource counter rolls up totals.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhPerXhtmlInput, PrhValidatorIssue } from './types';
+
+export function validatePrhPerXhtml(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+  const bookTitle = input.bookTitle?.trim().toLowerCase() ?? null;
+
+  for (const file of input.xhtmlFiles) {
+    // ── 1. <html> must carry both lang AND xml:lang ─────────────────────
+    const htmlOpenMatch = file.content.match(/<html\b([^>]*)>/i);
+    if (htmlOpenMatch) {
+      const attrs = htmlOpenMatch[1];
+      // Require start-of-attrs or whitespace before `lang` so the bare
+      // `lang` inside `xml:lang` doesn't trip the check (the colon counts
+      // as a word boundary, so a naive `\blang` matches both attribute
+      // names — a real bug surfaced by tests).
+      const hasLang = /(?:^|\s)lang\s*=\s*["'][^"']+["']/i.test(attrs);
+      const hasXmlLang = /\bxml:lang\s*=\s*["'][^"']+["']/i.test(attrs);
+      if (!hasLang || !hasXmlLang) {
+        const reasons: string[] = [];
+        if (!hasLang) reasons.push('lang');
+        if (!hasXmlLang) reasons.push('xml:lang');
+        issues.push(
+          buildIssue('PRH-XHTML-XML-LANG', file.path, {
+            message: `<html> is missing required attribute(s): ${reasons.join(', ')}`,
+            suggestion: `Add to the <html> element: ${reasons.map((r) => `${r}="en"`).join(' ')} (use the appropriate ISO 639-1 code for this book's language)`,
+          }),
+        );
+      }
+    }
+
+    // ── 2. <head><title> must be specific, not the book title alone ────
+    const titleValue = extractHeadTitle(file.content);
+    if (titleValue == null) {
+      issues.push(
+        buildIssue('PRH-XHTML-TITLE-EMPTY-OR-GENERIC', file.path, {
+          message: '<head><title> is missing or empty',
+          suggestion: 'Set <title> to a chapter or section identifier (e.g. "Chapter 7, [Book Title]")',
+        }),
+      );
+    } else if (bookTitle && titleValue.trim().toLowerCase() === bookTitle) {
+      issues.push(
+        buildIssue('PRH-XHTML-TITLE-EMPTY-OR-GENERIC', file.path, {
+          message: `<title> is just the book title ("${titleValue.trim()}"); PRH expects a chapter/section identifier`,
+          suggestion: `Update <title> to include a chapter or section identifier (e.g. "Chapter 7, ${titleValue.trim()}")`,
+        }),
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/** Pull the inner text of the first `<title>` element inside `<head>`. */
+function extractHeadTitle(content: string): string | null {
+  const headMatch = content.match(/<head\b[^>]*>([\s\S]*?)<\/head>/i);
+  if (!headMatch) return null;
+  const titleMatch = headMatch[1].match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+  if (!titleMatch) return null;
+  const inner = titleMatch[1].trim();
+  return inner.length === 0 ? null : inner;
+}
+
+function buildIssue(
+  code: keyof typeof PRH_ISSUE_CODES,
+  location: string,
+  parts: { message: string; suggestion: string },
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: parts.message,
+    suggestion: parts.suggestion,
+    location,
+  };
+}

--- a/src/services/epub/remediation.service.ts
+++ b/src/services/epub/remediation.service.ts
@@ -30,22 +30,26 @@ import {
   fixCertifierLink,
   fixTdmReservation,
   fixA11ySummaryUrl,
+  fixXmlLang,
 } from './profiles/prh-uk';
 
 /**
- * PRH metadata fix functions return a slim {success, description, before?,
- * after?} shape; this autoApplyHighConfidenceFixes pipeline expects the
- * full ModificationResult shape with filePath + modificationType. Adapt
- * the slim results into the expected shape so the caller's success/failure
+ * PRH fix functions return a slim {success, description, before?, after?}
+ * shape; this autoApplyHighConfidenceFixes pipeline expects the full
+ * ModificationResult shape with filePath + modificationType. Adapt the
+ * slim results into the expected shape so the caller's success/failure
  * accounting and change-log code paths work unchanged.
+ *
+ * Defaults assume an OPF metadata fix; xhtml fixes pass overrides.
  */
 function adaptPrhResults(
   results: Array<{ success: boolean; description: string; before?: string; after?: string }>,
+  overrides: { filePath?: string; modificationType?: string } = {},
 ): ModificationResult[] {
   return results.map((r) => ({
     success: r.success,
-    filePath: 'package.opf',
-    modificationType: 'metadata',
+    filePath: overrides.filePath ?? 'package.opf',
+    modificationType: overrides.modificationType ?? 'metadata',
     description: r.description,
     before: r.before,
     after: r.after,
@@ -1702,6 +1706,12 @@ class RemediationService {
             break;
           case 'PRH-META-A11Y-SUMMARY-URL':
             fixResults = adaptPrhResults(await fixA11ySummaryUrl(zip));
+            break;
+          case 'PRH-XHTML-XML-LANG':
+            fixResults = adaptPrhResults(await fixXmlLang(zip), {
+              filePath: '(multiple xhtml files)',
+              modificationType: 'add_html_lang',
+            });
             break;
           default:
             logger.debug(`[AutoFix] No auto-fix handler for ${code}, skipping`);

--- a/tests/unit/services/epub/profiles/prh-uk/remediators/xhtml-remediator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/remediators/xhtml-remediator.test.ts
@@ -98,6 +98,60 @@ describe('fixXmlLang', () => {
     expect(ch2).toMatch(/lang="en"/);
   });
 
+  it('replaces an empty lang="" with the default language (regression)', async () => {
+    // Regression for CodeRabbit: empty lang="" was treated as "present"
+    // so the remediator left it unchanged, leaving the file invalid.
+    zip.file(
+      'EPUB/xhtml/ch1.xhtml',
+      '<?xml version="1.0"?><html lang=""><head><title>T</title></head><body/></html>',
+    );
+    await fixXmlLang(zip);
+    const updated = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    expect(updated).toMatch(/<html\b[^>]*\blang="en"/);
+    expect(updated).toMatch(/<html\b[^>]*\bxml:lang="en"/);
+    expect(updated).not.toMatch(/lang=""/);
+  });
+
+  it('replaces an empty xml:lang="" with the propagated language (regression)', async () => {
+    zip.file(
+      'EPUB/xhtml/ch1.xhtml',
+      '<?xml version="1.0"?><html lang="fr" xml:lang=""><head><title>T</title></head><body/></html>',
+    );
+    await fixXmlLang(zip);
+    const updated = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    expect(updated).toMatch(/xml:lang="fr"/);
+    expect(updated).not.toMatch(/xml:lang=""/);
+  });
+
+  it('emits one ChangeResult per touched file (per-file accounting)', async () => {
+    // Regression for CodeRabbit major: per-file fixes need per-file
+    // results so completion accounting can match tasks → files.
+    zip.file(
+      'EPUB/xhtml/ch1.xhtml',
+      '<?xml version="1.0"?><html><head><title>T</title></head><body/></html>',
+    );
+    zip.file(
+      'EPUB/xhtml/ch2.xhtml',
+      '<?xml version="1.0"?><html><head><title>T</title></head><body/></html>',
+    );
+    zip.file(
+      'EPUB/xhtml/ch3-already-ok.xhtml',
+      '<?xml version="1.0"?><html lang="en" xml:lang="en"><head><title>T</title></head><body/></html>',
+    );
+    const results = await fixXmlLang(zip);
+    // Two files touched → two results, each with the file path in the
+    // description.
+    expect(results).toHaveLength(2);
+    const descriptions = results.map((r) => r.description).sort();
+    expect(descriptions[0]).toMatch(/ch1\.xhtml/);
+    expect(descriptions[1]).toMatch(/ch2\.xhtml/);
+    for (const r of results) {
+      expect(r.success).toBe(true);
+      expect(r.before).toBeDefined();
+      expect(r.after).toBeDefined();
+    }
+  });
+
   it('uses a custom default language when supplied', async () => {
     zip.file('EPUB/xhtml/ch1.xhtml', '<?xml version="1.0"?><html><body/></html>');
     await fixXmlLang(zip, 'fr');

--- a/tests/unit/services/epub/profiles/prh-uk/remediators/xhtml-remediator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/remediators/xhtml-remediator.test.ts
@@ -152,6 +152,25 @@ describe('fixXmlLang', () => {
     }
   });
 
+  it('rejects an existing lang value containing illegal chars and falls back to default (regression)', async () => {
+    // Regression for CodeRabbit: an attacker-crafted EPUB could carry
+    // <html lang="<script>"> — though the regex rejects the quote char,
+    // it still admits other XML-special characters. The remediator
+    // must validate the token shape before re-injecting it into another
+    // attribute, otherwise it will emit malformed XHTML.
+    zip.file(
+      'EPUB/xhtml/ch1.xhtml',
+      '<?xml version="1.0"?><html lang="<weird>"><head><title>T</title></head><body/></html>',
+    );
+    await fixXmlLang(zip);
+    const updated = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    // The malformed value should be replaced with the default ("en"),
+    // not propagated into xml:lang.
+    expect(updated).toMatch(/lang="en"/);
+    expect(updated).toMatch(/xml:lang="en"/);
+    expect(updated).not.toMatch(/<weird>/);
+  });
+
   it('falls back to "en" when defaultLanguage is empty/whitespace (regression)', async () => {
     // Regression for CodeRabbit: an empty or whitespace defaultLanguage
     // would have written `lang=""` / `xml:lang=""` — the same broken

--- a/tests/unit/services/epub/profiles/prh-uk/remediators/xhtml-remediator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/remediators/xhtml-remediator.test.ts
@@ -152,6 +152,19 @@ describe('fixXmlLang', () => {
     }
   });
 
+  it('falls back to "en" when defaultLanguage is empty/whitespace (regression)', async () => {
+    // Regression for CodeRabbit: an empty or whitespace defaultLanguage
+    // would have written `lang=""` / `xml:lang=""` — the same broken
+    // attributes the validator complains about. Sanitise to "en".
+    zip.file('EPUB/xhtml/ch1.xhtml', '<?xml version="1.0"?><html><body/></html>');
+    await fixXmlLang(zip, '   ');
+    const updated = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    expect(updated).toMatch(/lang="en"/);
+    expect(updated).toMatch(/xml:lang="en"/);
+    expect(updated).not.toMatch(/lang=""/);
+    expect(updated).not.toMatch(/lang="   "/);
+  });
+
   it('uses a custom default language when supplied', async () => {
     zip.file('EPUB/xhtml/ch1.xhtml', '<?xml version="1.0"?><html><body/></html>');
     await fixXmlLang(zip, 'fr');

--- a/tests/unit/services/epub/profiles/prh-uk/remediators/xhtml-remediator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/remediators/xhtml-remediator.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import JSZip from 'jszip';
+import { fixXmlLang } from '../../../../../../../src/services/epub/profiles/prh-uk/remediators/xhtml-remediator';
+
+const CONTAINER_XML = `<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`;
+
+async function getFile(zip: JSZip, path: string): Promise<string> {
+  const c = await zip.file(path)?.async('text');
+  if (!c) throw new Error(`File not in zip: ${path}`);
+  return c;
+}
+
+describe('fixXmlLang', () => {
+  let zip: JSZip;
+  beforeEach(() => {
+    zip = new JSZip();
+    zip.file('META-INF/container.xml', CONTAINER_XML);
+    zip.file('EPUB/package.opf', '<?xml version="1.0"?><package/>');
+  });
+
+  it('adds both lang and xml:lang to <html> with neither attribute', async () => {
+    zip.file(
+      'EPUB/xhtml/ch1.xhtml',
+      '<?xml version="1.0"?><html><head><title>T</title></head><body/></html>',
+    );
+    const result = await fixXmlLang(zip);
+    expect(result[0].success).toBe(true);
+    expect(result[0].description).toMatch(/added/i);
+    const updated = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    expect(updated).toMatch(/<html\b[^>]*\blang="en"/);
+    expect(updated).toMatch(/<html\b[^>]*\bxml:lang="en"/);
+  });
+
+  it('adds only xml:lang when lang already present (the existing-handler gap)', async () => {
+    zip.file(
+      'EPUB/xhtml/ch1.xhtml',
+      '<?xml version="1.0"?><html lang="en"><head><title>T</title></head><body/></html>',
+    );
+    await fixXmlLang(zip);
+    const updated = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    expect(updated).toMatch(/<html\b[^>]*\blang="en"/);
+    expect(updated).toMatch(/<html\b[^>]*\bxml:lang="en"/);
+    // Verify no duplicate lang attribute was inserted.
+    const langCount = (updated.match(/\blang\s*=/g) || []).length;
+    expect(langCount).toBe(2); // 1 lang + 1 xml:lang
+  });
+
+  it('reuses existing lang code when adding xml:lang (no en hardcoding)', async () => {
+    zip.file(
+      'EPUB/xhtml/ch1.xhtml',
+      '<?xml version="1.0"?><html lang="fr"><head><title>T</title></head><body/></html>',
+    );
+    await fixXmlLang(zip);
+    const updated = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    expect(updated).toMatch(/xml:lang="fr"/);
+    expect(updated).not.toMatch(/xml:lang="en"/);
+  });
+
+  it('reuses existing xml:lang code when adding lang', async () => {
+    zip.file(
+      'EPUB/xhtml/ch1.xhtml',
+      '<?xml version="1.0"?><html xml:lang="ja"><head><title>T</title></head><body/></html>',
+    );
+    await fixXmlLang(zip);
+    const updated = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    expect(updated).toMatch(/<html\b[^>]*\blang="ja"/);
+  });
+
+  it('is a no-op when both attributes are already present', async () => {
+    const original = '<?xml version="1.0"?><html lang="en" xml:lang="en"><head><title>T</title></head><body/></html>';
+    zip.file('EPUB/xhtml/ch1.xhtml', original);
+    const result = await fixXmlLang(zip);
+    const updated = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    expect(updated).toBe(original);
+    expect(result[0].description).toMatch(/already carry/i);
+  });
+
+  it('walks every XHTML file in the zip', async () => {
+    zip.file(
+      'EPUB/xhtml/ch1.xhtml',
+      '<?xml version="1.0"?><html><body/></html>',
+    );
+    zip.file(
+      'EPUB/xhtml/ch2.html',
+      '<?xml version="1.0"?><html><body/></html>',
+    );
+    // Non-XHTML file should be ignored.
+    zip.file('EPUB/styles/base.css', 'body {}');
+    await fixXmlLang(zip);
+    const ch1 = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    const ch2 = await getFile(zip, 'EPUB/xhtml/ch2.html');
+    expect(ch1).toMatch(/lang="en"/);
+    expect(ch2).toMatch(/lang="en"/);
+  });
+
+  it('uses a custom default language when supplied', async () => {
+    zip.file('EPUB/xhtml/ch1.xhtml', '<?xml version="1.0"?><html><body/></html>');
+    await fixXmlLang(zip, 'fr');
+    const updated = await getFile(zip, 'EPUB/xhtml/ch1.xhtml');
+    expect(updated).toMatch(/lang="fr"/);
+    expect(updated).toMatch(/xml:lang="fr"/);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/run-validators.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/run-validators.test.ts
@@ -73,9 +73,18 @@ describe('runPrhUkValidators (orchestrator)', () => {
   </spine>
 </package>`,
     );
-    // The nav doc lives at `text/nav-doc.xhtml` (zip-root-relative),
-    // reached from OEBPS/package.opf via `../text/nav-doc.xhtml`.
-    zip.file('text/nav-doc.xhtml', COMPLIANT_NAV);
+    // Use a deliberately non-compliant nav doc — it has the toc + landmarks
+    // blocks but is MISSING the page-list block. If path normalisation
+    // works, the nav validator parses the doc and emits
+    // PRH-NAV-MISSING-PAGELIST. If normalisation is broken, the doc isn't
+    // found and the validator silently emits nothing — and the test fails.
+    // This makes the assertion unambiguous about whether the nav lookup
+    // actually succeeded.
+    const NAV_MISSING_PAGELIST = COMPLIANT_NAV.replace(
+      /<nav epub:type="page-list"[\s\S]*?<\/nav>/,
+      '',
+    );
+    zip.file('text/nav-doc.xhtml', NAV_MISSING_PAGELIST);
     zip.file(
       'text/cover.xhtml',
       '<?xml version="1.0"?><html lang="en" xml:lang="en"><head><title>Cover, Cross-dir Book</title></head><body/></html>',
@@ -83,15 +92,13 @@ describe('runPrhUkValidators (orchestrator)', () => {
 
     const buffer = await zip.generateAsync({ type: 'nodebuffer' });
     const issues = await runPrhUkValidators(buffer);
-    // If path normalisation is broken, the orchestrator can't find
-    // nav-doc.xhtml and the nav validator silently emits nothing — but
-    // we'd also get NO PRH-NAV-MISSING-PAGELIST issue (since the source
-    // input was null). With normalisation working, the compliant nav doc
-    // is parsed and yields zero PRH-NAV-* issues.
-    const navIssues = issues.filter((i) => i.code.startsWith('PRH-NAV-'));
-    expect(navIssues).toEqual([]);
-    // Sanity: metadata validator also ran (we'd have flagged missing
-    // metadata if the orchestrator had aborted early).
+    // Path normalisation working ⇒ nav doc found ⇒ PRH-NAV-MISSING-PAGELIST
+    // is emitted. If normalisation is broken, the nav doc isn't found and
+    // this assertion fails — making the regression test unambiguous.
+    const pageListIssue = issues.find((i) => i.code === 'PRH-NAV-MISSING-PAGELIST');
+    expect(pageListIssue).toBeDefined();
+    // Sanity: metadata validator also ran (we'd have seen all-six PRH-META-*
+    // issues if the orchestrator had aborted early before reading the OPF).
     const metaIssues = issues.filter((i) => i.code.startsWith('PRH-META-'));
     expect(metaIssues).toEqual([]);
   });

--- a/tests/unit/services/epub/profiles/prh-uk/run-validators.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/run-validators.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { runPrhUkValidators } from '../../../../../../src/services/epub/profiles/prh-uk/run-validators';
+
+const COMPLIANT_NAV = `<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:epub="http://www.idpf.org/2007/ops"
+      lang="en" xml:lang="en">
+  <head><title>Contents</title></head>
+  <body>
+    <nav epub:type="toc" role="doc-toc" aria-labelledby="toc_head" id="toc">
+      <h2 id="toc_head">Contents</h2>
+      <ol><li><a href="cover.xhtml">Cover</a></li></ol>
+    </nav>
+    <nav epub:type="landmarks" class="at_only">
+      <ol>
+        <li><a epub:type="cover" href="cover.xhtml">Cover</a></li>
+        <li><a epub:type="frontmatter" href="title.xhtml">Frontmatter</a></li>
+        <li><a epub:type="toc" href="nav.xhtml">TOC</a></li>
+        <li><a epub:type="bodymatter" href="ch01.xhtml">Begin Reading</a></li>
+      </ol>
+    </nav>
+    <nav epub:type="page-list" hidden="hidden" class="hidden_content">
+      <ol><li><a href="ch01.xhtml#p1">1</a></li></ol>
+    </nav>
+  </body>
+</html>`;
+
+describe('runPrhUkValidators (orchestrator)', () => {
+  it('returns no issues when no OPF is present', async () => {
+    const zip = new JSZip();
+    zip.file('META-INF/container.xml', '<?xml version="1.0"?><container><rootfiles><rootfile full-path="missing.opf"/></rootfiles></container>');
+    const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+    expect(await runPrhUkValidators(buffer)).toEqual([]);
+  });
+
+  it('locates the nav doc when OPF references it via a relative href with ".." (path-normalisation regression)', async () => {
+    // Regression for CodeRabbit: resolveOpfRelative previously returned
+    // `OEBPS/../text/nav.xhtml` which doesn't exist as a literal zip
+    // entry, so the nav doc lookup silently failed and PRH-NAV-* checks
+    // never ran.
+    const zip = new JSZip();
+    zip.file(
+      'META-INF/container.xml',
+      `<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/package.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`,
+    );
+    zip.file(
+      'OEBPS/package.opf',
+      `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0"
+         prefix="schema: http://schema.org/ tdm: http://www.w3.org/ns/tdmrep#">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Cross-dir Book</dc:title>
+    <meta property="dcterms:conformsTo" id="conf">EPUB Accessibility 1.1 - WCAG 2.2 Level AA</meta>
+    <meta property="a11y:certifiedBy" refines="#conf" id="certifier">Penguin Random House UK</meta>
+    <meta property="a11y:certifierCredential" refines="#certifier">Ace by DAISY OK</meta>
+    <link rel="a11y:certifierCredential" href="https://daisy.github.io/ace"/>
+    <meta property="tdm:reservation">1</meta>
+    <meta property="schema:accessibilitySummary">Visit https://www.penguin.co.uk/accessibility</meta>
+  </metadata>
+  <manifest>
+    <item id="nav" href="../text/nav-doc.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="cover" href="../text/cover.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="cover" linear="no"/>
+    <itemref idref="nav"/>
+  </spine>
+</package>`,
+    );
+    // The nav doc lives at `text/nav-doc.xhtml` (zip-root-relative),
+    // reached from OEBPS/package.opf via `../text/nav-doc.xhtml`.
+    zip.file('text/nav-doc.xhtml', COMPLIANT_NAV);
+    zip.file(
+      'text/cover.xhtml',
+      '<?xml version="1.0"?><html lang="en" xml:lang="en"><head><title>Cover, Cross-dir Book</title></head><body/></html>',
+    );
+
+    const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+    const issues = await runPrhUkValidators(buffer);
+    // If path normalisation is broken, the orchestrator can't find
+    // nav-doc.xhtml and the nav validator silently emits nothing — but
+    // we'd also get NO PRH-NAV-MISSING-PAGELIST issue (since the source
+    // input was null). With normalisation working, the compliant nav doc
+    // is parsed and yields zero PRH-NAV-* issues.
+    const navIssues = issues.filter((i) => i.code.startsWith('PRH-NAV-'));
+    expect(navIssues).toEqual([]);
+    // Sanity: metadata validator also ran (we'd have flagged missing
+    // metadata if the orchestrator had aborted early).
+    const metaIssues = issues.filter((i) => i.code.startsWith('PRH-META-'));
+    expect(metaIssues).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/nav-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/nav-validator.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhNav } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/nav-validator';
+
+const COMPLIANT_NAV = `<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:epub="http://www.idpf.org/2007/ops"
+      lang="en" xml:lang="en">
+  <head><title>Contents</title></head>
+  <body>
+    <nav epub:type="toc" role="doc-toc" aria-labelledby="toc_head" id="toc">
+      <h2 id="toc_head">Contents</h2>
+      <ol class="toc_ol_root">
+        <li><a href="cover.xhtml">Cover</a></li>
+      </ol>
+    </nav>
+    <nav epub:type="landmarks" class="at_only">
+      <ol>
+        <li><a epub:type="cover" href="cover.xhtml">Cover</a></li>
+        <li><a epub:type="frontmatter ibooks:reader-start-page" href="title.xhtml">Frontmatter</a></li>
+        <li><a epub:type="toc" href="nav.xhtml">Table of Contents</a></li>
+        <li><a epub:type="bodymatter" href="title.xhtml">Begin Reading</a></li>
+      </ol>
+    </nav>
+    <nav epub:type="page-list" role="doc-pagelist" aria-label="Print Page List"
+         hidden="hidden" class="hidden_content">
+      <ol>
+        <li><a href="ch01.xhtml#page1">1</a></li>
+      </ol>
+    </nav>
+  </body>
+</html>`;
+
+const INPUT = (navContent: string | null) => ({
+  opfContent: '',
+  opfPath: 'EPUB/package.opf',
+  navContent,
+  navPath: 'EPUB/nav.xhtml',
+});
+
+describe('validatePrhNav', () => {
+  it('emits zero issues for a fully compliant nav doc', () => {
+    expect(validatePrhNav(INPUT(COMPLIANT_NAV))).toEqual([]);
+  });
+
+  it('returns no issues when there is no nav doc (EPUBCheck handles that)', () => {
+    expect(validatePrhNav(INPUT(null))).toEqual([]);
+  });
+
+  it('flags a missing page-list nav', () => {
+    const nav = COMPLIANT_NAV.replace(
+      /<nav epub:type="page-list"[\s\S]*?<\/nav>/,
+      '',
+    );
+    const issues = validatePrhNav(INPUT(nav));
+    expect(issues.find((i) => i.code === 'PRH-NAV-MISSING-PAGELIST')).toBeDefined();
+  });
+
+  it('flags a page-list nav hidden via inline style instead of the canonical attribute', () => {
+    // Common authoring mistake: using inline style="display:none" instead of
+    // the EPUB-canonical hidden="hidden" + class="hidden_content" pair.
+    const nav = COMPLIANT_NAV.replace(
+      'hidden="hidden" class="hidden_content"',
+      'style="display: none"',
+    );
+    const issues = validatePrhNav(INPUT(nav));
+    const issue = issues.find((i) => i.code === 'PRH-NAV-PAGELIST-NOT-HIDDEN');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/hidden="hidden"/);
+    expect(issue?.message).toMatch(/hidden_content/);
+  });
+
+  it('flags missing hidden attribute alone (class present)', () => {
+    const nav = COMPLIANT_NAV.replace('hidden="hidden" class="hidden_content"', 'class="hidden_content"');
+    const issues = validatePrhNav(INPUT(nav));
+    const issue = issues.find((i) => i.code === 'PRH-NAV-PAGELIST-NOT-HIDDEN');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/hidden="hidden"/);
+  });
+
+  it('flags missing class alone (hidden attribute present)', () => {
+    const nav = COMPLIANT_NAV.replace('hidden="hidden" class="hidden_content"', 'hidden="hidden"');
+    const issues = validatePrhNav(INPUT(nav));
+    const issue = issues.find((i) => i.code === 'PRH-NAV-PAGELIST-NOT-HIDDEN');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/hidden_content/);
+  });
+
+  it('flags every missing landmark (cover/frontmatter/toc/bodymatter)', () => {
+    // Strip the entire landmarks anchor list.
+    const nav = COMPLIANT_NAV.replace(
+      /<nav epub:type="landmarks"[\s\S]*?<\/nav>/,
+      '<nav epub:type="landmarks" class="at_only"><ol></ol></nav>',
+    );
+    const issues = validatePrhNav(INPUT(nav));
+    const codes = issues.map((i) => i.code).filter((c) => c.startsWith('PRH-NAV-LANDMARKS-')).sort();
+    expect(codes).toEqual([
+      'PRH-NAV-LANDMARKS-MISSING-BODYMATTER',
+      'PRH-NAV-LANDMARKS-MISSING-COVER',
+      'PRH-NAV-LANDMARKS-MISSING-FRONTMATTER',
+      'PRH-NAV-LANDMARKS-MISSING-TOC',
+    ]);
+  });
+
+  it('accepts a multi-token frontmatter epub:type ("frontmatter ibooks:reader-start-page")', () => {
+    // PRH templates commonly add the iBooks start-page hint as a second
+    // token. The validator must recognise the canonical frontmatter token
+    // even when it isn't the only value.
+    const issues = validatePrhNav(INPUT(COMPLIANT_NAV));
+    expect(issues.find((i) => i.code === 'PRH-NAV-LANDMARKS-MISSING-FRONTMATTER')).toBeUndefined();
+  });
+
+  it('accepts attributes in either quote style', () => {
+    const nav = COMPLIANT_NAV.replace(/"/g, "'");
+    expect(validatePrhNav(INPUT(nav))).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/xhtml-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/xhtml-validator.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhPerXhtml } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/xhtml-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(files: PrhXhtmlFile[], bookTitle: string | null = 'My Book') {
+  return {
+    opfContent: '',
+    opfPath: 'EPUB/package.opf',
+    bookTitle,
+    xhtmlFiles: files,
+  };
+}
+
+const compliantPage = (titleText: string): string => `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head><title>${titleText}</title></head>
+  <body><p>Hello</p></body>
+</html>`;
+
+describe('validatePrhPerXhtml', () => {
+  it('emits zero issues for a compliant XHTML file', () => {
+    const issues = validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: compliantPage('Chapter 1, My Book') },
+    ]));
+    expect(issues).toEqual([]);
+  });
+
+  it('flags <html> missing both lang and xml:lang', () => {
+    const html = compliantPage('Chapter 1').replace(
+      'lang="en" xml:lang="en"',
+      '',
+    );
+    const issues = validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: html },
+    ]));
+    const issue = issues.find((i) => i.code === 'PRH-XHTML-XML-LANG');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/lang/);
+    expect(issue?.message).toMatch(/xml:lang/);
+  });
+
+  it('flags <html> with lang but no xml:lang (the EPUB-SEM-001 gap)', () => {
+    const html = compliantPage('Chapter 1').replace(
+      'lang="en" xml:lang="en"',
+      'lang="en"',
+    );
+    const issues = validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: html },
+    ]));
+    const issue = issues.find((i) => i.code === 'PRH-XHTML-XML-LANG');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/xml:lang/);
+    expect(issue?.message).not.toMatch(/\blang\b,/);  // 'lang' alone shouldn't be in reasons list
+  });
+
+  it('flags <html> with xml:lang but no lang', () => {
+    const html = compliantPage('Chapter 1').replace(
+      'lang="en" xml:lang="en"',
+      'xml:lang="en"',
+    );
+    const issues = validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: html },
+    ]));
+    const issue = issues.find((i) => i.code === 'PRH-XHTML-XML-LANG');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/^.*missing[^:]*:.*\blang\b/);
+  });
+
+  it('flags an empty <head><title>', () => {
+    const html = compliantPage('').replace('<title></title>', '<title></title>');
+    const issues = validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: html },
+    ]));
+    expect(issues.find((i) => i.code === 'PRH-XHTML-TITLE-EMPTY-OR-GENERIC')).toBeDefined();
+  });
+
+  it('flags a missing <title> tag entirely', () => {
+    const html = compliantPage('x').replace(/<title>.*<\/title>/, '');
+    const issues = validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: html },
+    ]));
+    expect(issues.find((i) => i.code === 'PRH-XHTML-TITLE-EMPTY-OR-GENERIC')).toBeDefined();
+  });
+
+  it('flags <title> that equals the book title (no chapter/section identifier)', () => {
+    const issues = validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: compliantPage('My Book') },
+    ]));
+    const issue = issues.find((i) => i.code === 'PRH-XHTML-TITLE-EMPTY-OR-GENERIC');
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/just the book title/i);
+  });
+
+  it('does NOT flag <title> when there is no book title to compare against', () => {
+    // bookTitle null → skip the equality check, only flag empty/missing.
+    const issues = validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: compliantPage('Section') },
+    ], null));
+    expect(issues.find((i) => i.code === 'PRH-XHTML-TITLE-EMPTY-OR-GENERIC')).toBeUndefined();
+  });
+
+  it('compares <title> to book title case-insensitively', () => {
+    const issues = validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: compliantPage('MY BOOK') },
+    ], 'My Book'));
+    expect(issues.find((i) => i.code === 'PRH-XHTML-TITLE-EMPTY-OR-GENERIC')).toBeDefined();
+  });
+
+  it('emits one issue per offending file (granular reporting)', () => {
+    const issues = validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: compliantPage('Chapter 1, My Book') },
+      { path: 'EPUB/xhtml/ch2.xhtml', content: compliantPage('My Book') },
+      { path: 'EPUB/xhtml/ch3.xhtml', content: compliantPage('My Book') },
+    ]));
+    const titleIssues = issues.filter((i) => i.code === 'PRH-XHTML-TITLE-EMPTY-OR-GENERIC');
+    expect(titleIssues).toHaveLength(2);
+    expect(titleIssues.map((i) => i.location).sort()).toEqual([
+      'EPUB/xhtml/ch2.xhtml',
+      'EPUB/xhtml/ch3.xhtml',
+    ]);
+  });
+
+  it('handles attributes in either quote style', () => {
+    const html = compliantPage('Chapter 1, My Book').replace(/"/g, "'");
+    expect(validatePrhPerXhtml(input([
+      { path: 'EPUB/xhtml/ch1.xhtml', content: html },
+    ]))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Builds on PR #356/#357 (profile detector) and #358 (metadata + spine validators). Adds two more validators that fire when PRH-UK is detected at `medium` or `high` confidence — the nav doc structure and per-XHTML lang/title checks — plus one new auto-fix handler.

This is **PR3 of 5** in the P1 PRH UK validation plan (`Ninja-Documentation/PRH-Analysis/plans/P1-Implementation-Plan.md`).

## Issue codes emitted

| Code | Severity | WCAG | Auto-fix? |
|---|---|---|---|
| `PRH-NAV-MISSING-PAGELIST` | moderate | 2.4.5 | manual |
| `PRH-NAV-PAGELIST-NOT-HIDDEN` | minor | — | manual |
| `PRH-NAV-LANDMARKS-MISSING-COVER` | minor | 1.3.1 | manual |
| `PRH-NAV-LANDMARKS-MISSING-FRONTMATTER` | minor | 1.3.1 | manual |
| `PRH-NAV-LANDMARKS-MISSING-TOC` | minor | 1.3.1 | manual |
| `PRH-NAV-LANDMARKS-MISSING-BODYMATTER` | minor | 1.3.1 | manual |
| `PRH-XHTML-XML-LANG` | moderate | 3.1.1 | ✅ |
| `PRH-XHTML-TITLE-EMPTY-OR-GENERIC` | minor | 2.4.2 | manual |

`PRH-NAV-*` are detect-only because nav-doc structure changes need operator review (rewriting hidden landmarks can confuse readers). `PRH-XHTML-TITLE-EMPTY-OR-GENERIC` is detect-only because choosing the right chapter/section title is editorial, not mechanical.

## What this PR adds

| Path | Purpose |
|---|---|
| `src/services/epub/profiles/prh-uk/validators/nav-validator.ts` | Pure function over nav.xhtml content. Checks 3-block structure + page-list hiding + landmarks whitelist. |
| `src/services/epub/profiles/prh-uk/validators/xhtml-validator.ts` | Per-XHTML check: html-lang-and-xml:lang + non-generic title. Emits one issue per offending file. |
| `src/services/epub/profiles/prh-uk/remediators/xhtml-remediator.ts` | `fixXmlLang` walks every XHTML, ensures both `lang` and `xml:lang`. Reuses existing lang code when present (no `en` hardcoding). |

## What this PR modifies

- `run-validators.ts` — orchestrator extended to read nav doc + every XHTML file + dc:title; dispatches to all four validators
- `auto-remediation.service.ts` — registers `PRH-XHTML-XML-LANG` handler
- `remediation.service.ts` — adds `PRH-XHTML-XML-LANG` case to high-confidence switch; `adaptPrhResults` parameterised so xhtml fixes carry the right `modificationType`
- `fix-classification.ts` — `PRH-XHTML-XML-LANG` added to `BASE_AUTO_FIXABLE_CODES`; PRH-NAV-* and TITLE codes documented as detect-only

## Notable bug surfaced and fixed by tests

Naive `\blang` regex matches `lang` inside `xml:lang` because the colon is a word boundary. So `<html xml:lang="en">` (no `lang`) was being treated as having `lang` set — masking the missing-attribute error. Fixed in both validator and remediator by requiring start-of-attrs or whitespace before `lang`. The test "flags `<html>` with xml:lang but no lang" caught this and now passes.

## Design notes

1. **Multi-token epub:type values.** PRH templates frequently use values like `epub:type="frontmatter ibooks:reader-start-page"`. The landmarks check matches on the whitespace-separated token, not exact-string equality, so these pass.
2. **Page-list hiding rule.** PRH spec says hidden via BOTH `hidden="hidden"` AND `class="hidden_content"`. Using inline `style="display:none"` is the common authoring mistake — explicitly flagged with a clear suggestion.
3. **fixXmlLang language preservation.** When `lang="fr"` exists but `xml:lang` is missing, the remediator copies `fr` into `xml:lang` — doesn't drift to `en`.
4. **Title heuristic is generous.** Only flags exact equality (case-insensitive) with the dc:title. "Contents" or "Section 1" passes — the rule is *don't shadow the book title*, not *prove specificity*.
5. **One issue per file.** Per-XHTML validators emit per-file so the operator can locate broken files in a 200-chapter EPUB. The `summaryBySource['prh-uk'].total` counter rolls up.

## Test plan

- [x] **27 new Vitest unit tests** across 3 suites:
  - `nav-validator`: 9 cases — compliant pass, missing page-list, page-list hidden via inline style, missing hidden attr alone, missing class alone, all 4 landmarks missing, multi-token epub:type, single-quoted attrs
  - `xhtml-validator`: 11 cases — compliant, missing both lang + xml:lang, lang-without-xml:lang (the EPUB-SEM-001 gap), xml:lang-without-lang (regression for the `\blang` bug), empty title, missing title element, title equals book title (case-insensitive), null book title, multi-file granularity, single-quoted attrs
  - `xhtml-remediator`: 7 cases — adds both attrs, adds only xml:lang when lang present, language preservation (fr/ja), idempotency, multi-file walk, custom default language
- [x] PR1+PR2 PRH suites still pass — combined PRH suite now **95/95**
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean on touched files
- [x] Full vitest suite: **1121 passing** (was 1094 after PR2 fixes); same 7 pre-existing failures in `workflow-config.integration.test.ts` / `workflow-websocket.test.ts`. Zero regressions.

## Smoke-test plan after merge + deploy

1. Re-upload the PRH Technical Guide. Expect new `PRH-NAV-*`, `PRH-XHTML-*` entries in `combinedIssues` (the Technical Guide's nav.xhtml has the page-list hidden via the canonical pair, so we expect 0 PRH-NAV-PAGELIST-NOT-HIDDEN; landmarks present; some XHTML files may have title==book-title or missing xml:lang).
2. Trigger auto-fix on `PRH-XHTML-XML-LANG` if it appears; re-audit; verify it disappears.
3. Confirm previously merged `PRH-META-*` and `PRH-SPINE-*` issues from PR2 still appear correctly.

## Out of scope (PR4-5)

- PR4: cover-alt-non-empty + decorative-`role="presentation"` validators
- PR5: `VPAT2.5-PRH-UK` edition pinned to WCAG 2.2 AA + PRH certifier metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nav validation added for page-list and landmark requirements; per-XHTML checks for html language attrs and title content.
  * Orchestrator now loads EPUB nav and XHTML files to run all PRH phases.
  * Auto-fix classification now treats PRH-XHTML-XML-LANG as auto-remediable and applies automated XHTML lang fixes across files.

* **Tests**
  * Comprehensive unit tests for validators, remediator behavior, orchestration, and a regression rejecting malformed lang tokens.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/359)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->