### PR TITLE
feat(prh): brand-page + title-page validators (P2/PR2)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -227,6 +227,64 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'Copyright page must include the ISBN in 978-X-XXX-XXXXX-X format',
   },
+
+  // ── Brand page (P2/PR2) ────────────────────────────────────────────────
+  // Imprint-conditional. #Merky and Cornerstone Saga have no brand page in
+  // the canonical template — the validator gates on the imprint rules and
+  // does not emit these codes for those imprints.
+  'PRH-BRAND-PAGE-MISSING': {
+    code: 'PRH-BRAND-PAGE-MISSING',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'EPUB must include a brand page: <body epub:type="frontmatter" id="brand_page">',
+  },
+  'PRH-BRAND-PAGE-WRONG-CLASS': {
+    code: 'PRH-BRAND-PAGE-WRONG-CLASS',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Brand-page <figure> must use the imprint-specific CSS class (.brand_logo_solo for most; .image_full for Vintage)',
+  },
+  'PRH-BRAND-PAGE-WRONG-LOGO-ALT': {
+    code: 'PRH-BRAND-PAGE-WRONG-LOGO-ALT',
+    severity: 'minor',
+    wcag: ['1.1.1'],
+    fixType: 'manual',
+    summary: 'Brand-page logo alt text must match the imprint name (e.g. "Penguin Random House", "Puffin Books")',
+  },
+
+  // ── Title page (P2/PR2) ────────────────────────────────────────────────
+  // Imprint-conditional. Vintage and Cornerstone Saga don't ship a separate
+  // titlepage section in their canonical templates.
+  'PRH-TITLE-PAGE-MISSING': {
+    code: 'PRH-TITLE-PAGE-MISSING',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'EPUB must include a title page: <section epub:type="titlepage">',
+  },
+  'PRH-TITLE-PAGE-WRONG-STRUCTURE': {
+    code: 'PRH-TITLE-PAGE-WRONG-STRUCTURE',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Title page must use <section epub:type="titlepage" class="titlepage"> with book title (.booktitle)',
+  },
+  'PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO': {
+    code: 'PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Title page must include <figure class="imprint_logo"> with the imprint logo image',
+  },
+  'PRH-TITLE-PAGE-WRONG-LOGO-ALT': {
+    code: 'PRH-TITLE-PAGE-WRONG-LOGO-ALT',
+    severity: 'minor',
+    wcag: ['1.1.1'],
+    fixType: 'manual',
+    summary: 'Title-page imprint logo alt text must match the imprint expectation (most imprints: "Penguin Random House"; Pelican: "Pelican Books"; Ladybird: "Ladybird Books")',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/wcag-issue-mapper.service.ts
+++ b/src/services/acr/wcag-issue-mapper.service.ts
@@ -82,6 +82,15 @@ export const RULE_TO_CRITERIA_MAP: Record<string, string[]> = {
   'PRH-COPY-PRH-LOGO-MISSING': ['1.1.1'],
   'PRH-COPY-ISBN-MISSING': [],
 
+  // Brand + title page (P2/PR2)
+  'PRH-BRAND-PAGE-MISSING': [],
+  'PRH-BRAND-PAGE-WRONG-CLASS': [],
+  'PRH-BRAND-PAGE-WRONG-LOGO-ALT': ['1.1.1'],
+  'PRH-TITLE-PAGE-MISSING': [],
+  'PRH-TITLE-PAGE-WRONG-STRUCTURE': [],
+  'PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO': [],
+  'PRH-TITLE-PAGE-WRONG-LOGO-ALT': ['1.1.1'],
+
   // ============= STANDARD ACE RULES =============
   // Images and Non-text Content
   'img-alt': ['1.1.1'],

--- a/src/services/epub/profiles/prh-uk/imprints/_types.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/_types.ts
@@ -43,6 +43,69 @@ export interface CopyrightContentCheck {
   suggestion: string;
 }
 
+/**
+ * Brand-page rules per imprint (P2/PR2).
+ *
+ * Per Branding Guide §6, every imprint except #Merky and Cornerstone Saga
+ * ships a dedicated brand page — a frontmatter section with
+ * `<body epub:type="frontmatter" id="brand_page">` containing a full-bleed
+ * imprint logo. The logo's CSS class differs by imprint (`.brand_logo_solo`
+ * for most, `.image_full` for Vintage) and the alt text matches the
+ * imprint's marketing name ("Penguin Random House", "Puffin Books", etc.).
+ *
+ * When `null`, the imprint has no brand page in the canonical template
+ * and the validator should not emit `PRH-BRAND-PAGE-MISSING` for that
+ * imprint.
+ */
+export interface BrandPageRules {
+  /** Expected CSS class on the brand-page <figure>. */
+  figureClass: 'brand_logo_solo' | 'image_full';
+  /**
+   * Expected alt text on the brand-page <img>. Matched
+   * case-insensitively after whitespace normalisation.
+   */
+  logoAlt: string;
+}
+
+/**
+ * Title-page rules per imprint (P2/PR2).
+ *
+ * Every PRH imprint ships a title page, but the shape differs:
+ *   - Penguin (adult) — six structural variants. The validator does
+ *     a soft fingerprint match (which structural elements are present)
+ *     so any of the 6 variants passes.
+ *   - Puffin — full-bleed image-only title page (`<figure class="image_full">`
+ *     with descriptive alt text).
+ *   - Pelican — `<body class="pelican_titlepage">`, drops `<hr/>`.
+ *   - Ladybird — adds `<figure class="portrait_small">` interior
+ *     illustration + credits.
+ *   - #Merky — single bespoke title page (Penguin Random House logo
+ *     parent group).
+ *   - Vintage — n/a (Vintage's bespoke template doesn't include a
+ *     separate title-page section).
+ *   - Cornerstone Saga — n/a.
+ *
+ * Imprints with `titlePage: null` are skipped by the validator (the
+ * imprint genuinely doesn't have one in the canonical template).
+ */
+export interface TitlePageRules {
+  /**
+   * Expected alt text on the `<figure class="imprint_logo">` <img>.
+   * Matched case-insensitively after whitespace normalisation. Most
+   * imprints reference the parent group ("Penguin Random House"); a few
+   * use their own marketing name (Pelican → "Pelican Books").
+   */
+  logoAlt: string;
+  /**
+   * Whether this imprint uses the image-only title page (Puffin's full-bleed
+   * pattern). When true the validator looks for `<figure class="image_full">`
+   * instead of the structured `<section epub:type="titlepage">`, and the
+   * imprint_logo check is dropped (Puffin embeds the logo inside the
+   * full-bleed image).
+   */
+  imageOnly?: boolean;
+}
+
 export interface ImprintRules {
   /**
    * Stable identifier — must match a `PrhImprint` value. Used to look up
@@ -63,8 +126,16 @@ export interface ImprintRules {
    * XHTML's path.
    */
   copyrightContentChecks: CopyrightContentCheck[];
-  // Future fields land in P2/PR2-PR3:
-  //   brandPage: { logoAlt: string; brandFigureClass: string };
-  //   titlePage: { logoAlt: string; acceptedVariants: TitleVariantFingerprint[] };
+  /**
+   * Brand-page expectations. `null` when the imprint has no brand page
+   * in the canonical template (#Merky, Cornerstone Saga).
+   */
+  brandPage: BrandPageRules | null;
+  /**
+   * Title-page expectations. `null` when the imprint has no separate
+   * title page (Vintage, Cornerstone Saga).
+   */
+  titlePage: TitlePageRules | null;
+  // Future fields land in P2/PR3:
   //   socials: { channels: SocialChannel[]; strapline?: string } | null;
 }

--- a/src/services/epub/profiles/prh-uk/imprints/_types.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/_types.ts
@@ -88,23 +88,38 @@ export interface BrandPageRules {
  * Imprints with `titlePage: null` are skipped by the validator (the
  * imprint genuinely doesn't have one in the canonical template).
  */
-export interface TitlePageRules {
-  /**
-   * Expected alt text on the `<figure class="imprint_logo">` <img>.
-   * Matched case-insensitively after whitespace normalisation. Most
-   * imprints reference the parent group ("Penguin Random House"); a few
-   * use their own marketing name (Pelican → "Pelican Books").
-   */
-  logoAlt: string;
-  /**
-   * Whether this imprint uses the image-only title page (Puffin's full-bleed
-   * pattern). When true the validator looks for `<figure class="image_full">`
-   * instead of the structured `<section epub:type="titlepage">`, and the
-   * imprint_logo check is dropped (Puffin embeds the logo inside the
-   * full-bleed image).
-   */
-  imageOnly?: boolean;
-}
+/**
+ * Discriminated union: the structured-titlepage path validates an
+ * imprint-logo alt, but the image-only path skips that check entirely
+ * (the logo is baked into the full-bleed image). Modelling these as
+ * separate variants prevents config drift — e.g. setting both
+ * `imageOnly: true` and `logoAlt: 'Puffin Books'` (where the alt would
+ * silently be ignored).
+ */
+export type TitlePageRules =
+  | {
+      /**
+       * Image-only title page (Puffin's full-bleed pattern). The
+       * validator looks for `<figure class="image_full">` inside a
+       * frontmatter body and skips the imprint-logo check — the image
+       * itself carries the imprint mark + descriptive alt.
+       */
+      imageOnly: true;
+    }
+  | {
+      /**
+       * Structured title page (Penguin / Pelican / Ladybird / #Merky).
+       * `imageOnly` is omitted or explicitly false on this branch.
+       */
+      imageOnly?: false;
+      /**
+       * Expected alt text on the `<figure class="imprint_logo">` <img>.
+       * Matched case-insensitively after whitespace normalisation. Most
+       * imprints reference the parent group ("Penguin Random House");
+       * a few use their own marketing name (Pelican → "Pelican Books").
+       */
+      logoAlt: string;
+    };
 
 export interface ImprintRules {
   /**

--- a/src/services/epub/profiles/prh-uk/imprints/cornerstone-saga.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/cornerstone-saga.ts
@@ -14,4 +14,9 @@ export const CORNERSTONE_SAGA_RULES: ImprintRules = {
     ...adultCopyrightChecks(),
     PENGUIN_CO_UK_URL_CHECK,
   ],
+  // Cornerstone — Penny Street Saga has no canonical brand page or
+  // standalone title page in the Branding Guide; its imprint-specific
+  // styling lives on the socials page and end-matter promo blocks.
+  brandPage: null,
+  titlePage: null,
 };

--- a/src/services/epub/profiles/prh-uk/imprints/ladybird.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/ladybird.ts
@@ -30,4 +30,14 @@ export const LADYBIRD_RULES: ImprintRules = {
       suggestion: 'Add the imprint URL: www.puffin.co.uk',
     },
   ],
+  brandPage: {
+    figureClass: 'brand_logo_solo',
+    logoAlt: 'Ladybird Books',
+  },
+  titlePage: {
+    // Ladybird's title page adds <figure class="portrait_small"> for the
+    // interior illustration plus <h4> credits; structurally still a
+    // <section epub:type="titlepage"> with imprint_logo.
+    logoAlt: 'Ladybird Books',
+  },
 };

--- a/src/services/epub/profiles/prh-uk/imprints/merky.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/merky.ts
@@ -15,4 +15,13 @@ export const MERKY_RULES: ImprintRules = {
     ...adultCopyrightChecks(),
     PENGUIN_CO_UK_URL_CHECK,
   ],
+  // No dedicated brand page in the #Merky template — the imprint relies
+  // on the title page's logo and bespoke styling rather than a separate
+  // brand-mark frontmatter section.
+  brandPage: null,
+  titlePage: {
+    // #Merky uses the parent-group logo alt rather than its own
+    // marketing name (Branding Guide §6).
+    logoAlt: 'Penguin Random House',
+  },
 };

--- a/src/services/epub/profiles/prh-uk/imprints/pelican.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/pelican.ts
@@ -14,4 +14,14 @@ export const PELICAN_RULES: ImprintRules = {
     ...adultCopyrightChecks(),
     PENGUIN_CO_UK_URL_CHECK,
   ],
+  brandPage: {
+    figureClass: 'brand_logo_solo',
+    logoAlt: 'Pelican Books',
+  },
+  titlePage: {
+    // Pelican's title page drops <hr/> and uses <br/> for line breaks
+    // (Branding Guide §4); alt text uses the imprint name rather than
+    // the parent group.
+    logoAlt: 'Pelican Books',
+  },
 };

--- a/src/services/epub/profiles/prh-uk/imprints/penguin.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/penguin.ts
@@ -9,4 +9,14 @@ export const PENGUIN_RULES: ImprintRules = {
     ...adultCopyrightChecks(),
     PENGUIN_CO_UK_URL_CHECK,
   ],
+  brandPage: {
+    figureClass: 'brand_logo_solo',
+    logoAlt: 'Penguin Random House',
+  },
+  titlePage: {
+    // Branding Guide §4 ships 6 structural variants for Penguin; the
+    // validator does a soft fingerprint match so any of them passes.
+    // Logo alt is the parent-group name across all variants.
+    logoAlt: 'Penguin Random House',
+  },
 };

--- a/src/services/epub/profiles/prh-uk/imprints/puffin.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/puffin.ts
@@ -36,4 +36,16 @@ export const PUFFIN_RULES: ImprintRules = {
       suggestion: 'Add the imprint URL: www.ladybird.co.uk',
     },
   ],
+  brandPage: {
+    figureClass: 'brand_logo_solo',
+    logoAlt: 'Puffin Books',
+  },
+  titlePage: {
+    // Puffin uses the children's full-bleed title page (image-only).
+    // The validator drops the structured-imprint-logo check for this
+    // path; alt text is descriptive ("Book Title - Subtitle by Author")
+    // rather than the imprint name.
+    logoAlt: 'Puffin Books',
+    imageOnly: true,
+  },
 };

--- a/src/services/epub/profiles/prh-uk/imprints/puffin.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/puffin.ts
@@ -42,10 +42,11 @@ export const PUFFIN_RULES: ImprintRules = {
   },
   titlePage: {
     // Puffin uses the children's full-bleed title page (image-only).
-    // The validator drops the structured-imprint-logo check for this
-    // path; alt text is descriptive ("Book Title - Subtitle by Author")
-    // rather than the imprint name.
-    logoAlt: 'Puffin Books',
+    // The validator skips the structured-imprint-logo check on this
+    // path — the image itself carries the imprint mark with a
+    // descriptive alt ("Book Title - Subtitle by Author"), not the
+    // imprint name. The discriminated TitlePageRules union enforces
+    // that `logoAlt` is absent here.
     imageOnly: true,
   },
 };

--- a/src/services/epub/profiles/prh-uk/imprints/vintage.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/vintage.ts
@@ -23,6 +23,15 @@ export const VINTAGE_RULES: ImprintRules = {
   imprint: 'vintage',
   displayName: 'Vintage',
   copyrightTemplate: 'vintage-bespoke',
+  brandPage: {
+    // Vintage uses .image_full instead of .brand_logo_solo (red banner
+    // logo treated as a full image rather than a centred mark).
+    figureClass: 'image_full',
+    logoAlt: 'Vintage Books',
+  },
+  // Vintage's bespoke template doesn't ship a separate titlepage section;
+  // the copyright page carries the imprint header. Validator skips.
+  titlePage: null,
   copyrightContentChecks: [
     // No TDM check — Vintage doesn't use it.
     // No EEA check — Vintage doesn't use it either.

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -17,6 +17,8 @@ import { validatePrhNav } from './validators/nav-validator';
 import { validatePrhPerXhtml } from './validators/xhtml-validator';
 import { validatePrhImages } from './validators/image-validator';
 import { validatePrhCopyrightContent } from './validators/copyright-content-validator';
+import { validatePrhBrandPage } from './validators/brand-page-validator';
+import { validatePrhTitlePage } from './validators/title-page-validator';
 import { getImprintRules } from './imprints';
 import type { PublisherProfile } from '../types';
 import type { PrhValidatorIssue, PrhXhtmlFile } from './validators/types';
@@ -78,8 +80,11 @@ export async function runPrhUkValidators(
       ? getImprintRules(publisherProfile.imprint)
       : null;
     if (imprintRules && publisherProfile && publisherProfile.confidence !== 'low') {
+      const imprintInput = { ...perXhtmlInput, imprintRules };
       issues.push(
-        ...validatePrhCopyrightContent({ ...perXhtmlInput, imprintRules }),
+        ...validatePrhCopyrightContent(imprintInput),
+        ...validatePrhBrandPage(imprintInput),
+        ...validatePrhTitlePage(imprintInput),
       );
     }
 

--- a/src/services/epub/profiles/prh-uk/validators/brand-page-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/brand-page-validator.ts
@@ -1,0 +1,176 @@
+/**
+ * PRH UK brand-page validator (P2/PR2).
+ *
+ * Validates the structural markup and logo alt text of an imprint's
+ * brand page — the frontmatter section that displays the imprint's
+ * large logo. Per Branding Guide §6, the canonical shape is:
+ *
+ *   <body epub:type="frontmatter" id="brand_page">
+ *     <figure class="brand_logo_solo">
+ *       <img src="…/logo_large.png" alt="<Imprint Name>" />
+ *     </figure>
+ *   </body>
+ *
+ * Vintage deviates: it uses `<figure class="image_full">` instead of
+ * `.brand_logo_solo`. #Merky and Cornerstone Saga have no canonical
+ * brand page at all — the orchestrator skips them via `imprintRules.brandPage === null`.
+ *
+ * Issue codes emitted:
+ *   - PRH-BRAND-PAGE-MISSING       — no brand page found in any spine entry
+ *   - PRH-BRAND-PAGE-WRONG-CLASS   — figure class doesn't match imprint expectation
+ *   - PRH-BRAND-PAGE-WRONG-LOGO-ALT — figure exists but alt text doesn't match
+ *
+ * "Missing" is one-shot at the EPUB level (no path); structural issues
+ * are emitted against the brand-page XHTML's path.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { ImprintRules } from '../imprints/_types';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+interface BrandPageInput extends PrhPerXhtmlInput {
+  imprintRules: ImprintRules;
+}
+
+export function validatePrhBrandPage(input: BrandPageInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  // Imprint has no canonical brand page (#Merky, Cornerstone Saga).
+  if (!input.imprintRules.brandPage) return issues;
+  const rules = input.imprintRules.brandPage;
+
+  const brandFile = findBrandPageXhtml(input.xhtmlFiles);
+  if (!brandFile) {
+    issues.push(buildIssue(
+      'PRH-BRAND-PAGE-MISSING',
+      `Brand page not found. Expected a frontmatter section with id="brand_page" containing the ${input.imprintRules.displayName} logo.`,
+      `Add a brand page: <body epub:type="frontmatter" id="brand_page"><figure class="${rules.figureClass}"><img src="…/logo_large.png" alt="${rules.logoAlt}" /></figure></body>.`,
+      // No path — the issue is "this file doesn't exist in the EPUB".
+      'EPUB',
+    ));
+    return issues;
+  }
+
+  // Figure class — Vintage uses .image_full, others use .brand_logo_solo.
+  const figureClassFound = findFigureClass(brandFile.content);
+  if (figureClassFound !== rules.figureClass) {
+    issues.push(buildIssue(
+      'PRH-BRAND-PAGE-WRONG-CLASS',
+      `Brand-page <figure> class is ${figureClassFound ? `"${figureClassFound}"` : 'missing'}; ${input.imprintRules.displayName} expects "${rules.figureClass}".`,
+      `Change the brand-page <figure> to class="${rules.figureClass}".`,
+      brandFile.path,
+    ));
+  }
+
+  // Logo alt text — case-insensitive, whitespace-collapsed match against
+  // the imprint's expected alt.
+  const altFound = findBrandPageImgAlt(brandFile.content);
+  if (!altMatches(altFound, rules.logoAlt)) {
+    issues.push(buildIssue(
+      'PRH-BRAND-PAGE-WRONG-LOGO-ALT',
+      `Brand-page logo alt is ${altFound !== null ? `"${altFound}"` : 'missing'}; ${input.imprintRules.displayName} expects "${rules.logoAlt}".`,
+      `Set the brand-page <img alt="${rules.logoAlt}">.`,
+      brandFile.path,
+    ));
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+interface XhtmlFile {
+  path: string;
+  content: string;
+}
+
+/**
+ * Locate the brand-page XHTML. Preference order:
+ *   1. <body epub:type="frontmatter" id="brand_page"> (canonical marker).
+ *   2. <body id="brand_page"> (relaxed — some EPUBs drop the epub:type).
+ *   3. Filename heuristic: `brand*.xhtml` / `*brand_page*.xhtml`.
+ *
+ * Returns null when nothing matches.
+ */
+function findBrandPageXhtml(files: PrhPerXhtmlInput['xhtmlFiles']): XhtmlFile | null {
+  for (const f of files) {
+    if (/<body\b[^>]*\bid\s*=\s*["']brand_page["'][^>]*\bepub:type\s*=\s*["'][^"']*\bfrontmatter\b/i.test(f.content)
+      || /<body\b[^>]*\bepub:type\s*=\s*["'][^"']*\bfrontmatter\b[^>]*\bid\s*=\s*["']brand_page["']/i.test(f.content)) {
+      return f;
+    }
+  }
+  for (const f of files) {
+    if (/<body\b[^>]*\bid\s*=\s*["']brand_page["']/i.test(f.content)) {
+      return f;
+    }
+  }
+  for (const f of files) {
+    // Filename heuristic — match `brand_page.xhtml`, `penguin_brand.xhtml`,
+    // etc., but not unrelated files like `brand_marketing.xhtml`. We
+    // anchor on token boundary to limit false positives.
+    if (/(?:^|\/)(?:brand[-_ ]?page|[\w-]+[-_]brand|brand)\.x?html?$/i.test(f.path)) {
+      return f;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the first <figure class="…"> class value from the brand-page
+ * content. Returns the class name (`brand_logo_solo` / `image_full` /
+ * other) or null when no figure-with-class is present.
+ *
+ * Class attributes can hold multiple values (e.g. `class="brand_logo_solo
+ * with_caption"`); we check membership rather than equality so cosmetic
+ * variants pass.
+ */
+function findFigureClass(html: string): string | null {
+  const m = html.match(/<figure\b[^>]*\bclass\s*=\s*["']([^"']+)["']/i);
+  if (!m) return null;
+  const classes = m[1].split(/\s+/).map((c) => c.trim()).filter(Boolean);
+  // Prefer the canonical brand classes when present; otherwise return
+  // the first class so the wrong-class issue surfaces meaningfully.
+  for (const c of classes) {
+    if (c === 'brand_logo_solo' || c === 'image_full') return c;
+  }
+  return classes[0] ?? null;
+}
+
+/**
+ * Extract the alt text of the first <img> inside the brand-page's
+ * <figure>. Returns null when no <img alt="…"> is found.
+ */
+function findBrandPageImgAlt(html: string): string | null {
+  const figMatch = html.match(/<figure\b[\s\S]*?<\/figure>/i);
+  const scope = figMatch ? figMatch[0] : html;
+  const imgMatch = scope.match(/<img\b[^>]*\balt\s*=\s*["']([^"']*)["']/i);
+  return imgMatch ? imgMatch[1] : null;
+}
+
+/**
+ * Compare an observed alt-text value to the imprint's expected alt.
+ * Whitespace-collapsed, case-insensitive equality. Null observed values
+ * (no alt attribute at all) never match.
+ */
+function altMatches(observed: string | null, expected: string): boolean {
+  if (observed === null) return false;
+  const norm = (s: string) => s.replace(/\s+/g, ' ').trim().toLowerCase();
+  return norm(observed) === norm(expected);
+}
+
+function buildIssue(
+  code: keyof typeof PRH_ISSUE_CODES,
+  message: string,
+  suggestion: string,
+  location: string,
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${message}`,
+    suggestion,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/title-page-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/title-page-validator.ts
@@ -156,12 +156,14 @@ function findTitlePageXhtml(
       }
     }
   } else {
-    // Image-only title page: look for a frontmatter file with
-    // <figure class="image_full"> + a single descriptive <img>.
+    // Image-only title page: a frontmatter file with
+    // <figure class="image_full"> is sufficient — the filename is not
+    // a reliable signal for Puffin (real EPUBs use `half.xhtml`,
+    // `image-title.xhtml`, etc., not always `title.xhtml`). Filename
+    // heuristic is applied below as a secondary fallback only.
     for (const f of files) {
       if (/<body\b[^>]*\bepub:type\s*=\s*["'][^"']*\bfrontmatter\b/i.test(f.content)
-        && hasFigureWithClass(f.content, 'image_full')
-        && isLikelyTitlePageFilename(f.path)) {
+        && hasFigureWithClass(f.content, 'image_full')) {
         return f;
       }
     }

--- a/src/services/epub/profiles/prh-uk/validators/title-page-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/title-page-validator.ts
@@ -1,0 +1,234 @@
+/**
+ * PRH UK title-page validator (P2/PR2).
+ *
+ * Validates the structural shape and imprint logo of the title page.
+ * Per Branding Guide §4, the canonical Penguin (adult) title page is:
+ *
+ *   <body epub:type="frontmatter">
+ *     <section epub:type="titlepage" class="titlepage">
+ *       <h2>Author Name</h2>
+ *       <hr/>
+ *       <h3 class="booktitle">BOOK TITLE</h3>
+ *       <h4 class="booksubtitle">Subtitle</h4>
+ *       <figure class="imprint_logo">
+ *         <img src="…/title_page_logo.png" alt="Penguin Random House" />
+ *       </figure>
+ *     </section>
+ *   </body>
+ *
+ * Penguin defines 6 structural variants — different combinations of
+ * author / subtitle / contributor are all valid. The validator
+ * fingerprints the core structural elements (section + booktitle +
+ * imprint_logo) rather than enforcing a single variant.
+ *
+ * Imprint deviations:
+ *   - Puffin → full-bleed image-only (`<figure class="image_full">`).
+ *     We drop the imprint_logo requirement here; the image itself
+ *     carries the imprint mark + descriptive alt.
+ *   - Pelican → `<body class="pelican_titlepage">`, drops `<hr/>`, alt
+ *     = "Pelican Books".
+ *   - Ladybird → adds `<figure class="portrait_small">` + credits;
+ *     structurally still passes.
+ *   - Vintage / Cornerstone Saga → no separate titlepage in the
+ *     canonical template. `imprintRules.titlePage === null` skips the
+ *     validator.
+ *
+ * Issue codes emitted:
+ *   - PRH-TITLE-PAGE-MISSING            — no <section epub:type="titlepage"> found anywhere
+ *   - PRH-TITLE-PAGE-WRONG-STRUCTURE    — section present but missing key elements
+ *   - PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO — no <figure class="imprint_logo">
+ *   - PRH-TITLE-PAGE-WRONG-LOGO-ALT     — imprint_logo present but alt doesn't match
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { ImprintRules } from '../imprints/_types';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+interface TitlePageInput extends PrhPerXhtmlInput {
+  imprintRules: ImprintRules;
+}
+
+export function validatePrhTitlePage(input: TitlePageInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  // Imprint has no canonical title page (Vintage, Cornerstone Saga).
+  if (!input.imprintRules.titlePage) return issues;
+  const rules = input.imprintRules.titlePage;
+
+  const titleFile = findTitlePageXhtml(input.xhtmlFiles, rules.imageOnly === true);
+  if (!titleFile) {
+    issues.push(buildIssue(
+      'PRH-TITLE-PAGE-MISSING',
+      `Title page not found. Expected ${rules.imageOnly ? 'a frontmatter file with <figure class="image_full">' : '<section epub:type="titlepage">'}.`,
+      rules.imageOnly
+        ? `Add a title page with <body epub:type="frontmatter"><figure class="image_full"><img alt="Book Title - by Author" /></figure></body>.`
+        : `Add a title page with <section epub:type="titlepage" class="titlepage"> containing the book title (.booktitle) and a <figure class="imprint_logo"> with alt="${rules.logoAlt}".`,
+      'EPUB',
+    ));
+    return issues;
+  }
+
+  if (rules.imageOnly) {
+    // Image-only path (Puffin): require <figure class="image_full"> with
+    // a non-empty alt. Imprint_logo / .booktitle structure checks are
+    // intentionally skipped — the image *is* the title page.
+    const imageFullClass = hasFigureWithClass(titleFile.content, 'image_full');
+    if (!imageFullClass) {
+      issues.push(buildIssue(
+        'PRH-TITLE-PAGE-WRONG-STRUCTURE',
+        `Image-only title page expected <figure class="image_full"> but it was not found.`,
+        `Wrap the title-page image in <figure class="image_full"> per the Puffin / children's title-page pattern.`,
+        titleFile.path,
+      ));
+    }
+    return issues;
+  }
+
+  // Structured-titlepage path (Penguin / Pelican / Ladybird / Merky).
+  // Soft fingerprint: the validator passes if the page has a titlepage
+  // section AND a booktitle. Variants that drop author/subtitle/etc.
+  // still pass — those fields are content, not structural conformance.
+  if (!hasBookTitle(titleFile.content)) {
+    issues.push(buildIssue(
+      'PRH-TITLE-PAGE-WRONG-STRUCTURE',
+      `Title page is missing the <h3 class="booktitle"> (or .booktitle) element. ${input.imprintRules.displayName}'s title page must carry the book title in a tagged heading.`,
+      `Wrap the book title in <h3 class="booktitle">…</h3> per the PRH title-page template.`,
+      titleFile.path,
+    ));
+  }
+
+  const imprintLogoScope = extractImprintLogoFigure(titleFile.content);
+  if (imprintLogoScope === null) {
+    issues.push(buildIssue(
+      'PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO',
+      `Title page is missing <figure class="imprint_logo">. The closing imprint mark is mandatory per Branding Guide §4.`,
+      `Add <figure class="imprint_logo"><img src="…/title_page_logo.png" alt="${rules.logoAlt}" /></figure> at the end of the title page.`,
+      titleFile.path,
+    ));
+    return issues;
+  }
+
+  const altFound = findImgAlt(imprintLogoScope);
+  if (!altMatches(altFound, rules.logoAlt)) {
+    issues.push(buildIssue(
+      'PRH-TITLE-PAGE-WRONG-LOGO-ALT',
+      `Title-page imprint logo alt is ${altFound !== null ? `"${altFound}"` : 'missing'}; ${input.imprintRules.displayName} expects "${rules.logoAlt}".`,
+      `Set the imprint_logo <img alt="${rules.logoAlt}">.`,
+      titleFile.path,
+    ));
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+interface XhtmlFile {
+  path: string;
+  content: string;
+}
+
+/**
+ * Locate the title-page XHTML. Preference order:
+ *   1. <section epub:type="titlepage"> (structured path).
+ *   2. <body epub:type="frontmatter" class="*titlepage*"> (Pelican).
+ *   3. For image-only (Puffin): file containing <figure class="image_full">
+ *      inside a frontmatter body.
+ *   4. Filename heuristic: `title*.xhtml` (excluding `subtitle`,
+ *      `titlepage_back`, etc.).
+ *
+ * Returns null when nothing matches.
+ */
+function findTitlePageXhtml(
+  files: PrhPerXhtmlInput['xhtmlFiles'],
+  imageOnly: boolean,
+): XhtmlFile | null {
+  if (!imageOnly) {
+    for (const f of files) {
+      if (/<section\b[^>]*\bepub:type\s*=\s*["'][^"']*\btitlepage\b/i.test(f.content)) {
+        return f;
+      }
+    }
+    for (const f of files) {
+      if (/<body\b[^>]*\bclass\s*=\s*["'][^"']*\btitlepage\b/i.test(f.content)
+        && /<body\b[^>]*\bepub:type\s*=\s*["'][^"']*\bfrontmatter\b/i.test(f.content)) {
+        return f;
+      }
+    }
+  } else {
+    // Image-only title page: look for a frontmatter file with
+    // <figure class="image_full"> + a single descriptive <img>.
+    for (const f of files) {
+      if (/<body\b[^>]*\bepub:type\s*=\s*["'][^"']*\bfrontmatter\b/i.test(f.content)
+        && hasFigureWithClass(f.content, 'image_full')
+        && isLikelyTitlePageFilename(f.path)) {
+        return f;
+      }
+    }
+  }
+
+  // Filename fallback. Match `title.xhtml`, `title_3.xhtml`,
+  // `pelican_titlepage.xhtml`, but not `subtitle.xhtml` or
+  // `chapter-title.xhtml`.
+  for (const f of files) {
+    if (isLikelyTitlePageFilename(f.path)) {
+      return f;
+    }
+  }
+  return null;
+}
+
+function isLikelyTitlePageFilename(path: string): boolean {
+  // Anchored on token boundary so we don't false-match `subtitle`,
+  // `untitled`, `chapter-title`, etc.
+  return /(?:^|\/)(?:title(?:[_-]\d+)?|[a-z]+_titlepage)\.x?html?$/i.test(path);
+}
+
+function hasBookTitle(html: string): boolean {
+  return /\bclass\s*=\s*["'][^"']*\bbooktitle\b/i.test(html);
+}
+
+function hasFigureWithClass(html: string, target: string): boolean {
+  const regex = new RegExp(`<figure\\b[^>]*\\bclass\\s*=\\s*["'][^"']*\\b${target}\\b`, 'i');
+  return regex.test(html);
+}
+
+/**
+ * Extract the substring of the title-page HTML scoped to the
+ * <figure class="imprint_logo">…</figure> block. Returns null when
+ * no such figure is present. We scope to the figure so the alt-text
+ * check pulls the logo's alt rather than (for example) a body image
+ * earlier on the page.
+ */
+function extractImprintLogoFigure(html: string): string | null {
+  const m = html.match(/<figure\b[^>]*\bclass\s*=\s*["'][^"']*\bimprint_logo\b[^>]*>[\s\S]*?<\/figure>/i);
+  return m ? m[0] : null;
+}
+
+function findImgAlt(scope: string): string | null {
+  const m = scope.match(/<img\b[^>]*\balt\s*=\s*["']([^"']*)["']/i);
+  return m ? m[1] : null;
+}
+
+function altMatches(observed: string | null, expected: string): boolean {
+  if (observed === null) return false;
+  const norm = (s: string) => s.replace(/\s+/g, ' ').trim().toLowerCase();
+  return norm(observed) === norm(expected);
+}
+
+function buildIssue(
+  code: keyof typeof PRH_ISSUE_CODES,
+  message: string,
+  suggestion: string,
+  location: string,
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${message}`,
+    suggestion,
+    location,
+  };
+}

--- a/tests/unit/services/epub/profiles/prh-uk/imprints/registry.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/imprints/registry.test.ts
@@ -97,4 +97,47 @@ describe('getImprintRules', () => {
       }
     }
   });
+
+  // ── Brand-page rules (P2/PR2) ─────────────────────────────────────────
+  it('imprints with a brand page expose the canonical figure class', () => {
+    expect(getImprintRules('penguin')?.brandPage?.figureClass).toBe('brand_logo_solo');
+    expect(getImprintRules('puffin')?.brandPage?.figureClass).toBe('brand_logo_solo');
+    expect(getImprintRules('pelican')?.brandPage?.figureClass).toBe('brand_logo_solo');
+    expect(getImprintRules('ladybird')?.brandPage?.figureClass).toBe('brand_logo_solo');
+  });
+
+  it('Vintage uses .image_full on its brand page (not .brand_logo_solo)', () => {
+    expect(getImprintRules('vintage')?.brandPage?.figureClass).toBe('image_full');
+  });
+
+  it('#Merky and Cornerstone Saga have no brand page', () => {
+    expect(getImprintRules('merky')?.brandPage).toBeNull();
+    expect(getImprintRules('cornerstone-saga')?.brandPage).toBeNull();
+  });
+
+  it('brand-page logo alts match the marketing names', () => {
+    expect(getImprintRules('penguin')?.brandPage?.logoAlt).toBe('Penguin Random House');
+    expect(getImprintRules('puffin')?.brandPage?.logoAlt).toBe('Puffin Books');
+    expect(getImprintRules('vintage')?.brandPage?.logoAlt).toBe('Vintage Books');
+    expect(getImprintRules('pelican')?.brandPage?.logoAlt).toBe('Pelican Books');
+    expect(getImprintRules('ladybird')?.brandPage?.logoAlt).toBe('Ladybird Books');
+  });
+
+  // ── Title-page rules (P2/PR2) ─────────────────────────────────────────
+  it('imprints with a structured title page expose logo alt', () => {
+    expect(getImprintRules('penguin')?.titlePage?.logoAlt).toBe('Penguin Random House');
+    expect(getImprintRules('pelican')?.titlePage?.logoAlt).toBe('Pelican Books');
+    expect(getImprintRules('ladybird')?.titlePage?.logoAlt).toBe('Ladybird Books');
+    expect(getImprintRules('merky')?.titlePage?.logoAlt).toBe('Penguin Random House');
+  });
+
+  it('Puffin uses the image-only title page', () => {
+    const titlePage = getImprintRules('puffin')?.titlePage;
+    expect(titlePage?.imageOnly).toBe(true);
+  });
+
+  it('Vintage and Cornerstone Saga have no separate title page', () => {
+    expect(getImprintRules('vintage')?.titlePage).toBeNull();
+    expect(getImprintRules('cornerstone-saga')?.titlePage).toBeNull();
+  });
 });

--- a/tests/unit/services/epub/profiles/prh-uk/validators/brand-page-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/brand-page-validator.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhBrandPage } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/brand-page-validator';
+import { getImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+import type { ImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints/_types';
+
+function compliantPenguinBrandPage(): string {
+  return `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Brand</title></head>
+<body epub:type="frontmatter" id="brand_page">
+  <figure class="brand_logo_solo">
+    <img src="Penguin/images/logo_large.png" alt="Penguin Random House" />
+  </figure>
+</body>
+</html>`;
+}
+
+function compliantVintageBrandPage(): string {
+  return `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Vintage</title></head>
+<body epub:type="frontmatter" id="brand_page">
+  <figure class="image_full">
+    <img src="vintage/images/logo_large.png" alt="Vintage Books" />
+  </figure>
+</body>
+</html>`;
+}
+
+function input(files: PrhXhtmlFile[], imprintRules: ImprintRules) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test Book',
+    xhtmlFiles: files,
+    imprintRules,
+  };
+}
+
+describe('validatePrhBrandPage — Penguin (.brand_logo_solo)', () => {
+  const penguinRules = getImprintRules('penguin')!;
+
+  it('emits zero issues for a fully compliant Penguin brand page', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/brand.xhtml',
+      content: compliantPenguinBrandPage(),
+    };
+    expect(validatePrhBrandPage(input([file], penguinRules))).toEqual([]);
+  });
+
+  it('emits PRH-BRAND-PAGE-MISSING when no brand page exists in the EPUB', () => {
+    const issues = validatePrhBrandPage(input([], penguinRules));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-BRAND-PAGE-MISSING');
+  });
+
+  it('emits PRH-BRAND-PAGE-WRONG-CLASS when the figure uses .image_full (Vintage class) on Penguin', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/brand.xhtml',
+      content: compliantPenguinBrandPage().replace('brand_logo_solo', 'image_full'),
+    };
+    const issues = validatePrhBrandPage(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-BRAND-PAGE-WRONG-CLASS')).toBeDefined();
+  });
+
+  it('emits PRH-BRAND-PAGE-WRONG-LOGO-ALT when alt is "Penguin Books" instead of "Penguin Random House"', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/brand.xhtml',
+      content: compliantPenguinBrandPage().replace('alt="Penguin Random House"', 'alt="Penguin Books"'),
+    };
+    const issues = validatePrhBrandPage(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-BRAND-PAGE-WRONG-LOGO-ALT')).toBeDefined();
+  });
+
+  it('emits PRH-BRAND-PAGE-WRONG-LOGO-ALT when alt is empty', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/brand.xhtml',
+      content: compliantPenguinBrandPage().replace('alt="Penguin Random House"', 'alt=""'),
+    };
+    const issues = validatePrhBrandPage(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-BRAND-PAGE-WRONG-LOGO-ALT')).toBeDefined();
+  });
+
+  it('passes when alt is in a different case ("PENGUIN RANDOM HOUSE")', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/brand.xhtml',
+      content: compliantPenguinBrandPage().replace('alt="Penguin Random House"', 'alt="PENGUIN RANDOM HOUSE"'),
+    };
+    const issues = validatePrhBrandPage(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-BRAND-PAGE-WRONG-LOGO-ALT')).toBeUndefined();
+  });
+
+  it('finds the brand page via filename heuristic when epub:type is missing', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/brand_page.xhtml',
+      content: compliantPenguinBrandPage().replace(/<body[^>]*>/, '<body>'),
+    };
+    expect(validatePrhBrandPage(input([file], penguinRules))).toEqual([]);
+  });
+});
+
+describe('validatePrhBrandPage — Vintage (.image_full)', () => {
+  const vintageRules = getImprintRules('vintage')!;
+
+  it('emits zero issues for a fully compliant Vintage brand page', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/vintage_brand.xhtml',
+      content: compliantVintageBrandPage(),
+    };
+    expect(validatePrhBrandPage(input([file], vintageRules))).toEqual([]);
+  });
+
+  it('emits PRH-BRAND-PAGE-WRONG-CLASS when Vintage uses .brand_logo_solo (Penguin class)', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/vintage_brand.xhtml',
+      content: compliantVintageBrandPage().replace('image_full', 'brand_logo_solo'),
+    };
+    const issues = validatePrhBrandPage(input([file], vintageRules));
+    expect(issues.find((i) => i.code === 'PRH-BRAND-PAGE-WRONG-CLASS')).toBeDefined();
+  });
+
+  it('emits PRH-BRAND-PAGE-WRONG-LOGO-ALT when alt says "Vintage" not "Vintage Books"', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/vintage_brand.xhtml',
+      content: compliantVintageBrandPage().replace('alt="Vintage Books"', 'alt="Vintage"'),
+    };
+    const issues = validatePrhBrandPage(input([file], vintageRules));
+    expect(issues.find((i) => i.code === 'PRH-BRAND-PAGE-WRONG-LOGO-ALT')).toBeDefined();
+  });
+});
+
+describe('validatePrhBrandPage — imprints without a canonical brand page', () => {
+  it('#Merky emits zero brand-page issues regardless of EPUB content', () => {
+    const merkyRules = getImprintRules('merky')!;
+    expect(validatePrhBrandPage(input([], merkyRules))).toEqual([]);
+    // Even when a brand page IS present, #Merky has no rules → no issues.
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/brand.xhtml',
+      content: compliantPenguinBrandPage(),
+    };
+    expect(validatePrhBrandPage(input([file], merkyRules))).toEqual([]);
+  });
+
+  it('Cornerstone Saga emits zero brand-page issues regardless of EPUB content', () => {
+    const sagaRules = getImprintRules('cornerstone-saga')!;
+    expect(validatePrhBrandPage(input([], sagaRules))).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/title-page-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/title-page-validator.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhTitlePage } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/title-page-validator';
+import { getImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+import type { ImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints/_types';
+
+/** Penguin title.xhtml variant — full structure (author + title + subtitle). */
+function penguinTitleVariant1(): string {
+  return `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Title</title></head>
+<body epub:type="frontmatter">
+  <section epub:type="titlepage" class="titlepage">
+    <h2>Author Name</h2>
+    <hr/>
+    <h3 class="booktitle">BOOK TITLE</h3>
+    <h4 class="booksubtitle">Subtitle</h4>
+    <figure class="imprint_logo">
+      <img src="images/title_page_logo.png" alt="Penguin Random House" />
+    </figure>
+  </section>
+</body>
+</html>`;
+}
+
+/** Penguin title_5.xhtml variant — no author byline, title + contributor only. */
+function penguinTitleVariant5(): string {
+  return `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Title</title></head>
+<body epub:type="frontmatter">
+  <section epub:type="titlepage" class="titlepage">
+    <h3 class="booktitle">BOOK TITLE</h3>
+    <p>edited by Editor Name</p>
+    <figure class="imprint_logo">
+      <img src="images/title_page_logo.png" alt="Penguin Random House" />
+    </figure>
+  </section>
+</body>
+</html>`;
+}
+
+function puffinImageOnlyTitlePage(): string {
+  return `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Title</title></head>
+<body epub:type="frontmatter">
+  <figure class="image_full">
+    <img alt="The Victory Dogs by Megan Rix" src="images/half.jpg" />
+  </figure>
+</body>
+</html>`;
+}
+
+function input(files: PrhXhtmlFile[], imprintRules: ImprintRules) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test Book',
+    xhtmlFiles: files,
+    imprintRules,
+  };
+}
+
+describe('validatePrhTitlePage — Penguin structured', () => {
+  const penguinRules = getImprintRules('penguin')!;
+
+  it('emits zero issues for variant 1 (author + title + subtitle)', () => {
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/title.xhtml', content: penguinTitleVariant1() };
+    expect(validatePrhTitlePage(input([file], penguinRules))).toEqual([]);
+  });
+
+  it('emits zero issues for variant 5 (title + contributor, no author)', () => {
+    // Soft fingerprint match — drops the author byline but keeps the
+    // core structure. The 6 Penguin variants should all pass.
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/title_5.xhtml', content: penguinTitleVariant5() };
+    expect(validatePrhTitlePage(input([file], penguinRules))).toEqual([]);
+  });
+
+  it('emits PRH-TITLE-PAGE-MISSING when no titlepage section is present', () => {
+    const issues = validatePrhTitlePage(input([], penguinRules));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-TITLE-PAGE-MISSING');
+  });
+
+  it('emits PRH-TITLE-PAGE-WRONG-STRUCTURE when .booktitle is missing', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/title.xhtml',
+      content: penguinTitleVariant1().replace('class="booktitle"', 'class="generic_title"'),
+    };
+    const issues = validatePrhTitlePage(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-TITLE-PAGE-WRONG-STRUCTURE')).toBeDefined();
+  });
+
+  it('emits PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO when the imprint_logo figure is absent', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/title.xhtml',
+      content: penguinTitleVariant1().replace(/<figure class="imprint_logo">[\s\S]*?<\/figure>/, ''),
+    };
+    const issues = validatePrhTitlePage(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO')).toBeDefined();
+  });
+
+  it('emits PRH-TITLE-PAGE-WRONG-LOGO-ALT when alt is "Penguin Books" instead of "Penguin Random House"', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/title.xhtml',
+      content: penguinTitleVariant1().replace('alt="Penguin Random House"', 'alt="Penguin Books"'),
+    };
+    const issues = validatePrhTitlePage(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-TITLE-PAGE-WRONG-LOGO-ALT')).toBeDefined();
+  });
+});
+
+describe('validatePrhTitlePage — Puffin image-only', () => {
+  const puffinRules = getImprintRules('puffin')!;
+
+  it('emits zero issues for a compliant Puffin image-only title page', () => {
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/title.xhtml', content: puffinImageOnlyTitlePage() };
+    expect(validatePrhTitlePage(input([file], puffinRules))).toEqual([]);
+  });
+
+  it('emits PRH-TITLE-PAGE-WRONG-STRUCTURE when .image_full is missing', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/title.xhtml',
+      content: puffinImageOnlyTitlePage().replace('class="image_full"', 'class="cover_image"'),
+    };
+    const issues = validatePrhTitlePage(input([file], puffinRules));
+    expect(issues.find((i) => i.code === 'PRH-TITLE-PAGE-WRONG-STRUCTURE')).toBeDefined();
+  });
+
+  it('does NOT emit imprint-logo issues for the image-only path', () => {
+    // Puffin's full-bleed image carries the imprint mark; there's no
+    // separate .imprint_logo figure to check.
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/title.xhtml', content: puffinImageOnlyTitlePage() };
+    const issues = validatePrhTitlePage(input([file], puffinRules));
+    expect(issues.find((i) => i.code === 'PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO')).toBeUndefined();
+    expect(issues.find((i) => i.code === 'PRH-TITLE-PAGE-WRONG-LOGO-ALT')).toBeUndefined();
+  });
+});
+
+describe('validatePrhTitlePage — Pelican (imprint-specific alt)', () => {
+  const pelicanRules = getImprintRules('pelican')!;
+
+  it('passes when alt = "Pelican Books"', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/title.xhtml',
+      content: penguinTitleVariant1().replace('alt="Penguin Random House"', 'alt="Pelican Books"'),
+    };
+    expect(validatePrhTitlePage(input([file], pelicanRules))).toEqual([]);
+  });
+
+  it('flags alt = "Penguin Random House" as wrong for Pelican', () => {
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/title.xhtml', content: penguinTitleVariant1() };
+    const issues = validatePrhTitlePage(input([file], pelicanRules));
+    expect(issues.find((i) => i.code === 'PRH-TITLE-PAGE-WRONG-LOGO-ALT')).toBeDefined();
+  });
+});
+
+describe('validatePrhTitlePage — imprints without a canonical title page', () => {
+  it('Vintage emits zero title-page issues regardless of EPUB content', () => {
+    const vintageRules = getImprintRules('vintage')!;
+    expect(validatePrhTitlePage(input([], vintageRules))).toEqual([]);
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/title.xhtml', content: penguinTitleVariant1() };
+    expect(validatePrhTitlePage(input([file], vintageRules))).toEqual([]);
+  });
+
+  it('Cornerstone Saga emits zero title-page issues regardless of EPUB content', () => {
+    const sagaRules = getImprintRules('cornerstone-saga')!;
+    expect(validatePrhTitlePage(input([], sagaRules))).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/title-page-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/title-page-validator.test.ts
@@ -136,6 +136,14 @@ describe('validatePrhTitlePage — Puffin image-only', () => {
     expect(issues.find((i) => i.code === 'PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO')).toBeUndefined();
     expect(issues.find((i) => i.code === 'PRH-TITLE-PAGE-WRONG-LOGO-ALT')).toBeUndefined();
   });
+
+  it('finds the image-only title page even when the filename is not title-like', () => {
+    // Real Puffin EPUBs use `half.xhtml`, `image-title.xhtml`, etc. as
+    // the title-page filename. The detector must accept any frontmatter
+    // file with <figure class="image_full"> — filename is not load-bearing.
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/half.xhtml', content: puffinImageOnlyTitlePage() };
+    expect(validatePrhTitlePage(input([file], puffinRules))).toEqual([]);
+  });
 });
 
 describe('validatePrhTitlePage — Pelican (imprint-specific alt)', () => {


### PR DESCRIPTION
## Summary

Adds two imprint-conditional validators for PRH UK boilerplate pages:

- **Brand-page validator** — finds `<body epub:type="frontmatter" id="brand_page">`, validates the `<figure>` class (`.brand_logo_solo` for most imprints, `.image_full` for Vintage) and the logo alt text against per-imprint rules.
- **Title-page validator** — finds `<section epub:type="titlepage">`, soft-fingerprints the 6 Penguin structural variants, validates `<figure class="imprint_logo">` presence + alt text. For Puffin's image-only path, expects `<figure class="image_full">` instead.

Both validators gate on the imprint registry (`imprintRules.brandPage` / `imprintRules.titlePage`) — imprints without a canonical page (#Merky has no brand page; Vintage + Cornerstone Saga have no title page; Cornerstone Saga has neither) emit zero issues.

## New PRH issue codes (7)

All detect-only, manual fix. Auto-injection lands in P5.

| Code | Severity | WCAG |
|---|---|---|
| PRH-BRAND-PAGE-MISSING | minor | — |
| PRH-BRAND-PAGE-WRONG-CLASS | minor | — |
| PRH-BRAND-PAGE-WRONG-LOGO-ALT | minor | 1.1.1 |
| PRH-TITLE-PAGE-MISSING | moderate | — |
| PRH-TITLE-PAGE-WRONG-STRUCTURE | minor | — |
| PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO | minor | — |
| PRH-TITLE-PAGE-WRONG-LOGO-ALT | minor | 1.1.1 |

## Per-imprint rules added

| Imprint | Brand page | Title page |
|---|---|---|
| Penguin | `.brand_logo_solo` / "Penguin Random House" | structured / "Penguin Random House" |
| Puffin | `.brand_logo_solo` / "Puffin Books" | image-only `.image_full` |
| Vintage | `.image_full` / "Vintage Books" | none |
| Pelican | `.brand_logo_solo` / "Pelican Books" | structured / "Pelican Books" |
| Ladybird | `.brand_logo_solo` / "Ladybird Books" | structured / "Ladybird Books" |
| #Merky | none | structured / "Penguin Random House" |
| Cornerstone Saga | none | none |

## Test plan

- [x] 182/182 PRH unit tests passing (25 new: 12 brand-page + 13 title-page; 7 registry assertions for the new fields)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke test: PRH Branding Guide EPUB still produces a sensible result (multi-imprint demo doc resolves to `unknown` imprint → these validators don't fire, as designed)
- [ ] Staging smoke test: a real Penguin EPUB doesn't false-positive on the title-page variant matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validator now checks brand pages and title pages for expected structure, figure classes, and logo alt text.
  * Imprint-specific rules added (Penguin, Pelican, Puffin, Vintage, Ladybird, Merky, Cornerstone Saga) to tailor validations.

* **Tests**
  * Added unit tests covering brand-page and title-page scenarios, including image-only and structured variants.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/363)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->