### PR TITLE
feat(epub): PRH UK copyright-content matcher + imprint registry (P2/PR1)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -166,6 +166,67 @@ export const PRH_ISSUE_CODES = {
     fixType: 'auto',
     summary: 'Decorative images must declare role="presentation" alongside alt=""',
   },
+
+  // ── Copyright content (P2/PR1) ─────────────────────────────────────────
+  // All publisher-specific; mostly empty WCAG (legal/branding rather than
+  // accessibility). Auto-fix is intentionally deferred to P5 — pasting
+  // verbatim legal boilerplate is operator-supervised work.
+  'PRH-COPY-TDM-PARAGRAPH-MISSING': {
+    code: 'PRH-COPY-TDM-PARAGRAPH-MISSING',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Copyright page must include the PRH TDM-reservation paragraph (DSM Directive 2019/790 opt-out)',
+  },
+  'PRH-COPY-EEA-LINE-MISSING': {
+    code: 'PRH-COPY-EEA-LINE-MISSING',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Copyright page must include the EEA-representative line (Penguin Random House Ireland, Dublin)',
+  },
+  'PRH-COPY-BL-CIP-MISSING': {
+    code: 'PRH-COPY-BL-CIP-MISSING',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Copyright page must include the British Library CIP statement',
+  },
+  'PRH-COPY-ADDRESS-BLOCK-MISSING': {
+    code: 'PRH-COPY-ADDRESS-BLOCK-MISSING',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Copyright page must include the PRH correspondence address (imprint-specific)',
+  },
+  'PRH-COPY-GROUP-STATEMENT-MISSING': {
+    code: 'PRH-COPY-GROUP-STATEMENT-MISSING',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Copyright page must include the PRH group-of-companies statement',
+  },
+  'PRH-COPY-IMPRINT-URL-MISSING': {
+    code: 'PRH-COPY-IMPRINT-URL-MISSING',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Copyright page must reference the imprint URL (penguin.co.uk for adult; three URLs for children\'s; penguin.co.uk/vintage for Vintage)',
+  },
+  'PRH-COPY-PRH-LOGO-MISSING': {
+    code: 'PRH-COPY-PRH-LOGO-MISSING',
+    severity: 'minor',
+    wcag: ['1.1.1'],
+    fixType: 'manual',
+    summary: 'Copyright page must include the Penguin Random House UK logo via <figure class="copyright_logo">',
+  },
+  'PRH-COPY-ISBN-MISSING': {
+    code: 'PRH-COPY-ISBN-MISSING',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Copyright page must include the ISBN in 978-X-XXX-XXXXX-X format',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/wcag-issue-mapper.service.ts
+++ b/src/services/acr/wcag-issue-mapper.service.ts
@@ -72,6 +72,15 @@ export const RULE_TO_CRITERIA_MAP: Record<string, string[]> = {
   // Image (PR4)
   'PRH-COVER-ALT-EMPTY': ['1.1.1'],
   'PRH-DECORATIVE-MISSING-PRESENTATION-ROLE': ['4.1.2'],
+  // Copyright content (P2/PR1) — mostly publisher-specific, no WCAG analogue
+  'PRH-COPY-TDM-PARAGRAPH-MISSING': [],
+  'PRH-COPY-EEA-LINE-MISSING': [],
+  'PRH-COPY-BL-CIP-MISSING': [],
+  'PRH-COPY-ADDRESS-BLOCK-MISSING': [],
+  'PRH-COPY-GROUP-STATEMENT-MISSING': [],
+  'PRH-COPY-IMPRINT-URL-MISSING': [],
+  'PRH-COPY-PRH-LOGO-MISSING': ['1.1.1'],
+  'PRH-COPY-ISBN-MISSING': [],
 
   // ============= STANDARD ACE RULES =============
   // Images and Non-text Content

--- a/src/services/epub/epub-audit.service.ts
+++ b/src/services/epub/epub-audit.service.ts
@@ -304,7 +304,7 @@ class EpubAuditService {
       }
       if (publisherProfile.publisher === 'PRH-UK' && publisherProfile.confidence !== 'low') {
         try {
-          const prhIssues = await runPrhUkValidators(buffer);
+          const prhIssues = await runPrhUkValidators(buffer, publisherProfile);
           logger.info(`[PRH] validators emitted ${prhIssues.length} issues`);
           for (const v of prhIssues) {
             combinedIssues.push({

--- a/src/services/epub/profiles/prh-uk/imprints/_shared.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/_shared.ts
@@ -1,0 +1,170 @@
+/**
+ * Shared boilerplate fragments used by multiple PRH UK imprints.
+ *
+ * Most adult imprints (Penguin, Pelican, #Merky, Cornerstone Saga, plus
+ * fallback imprints like Ebury / Transworld / RHCP / BBC / Michael Joseph
+ * / Young Arrow) share the adult copyright template. Children's imprints
+ * (Puffin, Ladybird) share the children's template. Vintage is bespoke
+ * (separate fragments in `vintage.ts`).
+ *
+ * Strings are sourced from `branding-guide-digest.md` and verified
+ * against the Branding Guide EPUB's `copyright-ad.xhtml`,
+ * `copyright-ch.xhtml`, and `vintage/copyright.xhtml`.
+ */
+
+import type { CopyrightContentCheck } from './_types';
+
+// ── Distinctive needle fragments ─────────────────────────────────────────
+// Each is a short fragment unique to its host paragraph. The matcher
+// normalises whitespace + case before searching, so case-mismatches and
+// line-break variations don't fail the check. Paraphrasing IS tolerated as
+// a false-negative risk (see P2 implementation plan).
+
+/** TDM-reservation paragraph signature (DSM Directive 2019/790 opt-out). */
+export const TDM_RESERVATION_FRAGMENT =
+  'article 4(3) of the dsm directive 2019/790';
+
+/** EEA representative line — Penguin Random House Ireland, Dublin. */
+export const EEA_LINE_FRAGMENT =
+  'morrison chambers, 32 nassau street, dublin d02 yh68';
+
+/** British Library CIP statement. */
+export const BL_CIP_FRAGMENT =
+  'cip catalogue record for this book is available from the british library';
+
+/** Group statement — PRH group of companies. */
+export const GROUP_STATEMENT_FRAGMENT =
+  'part of the penguin random house group of companies';
+
+/** Adult correspondence address — One Embassy Gardens, London. */
+export const ADULT_ADDRESS_FRAGMENT =
+  'one embassy gardens, 8 viaduct gardens, london sw11 7bw';
+
+/** Children's correspondence address. */
+export const CHILDRENS_ADDRESS_FRAGMENT =
+  "penguin random house children's";
+
+/** PRH UK logo reference — checked separately as a file/alt-text concern, not text. */
+export const PRH_UK_LOGO_ALT = 'penguin random house uk';
+
+/** Generic ISBN pattern check — ISBN 13-digit format. */
+export const ISBN_FRAGMENT_HINT = 'isbn';
+
+// ── Shared check builders ────────────────────────────────────────────────
+
+/**
+ * Boilerplate checks every adult-template copyright page must satisfy.
+ * Composed into per-imprint rule files via spread; imprints customise
+ * the imprint-URL and group-statement checks where the wording differs.
+ */
+export function adultCopyrightChecks(): CopyrightContentCheck[] {
+  return [
+    {
+      code: 'PRH-COPY-TDM-PARAGRAPH-MISSING',
+      needle: TDM_RESERVATION_FRAGMENT,
+      severity: 'moderate',
+      suggestion:
+        'Add the verbatim PRH TDM-reservation paragraph (the one that ends with "...In accordance with Article 4(3) of the DSM Directive 2019/790, Penguin Random House expressly reserves this work from the text and data mining exception."). See the Branding Guide → copyright-ad.xhtml for the full text.',
+    },
+    {
+      code: 'PRH-COPY-EEA-LINE-MISSING',
+      needle: EEA_LINE_FRAGMENT,
+      severity: 'moderate',
+      suggestion:
+        'Add the verbatim EEA-representative line: "The authorized representative in the EEA is Penguin Random House Ireland, Morrison Chambers, 32 Nassau Street, Dublin D02 YH68".',
+    },
+    {
+      code: 'PRH-COPY-BL-CIP-MISSING',
+      needle: BL_CIP_FRAGMENT,
+      severity: 'minor',
+      suggestion:
+        'Add the British Library CIP statement: "A CIP catalogue record for this book is available from the British Library".',
+    },
+    {
+      code: 'PRH-COPY-GROUP-STATEMENT-MISSING',
+      needle: GROUP_STATEMENT_FRAGMENT,
+      severity: 'minor',
+      suggestion:
+        'Add the group statement: "[Division] is part of the Penguin Random House group of companies whose addresses can be found at global.penguinrandomhouse.com."',
+    },
+    {
+      code: 'PRH-COPY-ADDRESS-BLOCK-MISSING',
+      needle: ADULT_ADDRESS_FRAGMENT,
+      severity: 'minor',
+      suggestion:
+        'Add the correspondence address: "Penguin Random House, One Embassy Gardens, 8 Viaduct Gardens, London SW11 7BW".',
+    },
+    {
+      code: 'PRH-COPY-ISBN-MISSING',
+      needle: ISBN_FRAGMENT_HINT,
+      severity: 'moderate',
+      suggestion: 'Add the ISBN line in the format "ISBN: 978-X-XXX-XXXXX-X".',
+    },
+    // PRH-COPY-PRH-LOGO-MISSING is checked separately via an alt-text
+    // probe rather than a string-needle (the validator hands the
+    // logo-alt-check to a dedicated branch). Listed in the registry but
+    // omitted from this default-checks builder.
+    // PRH-COPY-IMPRINT-URL-MISSING is imprint-specific: adult templates
+    // expect www.penguin.co.uk; children's expects three URLs; Vintage
+    // expects penguin.co.uk/vintage. Each imprint file appends its own.
+  ];
+}
+
+/**
+ * Boilerplate checks every children's-template copyright page must
+ * satisfy. Identical to adult plus expects three imprint URLs (handled
+ * per-imprint) and a children's-specific address line.
+ */
+export function childrensCopyrightChecks(): CopyrightContentCheck[] {
+  return [
+    {
+      code: 'PRH-COPY-TDM-PARAGRAPH-MISSING',
+      needle: TDM_RESERVATION_FRAGMENT,
+      severity: 'moderate',
+      suggestion:
+        'Add the verbatim PRH TDM-reservation paragraph. See Branding Guide → copyright-ch.xhtml.',
+    },
+    {
+      code: 'PRH-COPY-EEA-LINE-MISSING',
+      needle: EEA_LINE_FRAGMENT,
+      severity: 'moderate',
+      suggestion:
+        'Add the verbatim EEA-representative line: "The authorized representative in the EEA is Penguin Random House Ireland, Morrison Chambers, 32 Nassau Street, Dublin D02 YH68".',
+    },
+    {
+      code: 'PRH-COPY-BL-CIP-MISSING',
+      needle: BL_CIP_FRAGMENT,
+      severity: 'minor',
+      suggestion:
+        'Add the British Library CIP statement: "A CIP catalogue record for this book is available from the British Library".',
+    },
+    {
+      code: 'PRH-COPY-GROUP-STATEMENT-MISSING',
+      needle: GROUP_STATEMENT_FRAGMENT,
+      severity: 'minor',
+      suggestion: 'Add the PRH group-of-companies statement.',
+    },
+    {
+      code: 'PRH-COPY-ADDRESS-BLOCK-MISSING',
+      needle: CHILDRENS_ADDRESS_FRAGMENT,
+      severity: 'minor',
+      suggestion:
+        'Add the correspondence address for Penguin Random House Children’s (One Embassy Gardens, London).',
+    },
+    {
+      code: 'PRH-COPY-ISBN-MISSING',
+      needle: ISBN_FRAGMENT_HINT,
+      severity: 'moderate',
+      suggestion: 'Add the ISBN line in the format "ISBN: 978-X-XXX-XXXXX-X".',
+    },
+  ];
+}
+
+/** Adult imprint URL check (penguin.co.uk). */
+export const PENGUIN_CO_UK_URL_CHECK: CopyrightContentCheck = {
+  code: 'PRH-COPY-IMPRINT-URL-MISSING',
+  needle: 'penguin.co.uk',
+  severity: 'minor',
+  suggestion:
+    'Add the imprint URL: <a href="http://www.penguin.co.uk">www.penguin.co.uk</a>.',
+};

--- a/src/services/epub/profiles/prh-uk/imprints/_shared.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/_shared.ts
@@ -40,15 +40,33 @@ export const GROUP_STATEMENT_FRAGMENT =
 export const ADULT_ADDRESS_FRAGMENT =
   'one embassy gardens, 8 viaduct gardens, london sw11 7bw';
 
-/** Children's correspondence address. */
-export const CHILDRENS_ADDRESS_FRAGMENT =
-  "penguin random house children's";
+/**
+ * Children's correspondence-address needle. Dropped the trailing
+ * apostrophe-s so the check is robust to curly-vs-straight apostrophe
+ * variations in real EPUBs (`children's` vs `children's`). The
+ * validator's normalisation step folds curly to straight quotes too,
+ * but this is belt-and-braces.
+ */
+export const CHILDRENS_ADDRESS_FRAGMENT = 'penguin random house children';
 
 /** PRH UK logo reference — checked separately as a file/alt-text concern, not text. */
 export const PRH_UK_LOGO_ALT = 'penguin random house uk';
 
-/** Generic ISBN pattern check — ISBN 13-digit format. */
-export const ISBN_FRAGMENT_HINT = 'isbn';
+/**
+ * ISBN-13 format check — matches `isbn` followed by an optional colon
+ * and a 978/979 prefix with the canonical hyphenated form `978-X-XXX-
+ * XXXXX-X`. Also accepts the unhyphenated 13-digit form so books that
+ * inline `ISBN 9781234567890` still pass. This is a *format* check —
+ * placeholders like "ISBN pending" intentionally fail it.
+ *
+ * Regex anchors are deliberately loose: case-insensitive, allows any
+ * whitespace runs around the colon, and matches the prefix + 13 digits
+ * with optional hyphens. Operates on the normalised (whitespace-
+ * collapsed, lowercased) text so the case flag here is redundant but
+ * kept for clarity.
+ */
+export const ISBN_FORMAT_REGEX =
+  /\bisbn\s*:?\s*97[89](?:[\s-]?\d){10}\b/i;
 
 // ── Shared check builders ────────────────────────────────────────────────
 
@@ -96,9 +114,9 @@ export function adultCopyrightChecks(): CopyrightContentCheck[] {
     },
     {
       code: 'PRH-COPY-ISBN-MISSING',
-      needle: ISBN_FRAGMENT_HINT,
+      regex: ISBN_FORMAT_REGEX,
       severity: 'moderate',
-      suggestion: 'Add the ISBN line in the format "ISBN: 978-X-XXX-XXXXX-X".',
+      suggestion: 'Add the ISBN line in the format "ISBN: 978-X-XXX-XXXXX-X". Placeholders like "ISBN pending" do not satisfy this check.',
     },
     // PRH-COPY-PRH-LOGO-MISSING is checked separately via an alt-text
     // probe rather than a string-needle (the validator hands the
@@ -153,9 +171,9 @@ export function childrensCopyrightChecks(): CopyrightContentCheck[] {
     },
     {
       code: 'PRH-COPY-ISBN-MISSING',
-      needle: ISBN_FRAGMENT_HINT,
+      regex: ISBN_FORMAT_REGEX,
       severity: 'moderate',
-      suggestion: 'Add the ISBN line in the format "ISBN: 978-X-XXX-XXXXX-X".',
+      suggestion: 'Add the ISBN line in the format "ISBN: 978-X-XXX-XXXXX-X". Placeholders like "ISBN pending" do not satisfy this check.',
     },
   ];
 }

--- a/src/services/epub/profiles/prh-uk/imprints/_types.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/_types.ts
@@ -12,21 +12,28 @@
 import type { PrhIssueSeverity } from '../../../../../constants/prh-issue-codes';
 
 /**
- * A "must-contain" check against the normalised copyright text. Code,
- * needle, and severity are mandatory; suggestion is shown to the
- * operator when the needle is missing.
+ * A "must-contain" check against the normalised copyright text. Provide
+ * either a `needle` (substring match, case-insensitive after
+ * normalisation) OR a `regex` (pattern match against the normalised
+ * text). Use `regex` for format checks like ISBN where presence of the
+ * word alone isn't enough.
  */
 export interface CopyrightContentCheck {
-  /** PRH-COPY-* code emitted when the needle is not found. */
+  /** PRH-COPY-* code emitted when the needle/regex doesn't match. */
   code: string;
   /**
-   * Needle to search for in the normalised copyright text. Should be a
-   * short distinctive fragment, NOT the whole boilerplate paragraph —
-   * matching the entire prose is brittle to typesetting drift. For the
-   * TDM-reservation paragraph for example, "Article 4(3) of the DSM
-   * Directive" is enough to uniquely identify it.
+   * Substring to search for in the normalised copyright text. Should be
+   * a short distinctive fragment, NOT the whole boilerplate paragraph —
+   * matching the entire prose is brittle to typesetting drift. Provide
+   * either `needle` OR `regex`; if both are supplied the regex wins.
    */
-  needle: string;
+  needle?: string;
+  /**
+   * Pattern to match against the normalised text. Use this for format
+   * checks (e.g. ISBN-13 digit pattern) where a plain substring match
+   * would let placeholders like "ISBN pending" pass.
+   */
+  regex?: RegExp;
   severity: PrhIssueSeverity;
   /**
    * Human-readable note about WHAT the operator should add. The

--- a/src/services/epub/profiles/prh-uk/imprints/_types.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/_types.ts
@@ -1,0 +1,63 @@
+/**
+ * Shape of per-imprint rules used by P2 boilerplate validators.
+ *
+ * Each imprint exports an `ImprintRules` object listing the verbatim
+ * strings that must appear in its copyright page, the brand-page logo
+ * alt text, the title-page logo alt text, and the socials-page rules
+ * (when applicable). The matcher (`copyright-content-validator.ts`)
+ * normalises whitespace and case before searching, so the strings here
+ * should be the *canonical* PRH form — not regex-tolerant fragments.
+ */
+
+import type { PrhIssueSeverity } from '../../../../../constants/prh-issue-codes';
+
+/**
+ * A "must-contain" check against the normalised copyright text. Code,
+ * needle, and severity are mandatory; suggestion is shown to the
+ * operator when the needle is missing.
+ */
+export interface CopyrightContentCheck {
+  /** PRH-COPY-* code emitted when the needle is not found. */
+  code: string;
+  /**
+   * Needle to search for in the normalised copyright text. Should be a
+   * short distinctive fragment, NOT the whole boilerplate paragraph —
+   * matching the entire prose is brittle to typesetting drift. For the
+   * TDM-reservation paragraph for example, "Article 4(3) of the DSM
+   * Directive" is enough to uniquely identify it.
+   */
+  needle: string;
+  severity: PrhIssueSeverity;
+  /**
+   * Human-readable note about WHAT the operator should add. The
+   * verbatim text is usually too long for the suggestion field; point
+   * the operator at the canonical source instead.
+   */
+  suggestion: string;
+}
+
+export interface ImprintRules {
+  /**
+   * Stable identifier — must match a `PrhImprint` value. Used to look up
+   * rules from `getImprintRules()`.
+   */
+  imprint: string;
+  /** Display name surfaced in issue messages. */
+  displayName: string;
+  /**
+   * Which copyright template this imprint uses. Most imprints use the
+   * adult or children's template (with imprint-specific deltas); Vintage
+   * is bespoke.
+   */
+  copyrightTemplate: 'adult' | 'children' | 'vintage-bespoke';
+  /**
+   * Ordered list of must-contain checks the copyright-content validator
+   * runs. Each missing needle emits its `code` against the copyright
+   * XHTML's path.
+   */
+  copyrightContentChecks: CopyrightContentCheck[];
+  // Future fields land in P2/PR2-PR3:
+  //   brandPage: { logoAlt: string; brandFigureClass: string };
+  //   titlePage: { logoAlt: string; acceptedVariants: TitleVariantFingerprint[] };
+  //   socials: { channels: SocialChannel[]; strapline?: string } | null;
+}

--- a/src/services/epub/profiles/prh-uk/imprints/cornerstone-saga.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/cornerstone-saga.ts
@@ -1,0 +1,17 @@
+import type { ImprintRules } from './_types';
+import { adultCopyrightChecks, PENGUIN_CO_UK_URL_CHECK } from './_shared';
+
+/**
+ * Cornerstone — Penny Street Saga. Uses the adult copyright template;
+ * bespoke branding lives in the socials page (Penny Street newsletter +
+ * Facebook handle), not the copyright boilerplate.
+ */
+export const CORNERSTONE_SAGA_RULES: ImprintRules = {
+  imprint: 'cornerstone-saga',
+  displayName: 'Cornerstone Saga',
+  copyrightTemplate: 'adult',
+  copyrightContentChecks: [
+    ...adultCopyrightChecks(),
+    PENGUIN_CO_UK_URL_CHECK,
+  ],
+};

--- a/src/services/epub/profiles/prh-uk/imprints/index.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/index.ts
@@ -1,0 +1,50 @@
+/**
+ * PRH UK imprint-rules registry.
+ *
+ * `getImprintRules(imprint)` returns the rule set for a detected
+ * imprint, or `null` when the imprint is `'unknown'` / `null` (P2
+ * validators gate on this — they don't run against unidentified
+ * imprints to avoid false positives on multi-imprint demo docs).
+ *
+ * Imprints documented in the Branding Guide with bespoke rule sets:
+ *   - Penguin, Puffin, Vintage, Pelican, Ladybird, #Merky,
+ *     Cornerstone Saga
+ *
+ * Imprints listed in the Style Guide as "use adult template" fall back
+ * to PENGUIN_RULES (which is the canonical adult template). Per Style
+ * Guide §10.4.1 this covers Ebury, Transworld, RHCP, BBC Books,
+ * Michael Joseph, Young Arrow and any others that aren't first-class
+ * here.
+ */
+
+import type { PrhImprint } from '../../types';
+import type { ImprintRules } from './_types';
+import { PENGUIN_RULES } from './penguin';
+import { PUFFIN_RULES } from './puffin';
+import { VINTAGE_RULES } from './vintage';
+import { PELICAN_RULES } from './pelican';
+import { LADYBIRD_RULES } from './ladybird';
+import { MERKY_RULES } from './merky';
+import { CORNERSTONE_SAGA_RULES } from './cornerstone-saga';
+
+const RULES_BY_IMPRINT: Partial<Record<PrhImprint, ImprintRules>> = {
+  penguin: PENGUIN_RULES,
+  puffin: PUFFIN_RULES,
+  vintage: VINTAGE_RULES,
+  pelican: PELICAN_RULES,
+  ladybird: LADYBIRD_RULES,
+  merky: MERKY_RULES,
+  'cornerstone-saga': CORNERSTONE_SAGA_RULES,
+  // 'unknown' is intentionally absent — P2 validators short-circuit on it.
+};
+
+/**
+ * Return imprint rules for a detected imprint, or null when the imprint
+ * is not first-class. Callers should also gate on this null check.
+ */
+export function getImprintRules(imprint: PrhImprint | null): ImprintRules | null {
+  if (!imprint || imprint === 'unknown') return null;
+  return RULES_BY_IMPRINT[imprint] ?? null;
+}
+
+export type { ImprintRules } from './_types';

--- a/src/services/epub/profiles/prh-uk/imprints/ladybird.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/ladybird.ts
@@ -1,0 +1,33 @@
+import type { ImprintRules } from './_types';
+import { childrensCopyrightChecks } from './_shared';
+
+/**
+ * Ladybird — children's classics imprint. Same template as Puffin
+ * (children's), with all three children's imprint URLs expected.
+ */
+export const LADYBIRD_RULES: ImprintRules = {
+  imprint: 'ladybird',
+  displayName: 'Ladybird',
+  copyrightTemplate: 'children',
+  copyrightContentChecks: [
+    ...childrensCopyrightChecks(),
+    {
+      code: 'PRH-COPY-IMPRINT-URL-MISSING',
+      needle: 'ladybird.co.uk',
+      severity: 'minor',
+      suggestion: 'Add the imprint URL: www.ladybird.co.uk',
+    },
+    {
+      code: 'PRH-COPY-IMPRINT-URL-MISSING',
+      needle: 'penguin.co.uk',
+      severity: 'minor',
+      suggestion: 'Add the imprint URL: www.penguin.co.uk (children\'s template references all three).',
+    },
+    {
+      code: 'PRH-COPY-IMPRINT-URL-MISSING',
+      needle: 'puffin.co.uk',
+      severity: 'minor',
+      suggestion: 'Add the imprint URL: www.puffin.co.uk',
+    },
+  ],
+};

--- a/src/services/epub/profiles/prh-uk/imprints/merky.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/merky.ts
@@ -1,0 +1,18 @@
+import type { ImprintRules } from './_types';
+import { adultCopyrightChecks, PENGUIN_CO_UK_URL_CHECK } from './_shared';
+
+/**
+ * #Merky Books (Cornerstone — Stormzy-founded imprint). Per Style Guide
+ * §10.4.1: uses the adult copyright template with "#MERKY BOOKS" as the
+ * division name. The imprint-specific deviation is on the title page,
+ * not the copyright page.
+ */
+export const MERKY_RULES: ImprintRules = {
+  imprint: 'merky',
+  displayName: '#Merky Books',
+  copyrightTemplate: 'adult',
+  copyrightContentChecks: [
+    ...adultCopyrightChecks(),
+    PENGUIN_CO_UK_URL_CHECK,
+  ],
+};

--- a/src/services/epub/profiles/prh-uk/imprints/pelican.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/pelican.ts
@@ -1,0 +1,17 @@
+import type { ImprintRules } from './_types';
+import { adultCopyrightChecks, PENGUIN_CO_UK_URL_CHECK } from './_shared';
+
+/**
+ * Pelican (Penguin Press) uses the adult copyright template per the
+ * Branding Guide; its bespoke branding lives in the brand page + title
+ * page + part-title styling rather than the copyright boilerplate.
+ */
+export const PELICAN_RULES: ImprintRules = {
+  imprint: 'pelican',
+  displayName: 'Pelican',
+  copyrightTemplate: 'adult',
+  copyrightContentChecks: [
+    ...adultCopyrightChecks(),
+    PENGUIN_CO_UK_URL_CHECK,
+  ],
+};

--- a/src/services/epub/profiles/prh-uk/imprints/penguin.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/penguin.ts
@@ -1,0 +1,12 @@
+import type { ImprintRules } from './_types';
+import { adultCopyrightChecks, PENGUIN_CO_UK_URL_CHECK } from './_shared';
+
+export const PENGUIN_RULES: ImprintRules = {
+  imprint: 'penguin',
+  displayName: 'Penguin',
+  copyrightTemplate: 'adult',
+  copyrightContentChecks: [
+    ...adultCopyrightChecks(),
+    PENGUIN_CO_UK_URL_CHECK,
+  ],
+};

--- a/src/services/epub/profiles/prh-uk/imprints/puffin.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/puffin.ts
@@ -1,0 +1,39 @@
+import type { ImprintRules } from './_types';
+import { childrensCopyrightChecks } from './_shared';
+
+/**
+ * Puffin — children's imprint. Uses the children's copyright template
+ * which expects all three children's imprint URLs (Penguin, Puffin,
+ * Ladybird) and a split Text/Illustrations Copyright structure.
+ *
+ * We check for all three URLs because PRH's `copyright-ch.xhtml`
+ * template uses the same three URLs across Puffin and Ladybird; an
+ * EPUB missing any of them is non-conforming regardless of which
+ * children's imprint published it.
+ */
+export const PUFFIN_RULES: ImprintRules = {
+  imprint: 'puffin',
+  displayName: 'Puffin',
+  copyrightTemplate: 'children',
+  copyrightContentChecks: [
+    ...childrensCopyrightChecks(),
+    {
+      code: 'PRH-COPY-IMPRINT-URL-MISSING',
+      needle: 'puffin.co.uk',
+      severity: 'minor',
+      suggestion: 'Add the imprint URL: www.puffin.co.uk',
+    },
+    {
+      code: 'PRH-COPY-IMPRINT-URL-MISSING',
+      needle: 'penguin.co.uk',
+      severity: 'minor',
+      suggestion: 'Add the imprint URL: www.penguin.co.uk (children\'s template references all three).',
+    },
+    {
+      code: 'PRH-COPY-IMPRINT-URL-MISSING',
+      needle: 'ladybird.co.uk',
+      severity: 'minor',
+      suggestion: 'Add the imprint URL: www.ladybird.co.uk',
+    },
+  ],
+};

--- a/src/services/epub/profiles/prh-uk/imprints/vintage.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/vintage.ts
@@ -1,0 +1,64 @@
+import type { ImprintRules } from './_types';
+import { BL_CIP_FRAGMENT, GROUP_STATEMENT_FRAGMENT, ISBN_FRAGMENT_HINT } from './_shared';
+
+/**
+ * Vintage — bespoke copyright template per the Branding Guide
+ * (vintage/copyright.xhtml). Notable differences from the adult template:
+ *   - Opens with a different anti-piracy paragraph (NOT the TDM/DSM one).
+ *   - 1988 Act assertion: "...has asserted his/her right to be identified
+ *     as the author of this Work in accordance with the Copyright,
+ *     Designs and Patents Act 1988".
+ *   - Address: "VINTAGE | 20 Vauxhall Bridge Road, London SW1V 2SA".
+ *   - Imprint URL: penguin.co.uk/vintage.
+ *   - Does NOT include the EEA-representative line.
+ *   - Does NOT include the TDM-reservation paragraph.
+ *   - Group statement IS included.
+ *   - CIP IS included.
+ *
+ * Because Vintage doesn't include the TDM clause or EEA line, we
+ * intentionally drop those checks from Vintage's rule set — otherwise
+ * every conformant Vintage book would emit false positives.
+ */
+export const VINTAGE_RULES: ImprintRules = {
+  imprint: 'vintage',
+  displayName: 'Vintage',
+  copyrightTemplate: 'vintage-bespoke',
+  copyrightContentChecks: [
+    // No TDM check — Vintage doesn't use it.
+    // No EEA check — Vintage doesn't use it either.
+    {
+      code: 'PRH-COPY-BL-CIP-MISSING',
+      needle: BL_CIP_FRAGMENT,
+      severity: 'minor',
+      suggestion:
+        'Add the British Library CIP statement: "A CIP catalogue record for this book is available from the British Library".',
+    },
+    {
+      code: 'PRH-COPY-GROUP-STATEMENT-MISSING',
+      needle: GROUP_STATEMENT_FRAGMENT,
+      severity: 'minor',
+      suggestion:
+        'Add the PRH group-of-companies statement (Vintage uses the same one as the adult template).',
+    },
+    {
+      code: 'PRH-COPY-ADDRESS-BLOCK-MISSING',
+      // Vintage-specific street address — different from adult.
+      needle: '20 vauxhall bridge road, london sw1v 2sa',
+      severity: 'minor',
+      suggestion:
+        'Add the Vintage correspondence address: "VINTAGE | 20 Vauxhall Bridge Road, London SW1V 2SA".',
+    },
+    {
+      code: 'PRH-COPY-ISBN-MISSING',
+      needle: ISBN_FRAGMENT_HINT,
+      severity: 'moderate',
+      suggestion: 'Add the ISBN line in the format "ISBN: 978-X-XXX-XXXXX-X".',
+    },
+    {
+      code: 'PRH-COPY-IMPRINT-URL-MISSING',
+      needle: 'penguin.co.uk/vintage',
+      severity: 'minor',
+      suggestion: 'Add the Vintage imprint URL: penguin.co.uk/vintage',
+    },
+  ],
+};

--- a/src/services/epub/profiles/prh-uk/imprints/vintage.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/vintage.ts
@@ -1,5 +1,5 @@
 import type { ImprintRules } from './_types';
-import { BL_CIP_FRAGMENT, GROUP_STATEMENT_FRAGMENT, ISBN_FRAGMENT_HINT } from './_shared';
+import { BL_CIP_FRAGMENT, GROUP_STATEMENT_FRAGMENT, ISBN_FORMAT_REGEX } from './_shared';
 
 /**
  * Vintage — bespoke copyright template per the Branding Guide
@@ -50,9 +50,9 @@ export const VINTAGE_RULES: ImprintRules = {
     },
     {
       code: 'PRH-COPY-ISBN-MISSING',
-      needle: ISBN_FRAGMENT_HINT,
+      regex: ISBN_FORMAT_REGEX,
       severity: 'moderate',
-      suggestion: 'Add the ISBN line in the format "ISBN: 978-X-XXX-XXXXX-X".',
+      suggestion: 'Add the ISBN line in the format "ISBN: 978-X-XXX-XXXXX-X". Placeholders like "ISBN pending" do not satisfy this check.',
     },
     {
       code: 'PRH-COPY-IMPRINT-URL-MISSING',

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -16,9 +16,28 @@ import { validatePrhSpine } from './validators/spine-validator';
 import { validatePrhNav } from './validators/nav-validator';
 import { validatePrhPerXhtml } from './validators/xhtml-validator';
 import { validatePrhImages } from './validators/image-validator';
+import { validatePrhCopyrightContent } from './validators/copyright-content-validator';
+import { getImprintRules } from './imprints';
+import type { PublisherProfile } from '../types';
 import type { PrhValidatorIssue, PrhXhtmlFile } from './validators/types';
 
-export async function runPrhUkValidators(buffer: Buffer): Promise<PrhValidatorIssue[]> {
+/**
+ * Run all PRH UK validators against an EPUB buffer.
+ *
+ * @param buffer            The EPUB file as a Buffer.
+ * @param publisherProfile  Optional profile from the detector. When
+ *                          omitted, all standards-based PRH validators
+ *                          (PR1-PR5 from P1) still run; imprint-gated
+ *                          validators (P2/PR1+) only run when the
+ *                          profile includes a recognised imprint AND
+ *                          confidence is `medium` or `high`. The
+ *                          confidence gate at the *publisher* level is
+ *                          done by the caller in `epub-audit.service.ts`.
+ */
+export async function runPrhUkValidators(
+  buffer: Buffer,
+  publisherProfile?: PublisherProfile,
+): Promise<PrhValidatorIssue[]> {
   try {
     const zip = await JSZip.loadAsync(buffer);
     const opf = await readOpf(zip);
@@ -43,13 +62,28 @@ export async function runPrhUkValidators(buffer: Buffer): Promise<PrhValidatorIs
       bookTitle,
     };
 
-    return [
+    const issues: PrhValidatorIssue[] = [
       ...validatePrhMetadata(opfInput),
       ...validatePrhSpine(opfInput),
       ...validatePrhNav(navInput),
       ...validatePrhPerXhtml(perXhtmlInput),
       ...validatePrhImages(perXhtmlInput),
     ];
+
+    // Imprint-gated P2 validators run only when we have a recognised
+    // imprint (not 'unknown' / null) AND confidence is medium-or-high.
+    // Multi-imprint demo docs (PRH Technical Guide / Branding Guide)
+    // resolve to 'unknown' and intentionally skip these.
+    const imprintRules = publisherProfile
+      ? getImprintRules(publisherProfile.imprint)
+      : null;
+    if (imprintRules && publisherProfile && publisherProfile.confidence !== 'low') {
+      issues.push(
+        ...validatePrhCopyrightContent({ ...perXhtmlInput, imprintRules }),
+      );
+    }
+
+    return issues;
   } catch (err) {
     logger.warn(
       `[PRH validators] run failed; returning no issues: ${err instanceof Error ? err.message : 'unknown error'}`,

--- a/src/services/epub/profiles/prh-uk/validators/copyright-content-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/copyright-content-validator.ts
@@ -1,0 +1,178 @@
+/**
+ * PRH UK copyright-content validator (P2/PR1).
+ *
+ * Locates the copyright XHTML inside the EPUB, normalises its visible
+ * text (strip tags + collapse whitespace + lowercase), then runs the
+ * `copyrightContentChecks` from the imprint's rule registry. Each
+ * missing needle emits the matching `PRH-COPY-*` code at the severity
+ * defined in the imprint's rules.
+ *
+ * Imprint-specific note: every imprint has a different set of checks:
+ *   - Adult template (Penguin, Pelican, #Merky, Cornerstone Saga +
+ *     unknown-imprint fallback) → TDM, EEA, CIP, group, address, URL,
+ *     ISBN.
+ *   - Children's (Puffin, Ladybird) → same as adult + three imprint
+ *     URLs.
+ *   - Vintage → NO TDM, NO EEA, bespoke address, vintage URL.
+ *
+ * Also probes for the PRH UK logo via a separate alt-text check, since
+ * its presence can't be detected via string-needle alone (the logo is
+ * an <img>, not text).
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { CopyrightContentCheck, ImprintRules } from '../imprints/_types';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+interface CopyrightInput extends PrhPerXhtmlInput {
+  imprintRules: ImprintRules;
+}
+
+export function validatePrhCopyrightContent(input: CopyrightInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  // 1. Find the copyright XHTML.
+  const copyrightFile = findCopyrightXhtml(input.xhtmlFiles);
+  if (!copyrightFile) {
+    // No copyright page at all — out of scope for this validator. PR4
+    // (content-order) will catch missing-copyright at a higher level.
+    return issues;
+  }
+
+  // 2. Normalise the visible text for substring matching.
+  const normalised = normaliseCopyrightText(copyrightFile.content);
+
+  // 3. De-duplicate checks by code: when an imprint registers multiple
+  //    PRH-COPY-IMPRINT-URL-MISSING checks (children's: 3 URLs), we
+  //    emit at most one issue per code per copyright file. The first
+  //    needle that's missing wins (so the operator sees one
+  //    representative suggestion).
+  const emittedCodes = new Set<string>();
+
+  for (const check of input.imprintRules.copyrightContentChecks) {
+    if (emittedCodes.has(check.code)) continue;
+    const present = normalised.includes(check.needle.toLowerCase());
+    if (present) {
+      // For codes that have multiple needles (URL check on children's
+      // imprints), one match doesn't mean all three URLs are present.
+      // We need to check ALL needles for that code before declaring it
+      // satisfied. Track satisfied codes separately.
+      continue;
+    }
+    issues.push(buildIssue(check, copyrightFile.path));
+    emittedCodes.add(check.code);
+  }
+
+  // 4. Check for the PRH UK logo image alt text. This is a separate
+  //    concern from the string-needle checks because the logo is an
+  //    <img>, not body text.
+  if (!hasPrhUkLogo(copyrightFile.content)) {
+    issues.push(
+      buildLogoIssue(copyrightFile.path),
+    );
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+interface XhtmlFile {
+  path: string;
+  content: string;
+}
+
+/**
+ * Locate the copyright XHTML file in the EPUB. Preference order:
+ *   1. body epub:type="copyright-page" (canonical marker).
+ *   2. <section epub:type="copyright-page">.
+ *   3. Filename heuristic — copyright.xhtml / copyright-*.xhtml.
+ */
+function findCopyrightXhtml(files: PrhPerXhtmlInput['xhtmlFiles']): XhtmlFile | null {
+  // 1. body epub:type="copyright-page".
+  for (const f of files) {
+    if (/<body\b[^>]*\bepub:type\s*=\s*["'][^"']*\bcopyright-page\b[^"']*["']/i.test(f.content)) {
+      return f;
+    }
+  }
+  // 2. <section epub:type="copyright-page">.
+  for (const f of files) {
+    if (/<section\b[^>]*\bepub:type\s*=\s*["'][^"']*\bcopyright-page\b[^"']*["']/i.test(f.content)) {
+      return f;
+    }
+  }
+  // 3. Filename heuristic.
+  for (const f of files) {
+    if (/(?:^|\/)copyright[^/]*\.x?html?$/i.test(f.path)) {
+      return f;
+    }
+  }
+  return null;
+}
+
+/**
+ * Normalise copyright XHTML to a single lowercase whitespace-collapsed
+ * string for substring matching. Strips:
+ *   - HTML tags (<...>),
+ *   - HTML entities (&amp; etc. — collapsed to their general meaning
+ *     so "&amp;" becomes " ", which still matches because we collapse
+ *     whitespace),
+ *   - whitespace runs (multiple spaces / newlines / tabs → single space),
+ *   - script/style blocks (defensive — copyright pages shouldn't have
+ *     either, but malformed input is real).
+ */
+function normaliseCopyrightText(html: string): string {
+  return html
+    // Strip script/style blocks first (their contents are not visible text).
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    // Strip all tags.
+    .replace(/<[^>]+>/g, ' ')
+    // Decode the few common entities that affect matching.
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&#x?[0-9a-f]+;/gi, ' ')  // numeric entities → space
+    // Collapse whitespace.
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+/** Detect the PRH UK logo via image src or alt-text reference. */
+function hasPrhUkLogo(html: string): boolean {
+  // Pattern 1: img src references prh_uk_logo file.
+  if (/<img\b[^>]*\bsrc\s*=\s*["'][^"']*prh_uk_logo[^"']*["']/i.test(html)) {
+    return true;
+  }
+  // Pattern 2: img alt text contains "Penguin Random House UK".
+  if (/<img\b[^>]*\balt\s*=\s*["'][^"']*penguin random house uk[^"']*["']/i.test(html)) {
+    return true;
+  }
+  return false;
+}
+
+function buildIssue(check: CopyrightContentCheck, location: string): PrhValidatorIssue {
+  return {
+    code: check.code,
+    severity: check.severity,
+    wcag: PRH_ISSUE_CODES[check.code as keyof typeof PRH_ISSUE_CODES]?.wcag ?? [],
+    message: `${PRH_ISSUE_CODES[check.code as keyof typeof PRH_ISSUE_CODES]?.summary ?? check.code}: needle "${check.needle.slice(0, 60)}" not found in copyright page`,
+    suggestion: check.suggestion,
+    location,
+  };
+}
+
+function buildLogoIssue(location: string): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES['PRH-COPY-PRH-LOGO-MISSING'];
+  return {
+    code: 'PRH-COPY-PRH-LOGO-MISSING',
+    severity: def.severity,
+    wcag: def.wcag,
+    message: def.summary,
+    suggestion:
+      'Add <figure class="copyright_logo"><img src="prh_core_assets/images/prh_uk_logo.jpg" alt="Penguin Random House UK" /></figure> to the copyright page.',
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/copyright-content-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/copyright-content-validator.ts
@@ -51,7 +51,7 @@ export function validatePrhCopyrightContent(input: CopyrightInput): PrhValidator
 
   for (const check of input.imprintRules.copyrightContentChecks) {
     if (emittedCodes.has(check.code)) continue;
-    const present = normalised.includes(check.needle.toLowerCase());
+    const present = isCheckSatisfied(check, normalised);
     if (present) {
       // For codes that have multiple needles (URL check on children's
       // imprints), one match doesn't mean all three URLs are present.
@@ -114,12 +114,14 @@ function findCopyrightXhtml(files: PrhPerXhtmlInput['xhtmlFiles']): XhtmlFile | 
  * Normalise copyright XHTML to a single lowercase whitespace-collapsed
  * string for substring matching. Strips:
  *   - HTML tags (<...>),
- *   - HTML entities (&amp; etc. — collapsed to their general meaning
- *     so "&amp;" becomes " ", which still matches because we collapse
- *     whitespace),
+ *   - HTML entities (&amp; etc.),
  *   - whitespace runs (multiple spaces / newlines / tabs → single space),
  *   - script/style blocks (defensive — copyright pages shouldn't have
- *     either, but malformed input is real).
+ *     either, but malformed input is real),
+ *   - smart-quote variations: curly quotes (’ ‘ “ ”), and a handful of
+ *     non-ASCII apostrophes get folded to ASCII equivalents so a needle
+ *     written with a straight apostrophe matches a haystack typeset
+ *     with a curly one.
  */
 function normaliseCopyrightText(html: string): string {
   return html
@@ -133,11 +135,36 @@ function normaliseCopyrightText(html: string): string {
     .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
-    .replace(/&#x?[0-9a-f]+;/gi, ' ')  // numeric entities → space
+    // Smart-quote handling: replace common curly variants with ASCII
+    // equivalents BEFORE the numeric-entity strip catches them. Both raw
+    // characters and HTML numeric refs are covered.
+    .replace(/[‘’‚‛′]/g, "'")
+    .replace(/[“”„‟″]/g, '"')
+    .replace(/&#(?:8216|8217|8218|8219|x201[89ab]);/gi, "'")
+    .replace(/&#(?:8220|8221|8222|8223|x201[cdef]);/gi, '"')
+    .replace(/&#x?[0-9a-f]+;/gi, ' ')  // remaining numeric entities → space
     // Collapse whitespace.
     .replace(/\s+/g, ' ')
     .trim()
     .toLowerCase();
+}
+
+/**
+ * Test whether a check is satisfied by the normalised text. Uses the
+ * regex when provided; otherwise falls back to a case-insensitive
+ * substring match on `needle`. Returns true (satisfied) when neither is
+ * defined — that's a malformed check and we don't want to false-fail
+ * over it. Validator should ensure every check has at least one of the
+ * two via tests.
+ */
+function isCheckSatisfied(check: CopyrightContentCheck, normalisedText: string): boolean {
+  if (check.regex) {
+    return check.regex.test(normalisedText);
+  }
+  if (check.needle) {
+    return normalisedText.includes(check.needle.toLowerCase());
+  }
+  return true;
 }
 
 /** Detect the PRH UK logo via image src or alt-text reference. */
@@ -154,11 +181,19 @@ function hasPrhUkLogo(html: string): boolean {
 }
 
 function buildIssue(check: CopyrightContentCheck, location: string): PrhValidatorIssue {
+  const summary = PRH_ISSUE_CODES[check.code as keyof typeof PRH_ISSUE_CODES]?.summary ?? check.code;
+  // Describe what we were looking for in the message — substring needle
+  // or regex source, whichever this check uses.
+  const fragment = check.needle
+    ? `needle "${check.needle.slice(0, 60)}"`
+    : check.regex
+      ? `pattern /${check.regex.source.slice(0, 60)}/`
+      : 'check';
   return {
     code: check.code,
     severity: check.severity,
     wcag: PRH_ISSUE_CODES[check.code as keyof typeof PRH_ISSUE_CODES]?.wcag ?? [],
-    message: `${PRH_ISSUE_CODES[check.code as keyof typeof PRH_ISSUE_CODES]?.summary ?? check.code}: needle "${check.needle.slice(0, 60)}" not found in copyright page`,
+    message: `${summary}: ${fragment} not found in copyright page`,
     suggestion: check.suggestion,
     location,
   };

--- a/tests/unit/services/epub/profiles/prh-uk/imprints/registry.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/imprints/registry.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { getImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints';
+
+describe('getImprintRules', () => {
+  it('returns null for null imprint', () => {
+    expect(getImprintRules(null)).toBeNull();
+  });
+
+  it('returns null for "unknown" imprint', () => {
+    expect(getImprintRules('unknown')).toBeNull();
+  });
+
+  it('returns rules for each first-class imprint', () => {
+    const imprints = ['penguin', 'puffin', 'vintage', 'pelican', 'ladybird', 'merky', 'cornerstone-saga'] as const;
+    for (const imprint of imprints) {
+      const rules = getImprintRules(imprint);
+      expect(rules, `${imprint} should have rules`).toBeDefined();
+      expect(rules?.imprint).toBe(imprint);
+    }
+  });
+
+  it('Penguin uses the adult copyright template', () => {
+    const rules = getImprintRules('penguin');
+    expect(rules?.copyrightTemplate).toBe('adult');
+  });
+
+  it('Puffin uses the children\'s copyright template', () => {
+    const rules = getImprintRules('puffin');
+    expect(rules?.copyrightTemplate).toBe('children');
+  });
+
+  it('Ladybird uses the children\'s copyright template', () => {
+    const rules = getImprintRules('ladybird');
+    expect(rules?.copyrightTemplate).toBe('children');
+  });
+
+  it('Vintage uses the bespoke copyright template', () => {
+    const rules = getImprintRules('vintage');
+    expect(rules?.copyrightTemplate).toBe('vintage-bespoke');
+  });
+
+  it('adult imprints include the TDM-reservation check', () => {
+    const adultImprints = ['penguin', 'pelican', 'merky', 'cornerstone-saga'] as const;
+    for (const imprint of adultImprints) {
+      const rules = getImprintRules(imprint);
+      const tdmCheck = rules?.copyrightContentChecks.find((c) => c.code === 'PRH-COPY-TDM-PARAGRAPH-MISSING');
+      expect(tdmCheck, `${imprint} should have TDM check`).toBeDefined();
+    }
+  });
+
+  it('children\'s imprints include all three URL checks (penguin + puffin + ladybird)', () => {
+    const childrensImprints = ['puffin', 'ladybird'] as const;
+    for (const imprint of childrensImprints) {
+      const rules = getImprintRules(imprint);
+      const urlChecks = rules?.copyrightContentChecks.filter((c) => c.code === 'PRH-COPY-IMPRINT-URL-MISSING') ?? [];
+      const needles = urlChecks.map((c) => c.needle);
+      expect(needles).toContain('penguin.co.uk');
+      expect(needles).toContain('puffin.co.uk');
+      expect(needles).toContain('ladybird.co.uk');
+    }
+  });
+
+  it('Vintage does NOT include TDM or EEA checks (template differs)', () => {
+    const rules = getImprintRules('vintage');
+    const codes = rules?.copyrightContentChecks.map((c) => c.code) ?? [];
+    expect(codes).not.toContain('PRH-COPY-TDM-PARAGRAPH-MISSING');
+    expect(codes).not.toContain('PRH-COPY-EEA-LINE-MISSING');
+  });
+
+  it('Vintage uses its own address (20 Vauxhall Bridge Road)', () => {
+    const rules = getImprintRules('vintage');
+    const addressCheck = rules?.copyrightContentChecks.find((c) => c.code === 'PRH-COPY-ADDRESS-BLOCK-MISSING');
+    expect(addressCheck?.needle).toMatch(/vauxhall bridge road/i);
+  });
+
+  it('Vintage uses the vintage-specific URL', () => {
+    const rules = getImprintRules('vintage');
+    const urlCheck = rules?.copyrightContentChecks.find((c) => c.code === 'PRH-COPY-IMPRINT-URL-MISSING');
+    expect(urlCheck?.needle).toBe('penguin.co.uk/vintage');
+  });
+
+  it('every check has severity, needle, suggestion, and a registered PRH code', () => {
+    const imprints = ['penguin', 'puffin', 'vintage', 'pelican', 'ladybird', 'merky', 'cornerstone-saga'] as const;
+    for (const imprint of imprints) {
+      const rules = getImprintRules(imprint);
+      expect(rules).not.toBeNull();
+      for (const check of rules!.copyrightContentChecks) {
+        expect(check.code, `${imprint}: ${check.code} should start with PRH-COPY-`).toMatch(/^PRH-COPY-/);
+        expect(check.needle.length).toBeGreaterThan(0);
+        expect(check.suggestion.length).toBeGreaterThan(0);
+        expect(['minor', 'moderate', 'serious', 'critical']).toContain(check.severity);
+      }
+    }
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/imprints/registry.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/imprints/registry.test.ts
@@ -79,14 +79,19 @@ describe('getImprintRules', () => {
     expect(urlCheck?.needle).toBe('penguin.co.uk/vintage');
   });
 
-  it('every check has severity, needle, suggestion, and a registered PRH code', () => {
+  it('every check has severity, a needle OR regex, suggestion, and a registered PRH code', () => {
     const imprints = ['penguin', 'puffin', 'vintage', 'pelican', 'ladybird', 'merky', 'cornerstone-saga'] as const;
     for (const imprint of imprints) {
       const rules = getImprintRules(imprint);
       expect(rules).not.toBeNull();
       for (const check of rules!.copyrightContentChecks) {
         expect(check.code, `${imprint}: ${check.code} should start with PRH-COPY-`).toMatch(/^PRH-COPY-/);
-        expect(check.needle.length).toBeGreaterThan(0);
+        // Every check must have either a needle OR a regex (validator
+        // short-circuits if neither is set, which would be a silent
+        // false-pass — guard against it).
+        const hasNeedle = typeof check.needle === 'string' && check.needle.length > 0;
+        const hasRegex = check.regex instanceof RegExp;
+        expect(hasNeedle || hasRegex, `${imprint}: ${check.code} must have needle or regex`).toBe(true);
         expect(check.suggestion.length).toBeGreaterThan(0);
         expect(['minor', 'moderate', 'serious', 'critical']).toContain(check.severity);
       }

--- a/tests/unit/services/epub/profiles/prh-uk/validators/copyright-content-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/copyright-content-validator.test.ts
@@ -114,6 +114,29 @@ describe('validatePrhCopyrightContent — Penguin (adult template)', () => {
     expect(issues.find((i) => i.code === 'PRH-COPY-ISBN-MISSING')).toBeDefined();
   });
 
+  it('flags ISBN placeholders that don\'t match the 13-digit format (regression)', () => {
+    // Regression for CodeRabbit P2: previously the substring needle
+    // "isbn" matched any copyright page that mentioned the word — so
+    // "ISBN pending" or an empty ISBN placeholder passed.
+    const placeholder = compliantAdultCopyrightXhtml().replace(
+      /<p>ISBN: [^<]*<\/p>/i,
+      '<p>ISBN: TBD pending publication</p>',
+    );
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: placeholder };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-ISBN-MISSING')).toBeDefined();
+  });
+
+  it('accepts a valid ISBN-13 without hyphens', () => {
+    const unhyphenated = compliantAdultCopyrightXhtml().replace(
+      /<p>ISBN: 978-1-234-56789-0<\/p>/i,
+      '<p>ISBN: 9781234567890</p>',
+    );
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: unhyphenated };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-ISBN-MISSING')).toBeUndefined();
+  });
+
   it('flags missing PRH UK logo when neither src nor alt matches', () => {
     const stripped = compliantAdultCopyrightXhtml().replace(
       /<figure class="copyright_logo">[\s\S]*?<\/figure>/i,

--- a/tests/unit/services/epub/profiles/prh-uk/validators/copyright-content-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/copyright-content-validator.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhCopyrightContent } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/copyright-content-validator';
+import { getImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+import type { ImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints/_types';
+
+/** Build the PRH-compliant adult copyright page text (one Penguin example). */
+function compliantAdultCopyrightXhtml(): string {
+  return `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Copyright</title></head>
+<body epub:type="frontmatter">
+<section epub:type="copyright-page" class="copyright_page_left">
+<p>PENGUIN BOOKS</p>
+<p>UK | USA | Canada | Ireland | Australia | New Zealand | India | South Africa</p>
+<p>Penguin Books is part of the Penguin Random House group of companies whose addresses can be found at global.penguinrandomhouse.com.</p>
+<p><a href="http://www.penguin.co.uk">www.penguin.co.uk</a></p>
+<figure class="copyright_logo"><img src="prh_core_assets/images/prh_uk_logo.jpg" alt="Penguin Random House UK" /></figure>
+<p>First published by Penguin Books in 2026</p>
+<p>Copyright &#169; Author Name, 2026</p>
+<p>The moral right of the author has been asserted</p>
+<p>ISBN: 978-1-234-56789-0</p>
+<p>Penguin Random House values and supports copyright. Copyright fuels creativity, encourages diverse voices, promotes freedom of expression and supports a vibrant culture. Thank you for purchasing an authorized edition of this book and for respecting intellectual property laws by not reproducing, scanning or distributing any part of it by any means without permission. You are supporting authors and enabling Penguin Random House to continue to publish books for everyone. No part of this book may be used or reproduced in any manner for the purpose of training artificial intelligence technologies or systems. In accordance with Article 4(3) of the DSM Directive 2019/790, Penguin Random House expressly reserves this work from the text and data mining exception.</p>
+<p>The authorized representative in the EEA is Penguin Random House Ireland, Morrison Chambers, 32 Nassau Street, Dublin D02 YH68</p>
+<p>A CIP catalogue record for this book is available from the British Library</p>
+<p>All correspondence to: Penguin Books, Penguin Random House, One Embassy Gardens, 8 Viaduct Gardens, London SW11 7BW</p>
+</section>
+</body>
+</html>`;
+}
+
+function input(file: PrhXhtmlFile, imprintRules: ImprintRules) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test Book',
+    xhtmlFiles: [file],
+    imprintRules,
+  };
+}
+
+describe('validatePrhCopyrightContent — Penguin (adult template)', () => {
+  const penguinRules = getImprintRules('penguin')!;
+
+  it('emits zero issues for a fully compliant Penguin copyright page', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/copyright.xhtml',
+      content: compliantAdultCopyrightXhtml(),
+    };
+    expect(validatePrhCopyrightContent(input(file, penguinRules))).toEqual([]);
+  });
+
+  it('flags missing TDM-reservation paragraph', () => {
+    const stripped = compliantAdultCopyrightXhtml().replace(/Article 4\(3\) of the DSM Directive 2019\/790[^<]*<\/p>/i, '</p>');
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: stripped };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-TDM-PARAGRAPH-MISSING')).toBeDefined();
+  });
+
+  it('flags missing EEA-representative line', () => {
+    const stripped = compliantAdultCopyrightXhtml().replace(
+      /<p>The authorized representative in the EEA[^<]*<\/p>/i,
+      '',
+    );
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: stripped };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-EEA-LINE-MISSING')).toBeDefined();
+  });
+
+  it('flags missing BL CIP statement', () => {
+    const stripped = compliantAdultCopyrightXhtml().replace(
+      /<p>A CIP catalogue record[^<]*<\/p>/i,
+      '',
+    );
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: stripped };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-BL-CIP-MISSING')).toBeDefined();
+  });
+
+  it('flags missing address block', () => {
+    const stripped = compliantAdultCopyrightXhtml().replace(
+      /One Embassy Gardens[^<]*<\/p>/,
+      'Somewhere</p>',
+    );
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: stripped };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-ADDRESS-BLOCK-MISSING')).toBeDefined();
+  });
+
+  it('flags missing group statement', () => {
+    const stripped = compliantAdultCopyrightXhtml().replace(
+      /<p>Penguin Books is part of the Penguin Random House group of companies[^<]*<\/p>/i,
+      '',
+    );
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: stripped };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-GROUP-STATEMENT-MISSING')).toBeDefined();
+  });
+
+  it('flags missing imprint URL', () => {
+    const stripped = compliantAdultCopyrightXhtml().replace(
+      /<a href="http:\/\/www\.penguin\.co\.uk">www\.penguin\.co\.uk<\/a>/i,
+      '',
+    );
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: stripped };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-IMPRINT-URL-MISSING')).toBeDefined();
+  });
+
+  it('flags missing ISBN', () => {
+    const stripped = compliantAdultCopyrightXhtml().replace(/<p>ISBN[^<]*<\/p>/i, '');
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: stripped };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-ISBN-MISSING')).toBeDefined();
+  });
+
+  it('flags missing PRH UK logo when neither src nor alt matches', () => {
+    const stripped = compliantAdultCopyrightXhtml().replace(
+      /<figure class="copyright_logo">[\s\S]*?<\/figure>/i,
+      '',
+    );
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: stripped };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-PRH-LOGO-MISSING')).toBeDefined();
+  });
+
+  it('accepts the PRH UK logo when only the alt text matches (no prh_uk_logo filename)', () => {
+    const swapped = compliantAdultCopyrightXhtml().replace(
+      /src="prh_core_assets\/images\/prh_uk_logo\.jpg"/,
+      'src="images/some-other-name.jpg"',
+    );
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: swapped };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-PRH-LOGO-MISSING')).toBeUndefined();
+  });
+
+  it('locates copyright page via filename when no epub:type marker is present', () => {
+    const noEpubType = compliantAdultCopyrightXhtml()
+      .replace(/epub:type="copyright-page"/g, '')
+      .replace(/epub:type="frontmatter"/g, '');
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/copyright.xhtml', content: noEpubType };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    // Validator must still find the page and run checks (zero issues = pass).
+    expect(issues).toEqual([]);
+  });
+
+  it('returns zero issues when no copyright XHTML can be located (different validator catches missing-copyright)', () => {
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/chapter001.xhtml', content: '<html><body>Just a chapter</body></html>' };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('validatePrhCopyrightContent — Vintage (bespoke template)', () => {
+  const vintageRules = getImprintRules('vintage')!;
+
+  it('does NOT flag missing TDM paragraph (Vintage doesn\'t use it)', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/copyright.xhtml',
+      content: `<html><body><section epub:type="copyright-page">
+        <p>VINTAGE | 20 Vauxhall Bridge Road, London SW1V 2SA</p>
+        <p>Vintage is part of the Penguin Random House group of companies whose addresses can be found at global.penguinrandomhouse.com.</p>
+        <figure class="copyright_logo"><img src="prh_uk_logo.jpg" alt="Penguin Random House UK" /></figure>
+        <p>A CIP catalogue record for this book is available from the British Library</p>
+        <p>ISBN: 978-1-234-56789-0</p>
+        <p>Visit penguin.co.uk/vintage for more</p>
+      </section></body></html>`,
+    };
+    const issues = validatePrhCopyrightContent(input(file, vintageRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-TDM-PARAGRAPH-MISSING')).toBeUndefined();
+    expect(issues.find((i) => i.code === 'PRH-COPY-EEA-LINE-MISSING')).toBeUndefined();
+  });
+
+  it('flags missing Vintage-specific address (20 Vauxhall Bridge Road)', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/copyright.xhtml',
+      content: `<html><body><section epub:type="copyright-page">
+        <p>VINTAGE</p>
+        <p>Vintage is part of the Penguin Random House group of companies.</p>
+        <figure class="copyright_logo"><img src="prh_uk_logo.jpg" alt="Penguin Random House UK" /></figure>
+        <p>A CIP catalogue record for this book is available from the British Library</p>
+        <p>ISBN: 978-1-234-56789-0</p>
+        <p>Visit penguin.co.uk/vintage for more</p>
+      </section></body></html>`,
+    };
+    const issues = validatePrhCopyrightContent(input(file, vintageRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-ADDRESS-BLOCK-MISSING')).toBeDefined();
+  });
+
+  it('flags missing Vintage-specific URL (penguin.co.uk/vintage)', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/copyright.xhtml',
+      content: `<html><body><section epub:type="copyright-page">
+        <p>VINTAGE | 20 Vauxhall Bridge Road, London SW1V 2SA</p>
+        <p>Vintage is part of the Penguin Random House group of companies.</p>
+        <figure class="copyright_logo"><img src="prh_uk_logo.jpg" alt="Penguin Random House UK" /></figure>
+        <p>A CIP catalogue record for this book is available from the British Library</p>
+        <p>ISBN: 978-1-234-56789-0</p>
+      </section></body></html>`,
+    };
+    const issues = validatePrhCopyrightContent(input(file, vintageRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-IMPRINT-URL-MISSING')).toBeDefined();
+  });
+});
+
+describe('validatePrhCopyrightContent — Puffin (children\'s template)', () => {
+  const puffinRules = getImprintRules('puffin')!;
+
+  it('flags missing ANY of the three children\'s URLs', () => {
+    // Only penguin.co.uk present; puffin.co.uk and ladybird.co.uk missing.
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/copyright.xhtml',
+      content: `<html><body><section epub:type="copyright-page">
+        <p>PENGUIN RANDOM HOUSE CHILDREN'S</p>
+        <p>Part of the Penguin Random House group of companies.</p>
+        <p>www.penguin.co.uk</p>
+        <figure class="copyright_logo"><img src="prh_uk_logo.jpg" alt="Penguin Random House UK" /></figure>
+        <p>First published by Puffin Books in 2026</p>
+        <p>Penguin Random House Children's, One Embassy Gardens, London</p>
+        <p>Article 4(3) of the DSM Directive 2019/790</p>
+        <p>Morrison Chambers, 32 Nassau Street, Dublin D02 YH68</p>
+        <p>A CIP catalogue record for this book is available from the British Library</p>
+        <p>ISBN: 978-1-234-56789-0</p>
+      </section></body></html>`,
+    };
+    const issues = validatePrhCopyrightContent(input(file, puffinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-IMPRINT-URL-MISSING')).toBeDefined();
+  });
+
+  it('passes when all three children\'s URLs are present', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/copyright.xhtml',
+      content: `<html><body><section epub:type="copyright-page">
+        <p>PENGUIN RANDOM HOUSE CHILDREN'S</p>
+        <p>Part of the Penguin Random House group of companies.</p>
+        <p>www.penguin.co.uk | www.puffin.co.uk | www.ladybird.co.uk</p>
+        <figure class="copyright_logo"><img src="prh_uk_logo.jpg" alt="Penguin Random House UK" /></figure>
+        <p>Penguin Random House Children's, One Embassy Gardens, London</p>
+        <p>Article 4(3) of the DSM Directive 2019/790 — text and data mining exception</p>
+        <p>Morrison Chambers, 32 Nassau Street, Dublin D02 YH68</p>
+        <p>A CIP catalogue record for this book is available from the British Library</p>
+        <p>ISBN: 978-1-234-56789-0</p>
+      </section></body></html>`,
+    };
+    const issues = validatePrhCopyrightContent(input(file, puffinRules));
+    expect(issues.find((i) => i.code === 'PRH-COPY-IMPRINT-URL-MISSING')).toBeUndefined();
+  });
+});
+
+describe('validatePrhCopyrightContent — text normalisation', () => {
+  const penguinRules = getImprintRules('penguin')!;
+
+  it('matches across HTML tag boundaries (collapsed whitespace)', () => {
+    // Wrap the TDM phrase across multiple tags + extra whitespace.
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/copyright.xhtml',
+      content: `<html><body><section epub:type="copyright-page">
+        <p>PENGUIN BOOKS</p>
+        <p>Penguin Books is <em>part of the</em> Penguin Random House
+          group of companies whose addresses can be found at global.penguinrandomhouse.com.</p>
+        <p>www.penguin.co.uk</p>
+        <figure class="copyright_logo"><img src="prh_uk_logo.jpg" alt="Penguin Random House UK" /></figure>
+        <p>... reserves this work from the text and data mining exception.
+        <strong>In   accordance with    Article  4(3)
+        of the DSM
+        Directive 2019/790</strong>, Penguin Random House expressly reserves...</p>
+        <p>The authorized representative in the EEA is
+        Penguin Random House Ireland, Morrison Chambers, 32 Nassau Street, Dublin D02 YH68</p>
+        <p>A CIP catalogue record for this book is available from the British Library</p>
+        <p>One Embassy Gardens, 8 Viaduct Gardens, London SW11 7BW</p>
+        <p>ISBN: 978-1-234-56789-0</p>
+      </section></body></html>`,
+    };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    // Despite the whitespace + tag noise, all needles should be found.
+    expect(issues).toEqual([]);
+  });
+
+  it('matches case-insensitively', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/copyright.xhtml',
+      content: compliantAdultCopyrightXhtml().toUpperCase(),
+    };
+    const issues = validatePrhCopyrightContent(input(file, penguinRules));
+    // After uppercasing, the validator must still find every needle.
+    // (Note: the cover img alt is now "PENGUIN RANDOM HOUSE UK" — still
+    // matches the lowercase "penguin random house uk" needle.)
+    expect(issues.filter((i) => i.code.startsWith('PRH-COPY-')).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

First PR of the **P2 PRH UK roadmap**. Adds an imprint-rules registry under `src/services/epub/profiles/prh-uk/imprints/` and a copyright-content validator that emits 8 new `PRH-COPY-*` issue codes per the detected imprint's template (adult / children's / Vintage-bespoke).

Reference plan: `Ninja-Documentation/PRH-Analysis/plans/P2-Implementation-Plan.md`

## Locked design decisions (from the plan)

| Decision | Choice | Why |
|---|---|---|
| Imprint coverage | 7 first-class | Branding Guide documents bespoke rules for exactly these; others fall back to adult template |
| String matching | Normalise-whitespace + lowercase + substring | Strict enough for legal clauses; permissive to typesetting drift |
| Severity | TDM, EEA, ISBN at `moderate`; rest `minor` | TDM + EEA have legal teeth; ISBN is real distribution metadata |
| Auto-fix | All `manual` | Auto-fixing legal boilerplate is operator-supervised; deferred to P5 |
| Imprint gating | Stricter than P1 | Requires `imprint !== 'unknown'` AND `confidence !== 'low'`. Multi-imprint demo docs (resolve to 'unknown') skip the new validator |

## Issue codes emitted

| Code | Severity | WCAG | Imprints |
|---|---|---|---|
| `PRH-COPY-TDM-PARAGRAPH-MISSING` | moderate | — | Adult + Children's (not Vintage) |
| `PRH-COPY-EEA-LINE-MISSING` | moderate | — | Adult + Children's (not Vintage) |
| `PRH-COPY-BL-CIP-MISSING` | minor | — | All 7 |
| `PRH-COPY-ADDRESS-BLOCK-MISSING` | minor | — | All 7 (different needles per template) |
| `PRH-COPY-GROUP-STATEMENT-MISSING` | minor | — | All 7 |
| `PRH-COPY-IMPRINT-URL-MISSING` | minor | — | All 7 (adult: penguin.co.uk; children's: 3 URLs; Vintage: penguin.co.uk/vintage) |
| `PRH-COPY-PRH-LOGO-MISSING` | minor | 1.1.1 | All 7 (checks img src OR alt) |
| `PRH-COPY-ISBN-MISSING` | moderate | — | All 7 |

## What this PR adds

| Path | Purpose |
|---|---|
| `imprints/_types.ts` | `ImprintRules` + `CopyrightContentCheck` interfaces |
| `imprints/_shared.ts` | Verbatim needle fragments + check-builder functions for adult & children's templates |
| `imprints/{penguin,puffin,vintage,pelican,ladybird,merky,cornerstone-saga}.ts` | Per-imprint rule sets (7 files) |
| `imprints/index.ts` | `getImprintRules(imprint)` registry lookup; null for unknown |
| `validators/copyright-content-validator.ts` | Locates copyright XHTML, normalises text, runs imprint checks, separate logo probe |

## What this PR modifies

- `run-validators.ts` — accepts optional `publisherProfile` parameter; runs the copyright-content validator only when imprint is recognised AND confidence is not 'low'
- `epub-audit.service.ts` — passes `publisherProfile` to the orchestrator
- `prh-issue-codes.ts` — 8 new code definitions
- `wcag-issue-mapper.service.ts` — WCAG mappings (mostly empty arrays; PRH-COPY-PRH-LOGO-MISSING → 1.1.1)

## Design notes worth your eye

1. **Normalisation strips tags + decodes entities + collapses whitespace + lowercases.** Match across tag boundaries (`Article 4(3) of the DSM <strong>Directive 2019/790</strong>`) works. Case mismatches work. Multi-paragraph prose-needle isn't attempted — we match short distinctive fragments (e.g. "article 4(3) of the dsm directive 2019/790") instead of full paragraphs.

2. **Multi-needle codes (children's URL check)** emit one issue when ANY needle is missing. So if puffin.co.uk is present but penguin.co.uk is missing, `PRH-COPY-IMPRINT-URL-MISSING` fires with the penguin-specific suggestion. Three different missing URLs → still one issue. The `emittedCodes` Set prevents duplicate emission.

3. **PRH UK logo is probed separately** from the string-needle checks because it's an `<img>`, not body text. The probe accepts either `src="...prh_uk_logo..."` OR `alt="Penguin Random House UK"`.

4. **Vintage explicitly omits TDM and EEA checks.** Vintage's bespoke template doesn't include those paragraphs; running adult-template checks against Vintage would emit two false-positives on every conformant Vintage book.

5. **Imprint detector ↔ imprint rules registry** are decoupled. The detector returns a `PrhImprint` (string), the registry maps that string to rules. Unrecognised imprints get null rules → P2 validator is a no-op for them. This is intentional — P1 imprint detector can resolve to 'unknown' for multi-imprint demo docs.

## Test plan

- [x] **32 new Vitest unit tests** across two suites:
  - `registry.test.ts` (12 tests) — null for unknown, all 7 imprints registered, template classification, per-imprint check composition (TDM present on adult, 3 URLs on children's, no TDM on Vintage), Vintage-specific address + URL, structural invariants on every check
  - `copyright-content-validator.test.ts` (20 tests) — Penguin happy path, all 8 codes individually flagged, logo via alt-only, filename-fallback, no-copyright-page no-op, Vintage doesn't false-positive on missing TDM/EEA but does flag its own address + URL, Puffin fires when any URL missing, text normalisation across tag boundaries + uppercase
- [x] PR1-5 of P1 still pass — combined PRH suite **161/161**
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean on touched files
- [x] Full vitest suite **1200 passing** (was 1167 after P1/PR5); same 7 pre-existing failures. Zero regressions.

## Smoke-test plan after merge + deploy

1. Re-upload a real PRH adult EPUB. Expect `prh-uk` summary to include any missing PRH-COPY-* codes; on a fully compliant book, zero new issues.
2. Re-upload a Vintage book (if available). Confirm no false-positive `PRH-COPY-TDM-PARAGRAPH-MISSING` or `PRH-COPY-EEA-LINE-MISSING`.
3. Re-upload the PRH Technical Guide. Imprint resolves to 'unknown' → the new P2 validator skips entirely. The existing P1 audit results stay the same (no new issues).
4. Upload an EPUB known to be missing one of the boilerplate items (e.g. an older book that pre-dates the TDM template). Verify the specific code fires.

## Out of scope (deferred to P2/PR2-PR4)

- **P2/PR2**: Brand page + title page validators
- **P2/PR3**: Socials-page validators (Penguin + YA + Vintage + Saga)
- **P2/PR4**: Content-order validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copyright-content validation for PRH UK imprints (Penguin, Puffin, Ladybird, Merky, Pelican, Cornerstone Saga, Vintage)
  * New checks for required copyright elements: TDM reservation, EEA representative line, British Library CIP, group statement, address block, imprint URL, ISBN, and PRH logo
  * Accessibility mapping updated for logo validation (WCAG 1.1.1)

* **Tests**
  * Added comprehensive tests for imprint registry and copyright-content validator

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/362)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->