### PR TITLE
feat(acr): VPAT2.5-PRH-UK edition (PR5/5)

### DIFF
--- a/src/controllers/acr.controller.ts
+++ b/src/controllers/acr.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { acrGeneratorService, AcrGenerationOptions, AcrDocument, AcrCriterion, AcrEdition } from '../services/acr/acr-generator.service';
+import { acrGeneratorService, AcrGenerationOptions, AcrDocument, AcrCriterion, AcrEdition, ACR_EDITIONS } from '../services/acr/acr-generator.service';
 import { conformanceEngineService, ConformanceLevel, ValidationResult } from '../services/acr/conformance-engine.service';
 import { 
   generateMethodologySection, 
@@ -37,7 +37,7 @@ const ProductInfoSchema = z.object({
 const GenerateAcrSchema = z.object({
   jobId: z.string().uuid(),
   options: z.object({
-    edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']).optional(),
+    edition: z.enum(ACR_EDITIONS).optional(),
     includeAppendix: z.boolean().optional(),
     includeMethodology: z.boolean().optional(),
     productInfo: ProductInfoSchema
@@ -319,7 +319,7 @@ export class AcrController {
       const ExportRequestSchema = z.object({
         options: ExportOptionsSchema,
         acrData: z.object({
-          edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']).optional(),
+          edition: z.enum(ACR_EDITIONS).optional(),
           productInfo: ProductInfoSchema.partial()
         }).optional()
       });
@@ -898,7 +898,7 @@ export class AcrController {
       const CreateVersionSchema = z.object({
         reason: z.string().optional(),
         acrData: z.object({
-          edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']).optional(),
+          edition: z.enum(ACR_EDITIONS).optional(),
           productInfo: ProductInfoSchema
         }).optional()
       });

--- a/src/controllers/acr.controller.ts
+++ b/src/controllers/acr.controller.ts
@@ -37,7 +37,7 @@ const ProductInfoSchema = z.object({
 const GenerateAcrSchema = z.object({
   jobId: z.string().uuid(),
   options: z.object({
-    edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT']).optional(),
+    edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']).optional(),
     includeAppendix: z.boolean().optional(),
     includeMethodology: z.boolean().optional(),
     productInfo: ProductInfoSchema
@@ -319,7 +319,7 @@ export class AcrController {
       const ExportRequestSchema = z.object({
         options: ExportOptionsSchema,
         acrData: z.object({
-          edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT']).optional(),
+          edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']).optional(),
           productInfo: ProductInfoSchema.partial()
         }).optional()
       });
@@ -898,7 +898,7 @@ export class AcrController {
       const CreateVersionSchema = z.object({
         reason: z.string().optional(),
         acrData: z.object({
-          edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT']).optional(),
+          edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']).optional(),
           productInfo: ProductInfoSchema
         }).optional()
       });

--- a/src/schemas/acr.schemas.ts
+++ b/src/schemas/acr.schemas.ts
@@ -4,7 +4,7 @@ export const batchAcrGenerateSchema = z.object({
   batchId: z.string().min(1, 'Batch ID is required'),
   mode: z.enum(['individual', 'aggregate']).describe('Mode is required'),
   options: z.object({
-    edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT']),
+    edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']),
     batchName: z.string().min(1, 'Batch name is required'),
     vendor: z.string().min(1, 'Vendor name is required'),
     contactEmail: z.string().email('Invalid email format'),

--- a/src/schemas/acr.schemas.ts
+++ b/src/schemas/acr.schemas.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
+import { ACR_EDITIONS } from '../services/acr/acr-generator.service';
 
 export const batchAcrGenerateSchema = z.object({
   batchId: z.string().min(1, 'Batch ID is required'),
   mode: z.enum(['individual', 'aggregate']).describe('Mode is required'),
   options: z.object({
-    edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']),
+    edition: z.enum(ACR_EDITIONS),
     batchName: z.string().min(1, 'Batch name is required'),
     vendor: z.string().min(1, 'Vendor name is required'),
     contactEmail: z.string().email('Invalid email format'),

--- a/src/schemas/batch.schemas.ts
+++ b/src/schemas/batch.schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ACR_EDITIONS } from '../services/acr/acr-generator.service';
 
 export const batchCreateSchema = z.object({
   name: z.string().min(1).max(255).optional(),
@@ -20,7 +21,7 @@ export const batchListSchema = z.object({
 export const batchAcrGenerateSchema = z.object({
   mode: z.enum(['individual', 'aggregate']),
   options: z.object({
-    edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']),
+    edition: z.enum(ACR_EDITIONS),
     batchName: z.string().min(1),
     vendor: z.string().min(1),
     contactEmail: z.string().email(),

--- a/src/schemas/batch.schemas.ts
+++ b/src/schemas/batch.schemas.ts
@@ -20,7 +20,7 @@ export const batchListSchema = z.object({
 export const batchAcrGenerateSchema = z.object({
   mode: z.enum(['individual', 'aggregate']),
   options: z.object({
-    edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT']),
+    edition: z.enum(['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']),
     batchName: z.string().min(1),
     vendor: z.string().min(1),
     contactEmail: z.string().email(),

--- a/src/services/acr/acr-generator.service.ts
+++ b/src/services/acr/acr-generator.service.ts
@@ -11,11 +11,30 @@ import { logger } from '../../lib/logger';
 import { wcagIssueMapperService, IssueMapping, AuditIssueInput } from './wcag-issue-mapper.service';
 import { ConfidenceAnalyzerService } from './confidence-analyzer.service';
 
-export type AcrEdition = 
+export type AcrEdition =
   | 'VPAT2.5-508'
   | 'VPAT2.5-WCAG'
   | 'VPAT2.5-EU'
-  | 'VPAT2.5-INT';
+  | 'VPAT2.5-INT'
+  | 'VPAT2.5-PRH-UK';
+
+/**
+ * Publisher-specific metadata that some VPAT editions embed. Today this
+ * is populated only by the PRH UK edition (certifier-of-record string,
+ * accessibility-summary URL, TDM-reservation note). Other editions
+ * leave it undefined.
+ */
+export interface AcrPublisherMetadata {
+  certifiedBy: string;
+  certifierCredential: string;
+  credentialUrl: string;
+  /** Verbatim string PRH expects in the OPF's dcterms:conformsTo meta. */
+  conformsTo: string;
+  /** Where the publisher's accessibility statement lives (linked from the OPF accessibilitySummary). */
+  accessibilitySummaryUrl: string;
+  /** Optional TDM-reservation note (PRH includes a verbatim paragraph in the copyright page). */
+  tdmReservationNote?: string;
+}
 
 export interface ProductInfo {
   name: string;
@@ -67,6 +86,12 @@ export interface AcrDocument {
   status: 'draft' | 'pending_review' | 'final';
   methodology?: MethodologyInfo;
   footerDisclaimer?: string;
+  /**
+   * Publisher-specific metadata (certifier-of-record, accessibility-summary
+   * URL, TDM-reservation note) — populated for editions tied to a specific
+   * publisher profile (today: only `VPAT2.5-PRH-UK`).
+   */
+  publisherMetadata?: AcrPublisherMetadata;
 }
 
 export interface AcrGenerationOptions {
@@ -135,7 +160,27 @@ const EDITION_INFO: Record<AcrEdition, EditionInfo> = {
     standards: ['Section 508', 'EN 301 549', 'WCAG 2.1'],
     recommended: true,
     isRecommended: true
+  },
+  'VPAT2.5-PRH-UK': {
+    id: 'VPAT2.5-PRH-UK',
+    code: 'VPAT2.5-PRH-UK',
+    name: 'PRH UK Edition',
+    description: 'Penguin Random House UK delivery profile — pinned to EPUB Accessibility 1.1 + WCAG 2.2 Level AA with PRH UK as certifier-of-record',
+    standards: ['EPUB Accessibility 1.1', 'WCAG 2.2'],
+    recommended: false,
+    isRecommended: false
   }
+};
+
+/** Publisher metadata pinned to the PRH UK edition — sourced from the PRH Technical Guide's accessibility_meta_boilerplates.txt. */
+const PRH_UK_PUBLISHER_METADATA: AcrPublisherMetadata = {
+  certifiedBy: 'Penguin Random House UK',
+  certifierCredential: 'Ace by DAISY OK',
+  credentialUrl: 'https://daisy.github.io/ace',
+  conformsTo: 'EPUB Accessibility 1.1 - WCAG 2.2 Level AA',
+  accessibilitySummaryUrl: 'https://www.penguin.co.uk/accessibility',
+  tdmReservationNote:
+    'No part of this work may be used or reproduced in any manner for the purpose of training artificial intelligence technologies or systems. In accordance with Article 4(3) of the DSM Directive 2019/790, Penguin Random House expressly reserves this work from the text and data mining exception.',
 };
 
 class AcrGeneratorService {
@@ -181,7 +226,11 @@ class AcrGeneratorService {
         aiModelInfo: `${AI_MODEL_INFO.name} (${AI_MODEL_INFO.provider}) - ${AI_MODEL_INFO.purpose}`,
         disclaimer: LEGAL_DISCLAIMER
       },
-      footerDisclaimer: generateFooterDisclaimer()
+      footerDisclaimer: generateFooterDisclaimer(),
+      // PRH UK is the only edition today with publisher-specific
+      // metadata embedded in the output. Other editions leave this
+      // field undefined.
+      publisherMetadata: edition === 'VPAT2.5-PRH-UK' ? PRH_UK_PUBLISHER_METADATA : undefined,
     };
 
     return acrDocument;
@@ -291,6 +340,8 @@ class AcrGeneratorService {
         return this.getEuCriteria();
       case 'VPAT2.5-INT':
         return this.getInternationalCriteria();
+      case 'VPAT2.5-PRH-UK':
+        return this.getPrhUkCriteria();
       default:
         return this.getInternationalCriteria();
     }
@@ -524,14 +575,58 @@ class AcrGeneratorService {
     const wcag21Base = this.getWcag21BaseCriteria();
     const enSpecific = this.getEnSpecificCriteria();
     const wcagAaa = this.getWcagAaaCriteria();
-    
+
     const criteriaMap = new Map<string, AcrCriterion>();
-    
+
     section508.forEach(c => criteriaMap.set(c.id, c));
     wcag21Base.forEach(c => criteriaMap.set(c.id, c));
     enSpecific.forEach(c => criteriaMap.set(c.id, c));
     wcagAaa.forEach(c => criteriaMap.set(c.id, c));
-    
+
+    return Array.from(criteriaMap.values());
+  }
+
+  /**
+   * WCAG 2.2 added six new success criteria over 2.1 (not counting
+   * AAA-only additions). PRH UK pins to Level AA, so we include Level A
+   * and AA from this set:
+   *
+   *   2.4.11 Focus Not Obscured (Minimum)   — AA
+   *   2.5.7  Dragging Movements             — AA
+   *   2.5.8  Target Size (Minimum)          — AA
+   *   3.2.6  Consistent Help                — A
+   *   3.3.7  Redundant Entry                — A
+   *   3.3.8  Accessible Authentication (Min)— AA
+   *
+   * (2.4.12, 2.4.13 and 3.3.9 are AAA-only and intentionally excluded —
+   * PRH's published delivery target is AA.)
+   */
+  private getWcag22NewAaCriteria(): AcrCriterion[] {
+    return [
+      criterion('2.4.11', 'Focus Not Obscured (Minimum)', 'AA'),
+      criterion('2.5.7', 'Dragging Movements', 'AA'),
+      criterion('2.5.8', 'Target Size (Minimum)', 'AA'),
+      criterion('3.2.6', 'Consistent Help', 'A'),
+      criterion('3.3.7', 'Redundant Entry', 'A'),
+      criterion('3.3.8', 'Accessible Authentication (Minimum)', 'AA'),
+    ];
+  }
+
+  /**
+   * Criteria list for the PRH UK delivery profile: WCAG 2.2 Level A + AA
+   * (no AAA — PRH's published target is AA). Built on top of the existing
+   * 2.1 base + the six 2.2-new A/AA criteria.
+   *
+   * Note: WCAG 2.2 formally obsoleted 4.1.1 "Parsing", but we keep it in
+   * the list for backward compatibility with VPAT-consuming tools that
+   * still expect it. Conforming-as-not-applicable is the right call.
+   */
+  private getPrhUkCriteria(): AcrCriterion[] {
+    const base = this.getWcag21BaseCriteria();
+    const wcag22NewAa = this.getWcag22NewAaCriteria();
+    const criteriaMap = new Map<string, AcrCriterion>();
+    base.forEach((c) => criteriaMap.set(c.id, c));
+    wcag22NewAa.forEach((c) => criteriaMap.set(c.id, c));
     return Array.from(criteriaMap.values());
   }
 

--- a/src/services/acr/acr-generator.service.ts
+++ b/src/services/acr/acr-generator.service.ts
@@ -469,6 +469,7 @@ class AcrGeneratorService {
       criterion('1.2.1', 'Audio-only and Video-only (Prerecorded)', 'A'),
       criterion('1.2.2', 'Captions (Prerecorded)', 'A'),
       criterion('1.2.3', 'Audio Description or Media Alternative', 'A'),
+      criterion('1.2.4', 'Captions (Live)', 'AA'),
       criterion('1.2.5', 'Audio Description (Prerecorded)', 'AA'),
       criterion('1.3.1', 'Info and Relationships', 'A'),
       criterion('1.3.2', 'Meaningful Sequence', 'A'),

--- a/src/services/acr/acr-generator.service.ts
+++ b/src/services/acr/acr-generator.service.ts
@@ -649,7 +649,15 @@ class AcrGeneratorService {
     const criteriaMap = new Map<string, AcrCriterion>();
     base.forEach((c) => criteriaMap.set(c.id, c));
     wcag22NewAa.forEach((c) => criteriaMap.set(c.id, c));
-    return Array.from(criteriaMap.values());
+    // Sort by canonical WCAG dotted-number ordering — the Map preserves
+    // insertion order, which would otherwise emit the six 2.2-new
+    // criteria after `4.1.3` instead of interspersed where they belong
+    // (e.g. 2.4.11 between 2.4.7 and 2.5.1).
+    return Array.from(criteriaMap.values()).sort((a, b) => {
+      const [aMajor = 0, aMinor = 0, aPatch = 0] = a.id.split('.').map(Number);
+      const [bMajor = 0, bMinor = 0, bPatch = 0] = b.id.split('.').map(Number);
+      return aMajor - bMajor || aMinor - bMinor || aPatch - bPatch;
+    });
   }
 
   async generateConfidenceAnalysis(

--- a/src/services/acr/acr-generator.service.ts
+++ b/src/services/acr/acr-generator.service.ts
@@ -186,8 +186,13 @@ const EDITION_INFO: Record<AcrEdition, EditionInfo> = {
   }
 };
 
-/** Publisher metadata pinned to the PRH UK edition — sourced from the PRH Technical Guide's accessibility_meta_boilerplates.txt. */
-const PRH_UK_PUBLISHER_METADATA: AcrPublisherMetadata = {
+/**
+ * Publisher metadata pinned to the PRH UK edition — sourced from the
+ * PRH Technical Guide's accessibility_meta_boilerplates.txt. Frozen so
+ * downstream mutation of `doc.publisherMetadata` can't bleed back into
+ * future generations through this shared reference.
+ */
+const PRH_UK_PUBLISHER_METADATA: Readonly<AcrPublisherMetadata> = Object.freeze({
   certifiedBy: 'Penguin Random House UK',
   certifierCredential: 'Ace by DAISY OK',
   credentialUrl: 'https://daisy.github.io/ace',
@@ -195,7 +200,7 @@ const PRH_UK_PUBLISHER_METADATA: AcrPublisherMetadata = {
   accessibilitySummaryUrl: 'https://www.penguin.co.uk/accessibility',
   tdmReservationNote:
     'No part of this work may be used or reproduced in any manner for the purpose of training artificial intelligence technologies or systems. In accordance with Article 4(3) of the DSM Directive 2019/790, Penguin Random House expressly reserves this work from the text and data mining exception.',
-};
+});
 
 class AcrGeneratorService {
   async generateAcr(
@@ -243,8 +248,10 @@ class AcrGeneratorService {
       footerDisclaimer: generateFooterDisclaimer(),
       // PRH UK is the only edition today with publisher-specific
       // metadata embedded in the output. Other editions leave this
-      // field undefined.
-      publisherMetadata: edition === 'VPAT2.5-PRH-UK' ? PRH_UK_PUBLISHER_METADATA : undefined,
+      // field undefined. Spread into a fresh object so downstream
+      // mutations on `doc.publisherMetadata` can't leak between
+      // generated documents through the shared module-level constant.
+      publisherMetadata: edition === 'VPAT2.5-PRH-UK' ? { ...PRH_UK_PUBLISHER_METADATA } : undefined,
     };
 
     return acrDocument;

--- a/src/services/acr/acr-generator.service.ts
+++ b/src/services/acr/acr-generator.service.ts
@@ -11,12 +11,26 @@ import { logger } from '../../lib/logger';
 import { wcagIssueMapperService, IssueMapping, AuditIssueInput } from './wcag-issue-mapper.service';
 import { ConfidenceAnalyzerService } from './confidence-analyzer.service';
 
-export type AcrEdition =
-  | 'VPAT2.5-508'
-  | 'VPAT2.5-WCAG'
-  | 'VPAT2.5-EU'
-  | 'VPAT2.5-INT'
-  | 'VPAT2.5-PRH-UK';
+/**
+ * Single source of truth for the supported ACR / VPAT editions. Schemas
+ * in `src/controllers/acr.controller.ts`, `src/schemas/acr.schemas.ts`,
+ * and `src/schemas/batch.schemas.ts` derive their `z.enum(...)`
+ * whitelists from this constant — adding a new edition only requires
+ * updating this list (plus the per-edition wiring in this service).
+ *
+ * NOTE: `src/types/workflow-contracts.ts` carries an independent copy
+ * of this whitelist; it's marked READ-ONLY per the workflow-sprint
+ * agreement and must be reconciled in a coordinated pass.
+ */
+export const ACR_EDITIONS = [
+  'VPAT2.5-508',
+  'VPAT2.5-WCAG',
+  'VPAT2.5-EU',
+  'VPAT2.5-INT',
+  'VPAT2.5-PRH-UK',
+] as const;
+
+export type AcrEdition = (typeof ACR_EDITIONS)[number];
 
 /**
  * Publisher-specific metadata that some VPAT editions embed. Today this

--- a/src/services/acr/templates/index.ts
+++ b/src/services/acr/templates/index.ts
@@ -2,3 +2,4 @@ export { VPAT_508_TEMPLATE } from './vpat-508-template';
 export { VPAT_WCAG_TEMPLATE } from './vpat-wcag-template';
 export { VPAT_EU_TEMPLATE } from './vpat-eu-template';
 export { VPAT_INT_TEMPLATE } from './vpat-int-template';
+export { VPAT_PRH_UK_TEMPLATE } from './vpat-prh-uk-template';

--- a/src/services/acr/templates/vpat-prh-uk-template.ts
+++ b/src/services/acr/templates/vpat-prh-uk-template.ts
@@ -1,0 +1,54 @@
+/**
+ * PRH UK VPAT 2.5 edition template.
+ *
+ * Pinned to PRH UK's accessibility delivery standard per the Technical
+ * Guide's `accessibility_meta_boilerplates.txt`:
+ *   - Conforms to: EPUB Accessibility 1.1 - WCAG 2.2 Level AA
+ *   - Certified by: Penguin Random House UK
+ *   - Certifier credential: Ace by DAISY OK
+ *   - Accessibility summary URL: https://www.penguin.co.uk/accessibility
+ *   - TDM-reservation: declared at publisher level
+ *
+ * Note: like the other VPAT templates in this directory, this file is
+ * declarative metadata that the wider codebase doesn't (yet) consume —
+ * the canonical edition wiring lives in `acr-generator.service.ts`.
+ * Keeping it here for symmetry with the existing 4 editions and so a
+ * future template-rendering pipeline has a single source of truth.
+ */
+
+export const VPAT_PRH_UK_TEMPLATE = {
+  edition: 'VPAT2.5-PRH-UK',
+  title: 'Voluntary Product Accessibility Template (VPAT) - PRH UK Edition',
+  standards: ['EPUB Accessibility 1.1', 'WCAG 2.2'],
+  description:
+    'Penguin Random House UK delivery profile. Pins conformance to EPUB Accessibility 1.1 + WCAG 2.2 Level AA; certifier-of-record is Penguin Random House UK with Ace by DAISY OK credential.',
+  certifier: {
+    certifiedBy: 'Penguin Random House UK',
+    certifierCredential: 'Ace by DAISY OK',
+    credentialUrl: 'https://daisy.github.io/ace',
+  },
+  accessibilityConformsTo: 'EPUB Accessibility 1.1 - WCAG 2.2 Level AA',
+  accessibilitySummaryUrl: 'https://www.penguin.co.uk/accessibility',
+  tdmReservation: true,
+  tdmReservationNote:
+    'No part of this work may be used or reproduced in any manner for the purpose of training artificial intelligence technologies or systems. In accordance with Article 4(3) of the DSM Directive 2019/790, Penguin Random House expressly reserves this work from the text and data mining exception.',
+  sections: [
+    {
+      id: 'wcag-a',
+      title: 'Table 1: Success Criteria, Level A',
+      description: 'WCAG 2.2 Level A criteria',
+    },
+    {
+      id: 'wcag-aa',
+      title: 'Table 2: Success Criteria, Level AA',
+      description: 'WCAG 2.2 Level AA criteria',
+    },
+    // No AAA section — PRH's published target is AA.
+  ],
+  benefits: [
+    'Pinned to PRH UK accessibility certification (WCAG 2.2 AA + EPUB Accessibility 1.1)',
+    'Embeds the certifier-of-record line PRH requires in delivered VPATs',
+    'Surfaces the TDM-reservation publisher notice',
+    'Single document covers what PRH production controllers expect at hand-off',
+  ],
+} as const;

--- a/tests/unit/services/acr/acr-generator.prh-uk.test.ts
+++ b/tests/unit/services/acr/acr-generator.prh-uk.test.ts
@@ -124,6 +124,26 @@ describe('AcrGeneratorService — VPAT2.5-PRH-UK edition', () => {
     expect(details?.sections.some((s) => s.id === 'level-aaa')).toBe(false);
   });
 
+  it('publisherMetadata is a fresh per-document object — mutations do not leak (regression)', async () => {
+    // Regression for CodeRabbit minor: previously the module-level
+    // PRH_UK_PUBLISHER_METADATA was assigned by reference, so a mutation
+    // on docA.publisherMetadata would affect docB's metadata too.
+    const docA = await acrGeneratorService.generateAcr('test-job-a', {
+      edition: 'VPAT2.5-PRH-UK',
+      productInfo: PRODUCT_INFO,
+    });
+    // Mutate the assigned metadata on docA.
+    if (docA.publisherMetadata) {
+      docA.publisherMetadata.certifiedBy = 'Mutated Publisher';
+    }
+    // Generate docB — it must NOT see the mutation.
+    const docB = await acrGeneratorService.generateAcr('test-job-b', {
+      edition: 'VPAT2.5-PRH-UK',
+      productInfo: PRODUCT_INFO,
+    });
+    expect(docB.publisherMetadata?.certifiedBy).toBe('Penguin Random House UK');
+  });
+
   it('template constant agrees with the runtime edition definition (single source of truth)', () => {
     // The template file is declarative metadata; the runtime EDITION_INFO
     // is what generateAcr actually reads. They must agree on the literal

--- a/tests/unit/services/acr/acr-generator.prh-uk.test.ts
+++ b/tests/unit/services/acr/acr-generator.prh-uk.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  acrGeneratorService,
+  type AcrEdition,
+  type ProductInfo,
+} from '../../../../src/services/acr/acr-generator.service';
+import { VPAT_PRH_UK_TEMPLATE } from '../../../../src/services/acr/templates/vpat-prh-uk-template';
+
+const PRODUCT_INFO: ProductInfo = {
+  name: 'Sample Title',
+  version: '1.0.0',
+  description: 'Sample EPUB for ACR generation tests',
+  vendor: 'Test Publisher',
+  contactEmail: 'test@example.com',
+  evaluationDate: new Date('2026-05-11'),
+};
+
+describe('AcrGeneratorService — VPAT2.5-PRH-UK edition', () => {
+  it('appears in getEditions() alongside the existing 4 editions', () => {
+    const { editions } = acrGeneratorService.getEditions();
+    const codes = editions.map((e) => e.id).sort();
+    expect(codes).toContain('VPAT2.5-PRH-UK');
+    expect(codes).toContain('VPAT2.5-INT');
+    expect(codes).toContain('VPAT2.5-508');
+    expect(codes).toContain('VPAT2.5-WCAG');
+    expect(codes).toContain('VPAT2.5-EU');
+  });
+
+  it('exposes edition metadata pinned to WCAG 2.2 + EPUB Accessibility 1.1', () => {
+    const info = acrGeneratorService.getEditionInfo('VPAT2.5-PRH-UK');
+    expect(info).toBeDefined();
+    expect(info?.name).toMatch(/PRH UK/i);
+    expect(info?.standards).toContain('WCAG 2.2');
+    expect(info?.standards).toContain('EPUB Accessibility 1.1');
+    // PRH-UK is intentionally not the recommended default (international
+    // remains the global recommendation).
+    expect(info?.recommended).toBe(false);
+  });
+
+  it('getCriteriaForEdition includes WCAG 2.2 Level A + AA but excludes AAA', async () => {
+    const criteria = await acrGeneratorService.getCriteriaForEdition('VPAT2.5-PRH-UK');
+    const levels = new Set(criteria.map((c) => c.level));
+    expect(levels.has('A')).toBe(true);
+    expect(levels.has('AA')).toBe(true);
+    // PRH UK's published target is AA — no AAA criteria in this edition.
+    expect(levels.has('AAA')).toBe(false);
+  });
+
+  it('includes the six new WCAG 2.2 A/AA criteria over the 2.1 base', async () => {
+    const criteria = await acrGeneratorService.getCriteriaForEdition('VPAT2.5-PRH-UK');
+    const ids = new Set(criteria.map((c) => c.id));
+    // The six new 2.2 A/AA criteria (Style/Technical Guide pin to 2.2 AA).
+    expect(ids.has('2.4.11')).toBe(true);  // Focus Not Obscured (Minimum) — AA
+    expect(ids.has('2.5.7')).toBe(true);   // Dragging Movements — AA
+    expect(ids.has('2.5.8')).toBe(true);   // Target Size (Minimum) — AA
+    expect(ids.has('3.2.6')).toBe(true);   // Consistent Help — A
+    expect(ids.has('3.3.7')).toBe(true);   // Redundant Entry — A
+    expect(ids.has('3.3.8')).toBe(true);   // Accessible Authentication (Min) — AA
+    // AAA-only 2.2 additions should NOT be present.
+    expect(ids.has('2.4.12')).toBe(false); // Focus Not Obscured (Enhanced) — AAA
+    expect(ids.has('3.3.9')).toBe(false);  // Accessible Authentication (Enhanced) — AAA
+  });
+
+  it('still contains the WCAG 2.1 base criteria (no regression in coverage)', async () => {
+    const criteria = await acrGeneratorService.getCriteriaForEdition('VPAT2.5-PRH-UK');
+    const ids = new Set(criteria.map((c) => c.id));
+    // Spot-check a handful of 2.1 criteria that are core to EPUB
+    // accessibility — they must still be present.
+    for (const id of ['1.1.1', '1.3.1', '2.4.5', '3.1.1', '4.1.2']) {
+      expect(ids.has(id)).toBe(true);
+    }
+  });
+
+  it('does not duplicate criteria when 2.1 and 2.2 lists overlap (defensive)', async () => {
+    const criteria = await acrGeneratorService.getCriteriaForEdition('VPAT2.5-PRH-UK');
+    const ids = criteria.map((c) => c.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it('generates an AcrDocument with publisherMetadata pinned to PRH UK values', async () => {
+    const doc = await acrGeneratorService.generateAcr('test-job', {
+      edition: 'VPAT2.5-PRH-UK',
+      productInfo: PRODUCT_INFO,
+    });
+    expect(doc.edition).toBe('VPAT2.5-PRH-UK');
+    expect(doc.publisherMetadata).toBeDefined();
+    expect(doc.publisherMetadata?.certifiedBy).toBe('Penguin Random House UK');
+    expect(doc.publisherMetadata?.certifierCredential).toBe('Ace by DAISY OK');
+    expect(doc.publisherMetadata?.credentialUrl).toBe('https://daisy.github.io/ace');
+    expect(doc.publisherMetadata?.conformsTo).toBe('EPUB Accessibility 1.1 - WCAG 2.2 Level AA');
+    expect(doc.publisherMetadata?.accessibilitySummaryUrl).toBe('https://www.penguin.co.uk/accessibility');
+    expect(doc.publisherMetadata?.tdmReservationNote).toMatch(/DSM Directive 2019\/790/);
+  });
+
+  it('non-PRH editions do NOT receive publisherMetadata', async () => {
+    const editions: AcrEdition[] = ['VPAT2.5-508', 'VPAT2.5-WCAG', 'VPAT2.5-EU', 'VPAT2.5-INT'];
+    for (const edition of editions) {
+      const doc = await acrGeneratorService.generateAcr('test-job', {
+        edition,
+        productInfo: PRODUCT_INFO,
+      });
+      expect(doc.publisherMetadata).toBeUndefined();
+    }
+  });
+
+  it('PRH UK getEditionDetails groups criteria into Level A and Level AA sections', async () => {
+    const details = await acrGeneratorService.getEditionDetails('VPAT2.5-PRH-UK');
+    expect(details).toBeDefined();
+    expect(details?.sections.some((s) => s.id === 'level-a')).toBe(true);
+    expect(details?.sections.some((s) => s.id === 'level-aa')).toBe(true);
+    // No AAA section — PRH targets AA.
+    expect(details?.sections.some((s) => s.id === 'level-aaa')).toBe(false);
+  });
+
+  it('template constant agrees with the runtime edition definition (single source of truth)', () => {
+    // The template file is declarative metadata; the runtime EDITION_INFO
+    // is what generateAcr actually reads. They must agree on the literal
+    // PRH-required strings so a future template renderer doesn't drift.
+    expect(VPAT_PRH_UK_TEMPLATE.edition).toBe('VPAT2.5-PRH-UK');
+    expect(VPAT_PRH_UK_TEMPLATE.accessibilityConformsTo).toBe('EPUB Accessibility 1.1 - WCAG 2.2 Level AA');
+    expect(VPAT_PRH_UK_TEMPLATE.certifier.certifiedBy).toBe('Penguin Random House UK');
+    expect(VPAT_PRH_UK_TEMPLATE.certifier.certifierCredential).toBe('Ace by DAISY OK');
+    expect(VPAT_PRH_UK_TEMPLATE.accessibilitySummaryUrl).toBe('https://www.penguin.co.uk/accessibility');
+    expect(VPAT_PRH_UK_TEMPLATE.tdmReservation).toBe(true);
+  });
+});

--- a/tests/unit/services/acr/acr-generator.prh-uk.test.ts
+++ b/tests/unit/services/acr/acr-generator.prh-uk.test.ts
@@ -82,6 +82,29 @@ describe('AcrGeneratorService — VPAT2.5-PRH-UK edition', () => {
     }
   });
 
+  it('emits criteria in canonical WCAG dotted-number order (regression)', async () => {
+    // Regression for CodeRabbit: the Map-based merge preserves insertion
+    // order, so the six WCAG 2.2-new criteria (2.4.11, 2.5.7, 2.5.8,
+    // 3.2.6, 3.3.7, 3.3.8) were emitted after 4.1.3 instead of where
+    // they belong numerically (e.g. 2.4.11 between 2.4.7 and 2.5.1).
+    const criteria = await acrGeneratorService.getCriteriaForEdition('VPAT2.5-PRH-UK');
+    for (let i = 1; i < criteria.length; i++) {
+      const prev = criteria[i - 1].id.split('.').map(Number);
+      const curr = criteria[i].id.split('.').map(Number);
+      // Compare lexicographically as numbers, not strings.
+      const compare =
+        (prev[0] - curr[0])
+        || (prev[1] - curr[1])
+        || ((prev[2] ?? 0) - (curr[2] ?? 0));
+      expect(compare).toBeLessThanOrEqual(0);
+    }
+    // Spot-check: 2.4.11 must come before 2.5.1 (was after 4.1.3 before fix).
+    const idx2411 = criteria.findIndex((c) => c.id === '2.4.11');
+    const idx251 = criteria.findIndex((c) => c.id === '2.5.1');
+    expect(idx2411).toBeGreaterThanOrEqual(0);
+    expect(idx2411).toBeLessThan(idx251);
+  });
+
   it('does not duplicate criteria when 2.1 and 2.2 lists overlap (defensive)', async () => {
     const criteria = await acrGeneratorService.getCriteriaForEdition('VPAT2.5-PRH-UK');
     const ids = criteria.map((c) => c.id);

--- a/tests/unit/services/acr/acr-generator.prh-uk.test.ts
+++ b/tests/unit/services/acr/acr-generator.prh-uk.test.ts
@@ -61,6 +61,17 @@ describe('AcrGeneratorService — VPAT2.5-PRH-UK edition', () => {
     expect(ids.has('3.3.9')).toBe(false);  // Accessible Authentication (Enhanced) — AAA
   });
 
+  it('includes WCAG 2.1 AA criterion 1.2.4 Captions (Live) — regression', async () => {
+    // Regression for CodeRabbit P2: getWcag21BaseCriteria previously
+    // omitted 1.2.4 (Captions (Live), AA). For a report claiming WCAG 2.2
+    // Level AA conformance, omitting an AA criterion is a hard gap.
+    const criteria = await acrGeneratorService.getCriteriaForEdition('VPAT2.5-PRH-UK');
+    const c124 = criteria.find((c) => c.id === '1.2.4');
+    expect(c124).toBeDefined();
+    expect(c124?.level).toBe('AA');
+    expect(c124?.name).toMatch(/Captions \(Live\)/i);
+  });
+
   it('still contains the WCAG 2.1 base criteria (no regression in coverage)', async () => {
     const criteria = await acrGeneratorService.getCriteriaForEdition('VPAT2.5-PRH-UK');
     const ids = new Set(criteria.map((c) => c.id));


### PR DESCRIPTION
## Summary

Final PR in the **P1 PRH UK roadmap**. Adds a fifth VPAT edition tailored to Penguin Random House UK's delivery profile — pinned to **EPUB Accessibility 1.1 + WCAG 2.2 Level AA**, with PRH UK as certifier-of-record and an embedded TDM-reservation note.

Reference plan: `Ninja-Documentation/PRH-Analysis/plans/P1-Implementation-Plan.md`

## Edition shape

| Field | Value |
|---|---|
| Code | `VPAT2.5-PRH-UK` |
| Standards | `EPUB Accessibility 1.1`, `WCAG 2.2` |
| Recommended? | No (international remains the default) |
| Conforms to | `EPUB Accessibility 1.1 - WCAG 2.2 Level AA` |
| Certified by | `Penguin Random House UK` |
| Certifier credential | `Ace by DAISY OK` |
| Credential URL | `https://daisy.github.io/ace` |
| Accessibility summary URL | `https://www.penguin.co.uk/accessibility` |
| TDM reservation note | Verbatim DSM Directive 2019/790 paragraph |
| Criteria | WCAG 2.2 Level A + AA (no AAA — PRH targets AA) |

## What this PR adds

| Path | Purpose |
|---|---|
| `src/services/acr/templates/vpat-prh-uk-template.ts` | Declarative template metadata, mirroring the structure of the existing 4 templates |
| `src/services/acr/acr-generator.service.ts` | Edition wiring: type union, EDITION_INFO entry, publisher-metadata constant + interface, switch case, `getPrhUkCriteria()` + `getWcag22NewAaCriteria()` helpers |
| `tests/unit/services/acr/acr-generator.prh-uk.test.ts` | 10 unit tests |
| `src/services/acr/templates/index.ts` | Re-exports the new template constant |

## Design notes worth your eye

1. **Single source of truth for publisher strings.** The literal PRH-required strings live in `PRH_UK_PUBLISHER_METADATA` inside `acr-generator.service.ts`. The template file (`vpat-prh-uk-template.ts`) declares the same values. A "template constant agrees with runtime" test asserts they don't drift.

2. **`publisherMetadata` is an optional field on `AcrDocument`.** Populated only when `edition === 'VPAT2.5-PRH-UK'`; other editions get `undefined`. Non-breaking type change — all existing edition flows untouched.

3. **WCAG 2.2 added 6 A/AA criteria over 2.1.** Composed via a new `getWcag22NewAaCriteria()` helper. The 3 AAA-only 2.2 additions (2.4.12, 2.4.13, 3.3.9) are intentionally excluded — PRH's published delivery target is AA.

4. **4.1.1 (Parsing) kept for backward compat.** WCAG 2.2 formally obsoleted it, but many VPAT-consuming tools still expect it on the list; conforming-as-not-applicable is the right call.

5. **Not the recommended default.** `VPAT2.5-INT` remains the global recommendation. PRH UK is opt-in for publishers delivering through that channel.

## Test plan

- [x] **10 new Vitest unit tests** in `acr-generator.prh-uk.test.ts`:
  - Edition appears in `getEditions()` alongside the 4 existing
  - Metadata pinned to WCAG 2.2 + EPUB Accessibility 1.1
  - Criteria include A + AA, exclude AAA
  - 6 new 2.2 A/AA criteria present (2.4.11, 2.5.7, 2.5.8, 3.2.6, 3.3.7, 3.3.8)
  - AAA-only 2.2 criteria (2.4.12, 3.3.9) absent
  - 2.1 base criteria still present (no regression)
  - No duplicate criterion IDs
  - `generateAcr` populates `publisherMetadata` for PRH-UK with all 6 PRH-required literal strings
  - Non-PRH editions get `publisherMetadata: undefined`
  - `getEditionDetails` returns level-a + level-aa sections (no level-aaa)
  - Template constant agrees with runtime EDITION_INFO (single-source-of-truth check)
- [x] 13 existing acr-generator tests still pass — combined ACR suite **23/23**
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean on touched files
- [x] Full vitest suite **1165 passing** (was 1155 after PR4); same 7 pre-existing failures in `workflow-config.integration.test.ts` / `workflow-websocket.test.ts`. Zero regressions.

## Smoke-test plan after merge + deploy

1. Hit the existing editions endpoint (probably `GET /api/v1/acr/editions` or similar) and confirm `VPAT2.5-PRH-UK` is in the list.
2. Generate a VPAT against a PRH EPUB with `edition: 'VPAT2.5-PRH-UK'`. Verify:
   - `publisherMetadata.certifiedBy === 'Penguin Random House UK'`
   - `publisherMetadata.conformsTo === 'EPUB Accessibility 1.1 - WCAG 2.2 Level AA'`
   - Criteria list contains the 6 new 2.2 A/AA criteria
   - No AAA criteria

## Frontend follow-up

The existing UI VPAT-edition dropdown needs a new "PRH UK Edition" option pointing to `'VPAT2.5-PRH-UK'`. Out of scope for this backend PR — tracked separately for the FE agent.

## P1 PRH UK roadmap status after this merge

| PR | Status |
|---|---|
| PR1 — Profile detector (#356) | ✅ |
| PR1.5 — Detector hot-fix (#357) | ✅ |
| PR2 — Metadata + Spine validators (#358) | ✅ |
| PR3 — Nav + Per-XHTML validators (#359) | ✅ |
| PR4 — Image validators (#360) | ✅ |
| **PR5 — VPAT2.5-PRH-UK edition (this PR)** | 🟡 ready to merge |

After this merge, **P1 is fully shipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for VPAT2.5-PRH-UK with a dedicated PRH‑UK template and publisher metadata shown for that edition; criteria include WCAG 2.2 A/AA additions.

* **Schema / API**
  * Generation, export, and batch endpoints now accept VPAT2.5-PRH-UK and list it among available editions.

* **Tests**
  * New unit tests cover edition listing, criteria composition/order/no-duplicates, template values, and publisher metadata behavior.

* **Bug Fixes**
  * Ensure footer disclaimer is always populated.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/361)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->