### PR TITLE
feat(prh): socials-page validator (P2/PR3)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -285,6 +285,46 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'Title-page imprint logo alt text must match the imprint expectation (most imprints: "Penguin Random House"; Pelican: "Pelican Books"; Ladybird: "Ladybird Books")',
   },
+
+  // ── Socials page (P2/PR3) ──────────────────────────────────────────────
+  // Imprint-conditional. Only Penguin / Vintage / Cornerstone Saga ship a
+  // canonical socials page. Puffin / Pelican / Ladybird / #Merky have
+  // `socials: null` in the imprint registry and the validator skips them.
+  'PRH-SOCIALS-PAGE-MISSING': {
+    code: 'PRH-SOCIALS-PAGE-MISSING',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'EPUB must include a socials / "Follow us" page in backmatter',
+  },
+  'PRH-SOCIALS-CHANNEL-MISSING': {
+    code: 'PRH-SOCIALS-CHANNEL-MISSING',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Socials page is missing one or more expected channels for the imprint',
+  },
+  'PRH-SOCIALS-CHANNEL-ORDER-WRONG': {
+    code: 'PRH-SOCIALS-CHANNEL-ORDER-WRONG',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Socials channels appear in a different order than the imprint specifies (Penguin: Twitter, Facebook, Instagram, YouTube, Pinterest, LinkedIn, TikTok)',
+  },
+  'PRH-SOCIALS-HANDLE-WRONG': {
+    code: 'PRH-SOCIALS-HANDLE-WRONG',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Socials page references a channel but with an unexpected handle (e.g. twitter.com/penguinbooks instead of twitter.com/penguinukbooks)',
+  },
+  'PRH-SOCIALS-STRAPLINE-MISSING': {
+    code: 'PRH-SOCIALS-STRAPLINE-MISSING',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Socials page must include the imprint strapline (Penguin: "Find out more…at Penguin.co.uk"; Vintage: "World-class writing. Beautiful design. Ideas that matter.")',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/wcag-issue-mapper.service.ts
+++ b/src/services/acr/wcag-issue-mapper.service.ts
@@ -91,6 +91,13 @@ export const RULE_TO_CRITERIA_MAP: Record<string, string[]> = {
   'PRH-TITLE-PAGE-MISSING-IMPRINT-LOGO': [],
   'PRH-TITLE-PAGE-WRONG-LOGO-ALT': ['1.1.1'],
 
+  // Socials page (P2/PR3) — all publisher-specific (no WCAG analogue).
+  'PRH-SOCIALS-PAGE-MISSING': [],
+  'PRH-SOCIALS-CHANNEL-MISSING': [],
+  'PRH-SOCIALS-CHANNEL-ORDER-WRONG': [],
+  'PRH-SOCIALS-HANDLE-WRONG': [],
+  'PRH-SOCIALS-STRAPLINE-MISSING': [],
+
   // ============= STANDARD ACE RULES =============
   // Images and Non-text Content
   'img-alt': ['1.1.1'],

--- a/src/services/epub/profiles/prh-uk/imprints/_types.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/_types.ts
@@ -136,6 +136,18 @@ export interface SocialChannel {
   id: 'twitter' | 'facebook' | 'instagram' | 'youtube' | 'pinterest' | 'linkedin' | 'tiktok' | 'newsletter';
   /** Substring that must appear in the socials page (case-insensitive, post-normalisation). */
   handle: string;
+  /**
+   * Optional context-aware matcher used when the bare `handle` is
+   * ambiguous across channels. Vintage is the motivating case — three
+   * of its four channels share the handle "@vintagebooks", so a plain
+   * `includes('@vintagebooks')` returns the same index for all three
+   * and silently bypasses the order check. When `detector` is set, the
+   * validator uses its match position for ordering/presence; `handle`
+   * is still surfaced in messages and suggestions as the canonical
+   * text the operator should display. The detector should be
+   * case-insensitive (the haystack is lowercased before matching).
+   */
+  detector?: RegExp;
 }
 
 /**
@@ -213,4 +225,14 @@ export interface ImprintRules {
    * Ladybird, #Merky).
    */
   socials: SocialsRules | null;
+  /**
+   * Optional secondary socials ruleset for imprints that ship a
+   * cut-down variant (Penguin's `follow_penguin_ya.xhtml` is the
+   * motivating case — YA editions list Instagram + YouTube + TikTok
+   * only, with TikTok pointing at `@houseofya`). When the validator
+   * detects the YA-variant filename it switches to these rules in
+   * place of the full set; otherwise undefined means the imprint
+   * has no YA variant.
+   */
+  socialsYa?: SocialsRules;
 }

--- a/src/services/epub/profiles/prh-uk/imprints/_types.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/_types.ts
@@ -121,6 +121,62 @@ export type TitlePageRules =
       logoAlt: string;
     };
 
+/**
+ * Per-channel needle for a socials page (P2/PR3).
+ *
+ * Each channel has a stable `id` (used to detect missing channels and
+ * to assert ordering) and a `handle` — a URL or @-handle fragment that
+ * MUST appear in the socials page content. The handle is matched as a
+ * lowercased substring after whitespace normalisation, so it tolerates
+ * markup variations like `<a href="...">@vintagebooks</a>` vs
+ * `Twitter: @vintagebooks` vs link wrapping.
+ */
+export interface SocialChannel {
+  /** Channel identifier — used for ordering and missing-channel diagnostics. */
+  id: 'twitter' | 'facebook' | 'instagram' | 'youtube' | 'pinterest' | 'linkedin' | 'tiktok' | 'newsletter';
+  /** Substring that must appear in the socials page (case-insensitive, post-normalisation). */
+  handle: string;
+}
+
+/**
+ * Socials-page rules per imprint (P2/PR3).
+ *
+ * Per Branding Guide §6, the "Follow us" / socials page is in
+ * `<body epub:type="backmatter">`. Only a handful of imprints ship
+ * one in the canonical template:
+ *
+ *   - Penguin → 7 channels in a prescribed order, plus a closing
+ *     strapline pointing at Penguin.co.uk.
+ *   - Vintage → 4 channels (Twitter / Instagram / TikTok / Facebook),
+ *     all under `@vintagebooks` except TikTok (`@vintageukbooks`),
+ *     plus the Vintage strapline.
+ *   - Cornerstone Saga → Facebook + Penny Street newsletter URL.
+ *   - Puffin / Pelican / Ladybird / #Merky → no socials page;
+ *     `socials: null` skips the validator entirely.
+ *
+ * Penguin's "YA cut-down" socials page (`follow_penguin_ya.xhtml`,
+ * Instagram + YouTube + TikTok @houseofya only) is treated as an
+ * alternate Penguin variant in the detector; the validator falls
+ * back to the full 7-channel ruleset when both variants are absent
+ * but doesn't false-positive on a conformant YA-only build.
+ */
+export interface SocialsRules {
+  /**
+   * Ordered list of expected channels. Order is enforced via
+   * `PRH-SOCIALS-CHANNEL-ORDER-WRONG`; presence is enforced via
+   * `PRH-SOCIALS-CHANNEL-MISSING`; handle correctness is enforced via
+   * `PRH-SOCIALS-HANDLE-WRONG`.
+   */
+  channels: SocialChannel[];
+  /**
+   * Optional verbatim strapline expected at the foot of the socials
+   * page. When set, `PRH-SOCIALS-STRAPLINE-MISSING` fires when it's
+   * absent. Match is case-insensitive substring after whitespace
+   * collapse.
+   */
+  strapline?: string;
+}
+
 export interface ImprintRules {
   /**
    * Stable identifier — must match a `PrhImprint` value. Used to look up
@@ -151,6 +207,10 @@ export interface ImprintRules {
    * title page (Vintage, Cornerstone Saga).
    */
   titlePage: TitlePageRules | null;
-  // Future fields land in P2/PR3:
-  //   socials: { channels: SocialChannel[]; strapline?: string } | null;
+  /**
+   * Socials-page expectations. `null` when the imprint has no
+   * dedicated socials page in the canonical template (Puffin, Pelican,
+   * Ladybird, #Merky).
+   */
+  socials: SocialsRules | null;
 }

--- a/src/services/epub/profiles/prh-uk/imprints/cornerstone-saga.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/cornerstone-saga.ts
@@ -19,4 +19,13 @@ export const CORNERSTONE_SAGA_RULES: ImprintRules = {
   // styling lives on the socials page and end-matter promo blocks.
   brandPage: null,
   titlePage: null,
+  socials: {
+    // Penny Street Saga has a slimmer socials page than the main
+    // imprints — a Facebook link plus the Penny Street newsletter URL.
+    // Order: Facebook first, newsletter second per the Branding Guide.
+    channels: [
+      { id: 'facebook', handle: 'facebook.com/welcometopennystreet' },
+      { id: 'newsletter', handle: 'penguin.co.uk/pennystreet' },
+    ],
+  },
 };

--- a/src/services/epub/profiles/prh-uk/imprints/ladybird.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/ladybird.ts
@@ -40,4 +40,6 @@ export const LADYBIRD_RULES: ImprintRules = {
     // <section epub:type="titlepage"> with imprint_logo.
     logoAlt: 'Ladybird Books',
   },
+  // Ladybird has no canonical socials page — classics ads only.
+  socials: null,
 };

--- a/src/services/epub/profiles/prh-uk/imprints/merky.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/merky.ts
@@ -24,4 +24,6 @@ export const MERKY_RULES: ImprintRules = {
     // marketing name (Branding Guide §6).
     logoAlt: 'Penguin Random House',
   },
+  // #Merky has no canonical socials page in the Branding Guide.
+  socials: null,
 };

--- a/src/services/epub/profiles/prh-uk/imprints/pelican.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/pelican.ts
@@ -24,4 +24,6 @@ export const PELICAN_RULES: ImprintRules = {
     // the parent group.
     logoAlt: 'Pelican Books',
   },
+  // Pelican has no canonical socials page — series list backmatter only.
+  socials: null,
 };

--- a/src/services/epub/profiles/prh-uk/imprints/penguin.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/penguin.ts
@@ -19,4 +19,22 @@ export const PENGUIN_RULES: ImprintRules = {
     // Logo alt is the parent-group name across all variants.
     logoAlt: 'Penguin Random House',
   },
+  socials: {
+    // Penguin full socials page (follow_penguin.xhtml). Order matters
+    // per Branding Guide §6 — Twitter first, TikTok last. The YA
+    // cut-down variant (follow_penguin_ya.xhtml) is a subset of these
+    // channels and is treated as conformant by the validator's
+    // missing-channel logic (it only flags channels declared here that
+    // don't appear in the page).
+    channels: [
+      { id: 'twitter', handle: 'twitter.com/penguinukbooks' },
+      { id: 'facebook', handle: 'facebook.com/penguinbooks' },
+      { id: 'instagram', handle: 'instagram.com/penguinukbooks' },
+      { id: 'youtube', handle: 'youtube.com/penguinbooks' },
+      { id: 'pinterest', handle: 'pinterest.com/penguinukbooks' },
+      { id: 'linkedin', handle: 'linkedin.com/company/penguin-random-house-uk' },
+      { id: 'tiktok', handle: 'tiktok.com/@penguinukbooks' },
+    ],
+    strapline: 'Find out more about the author and discover your next read at',
+  },
 };

--- a/src/services/epub/profiles/prh-uk/imprints/penguin.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/penguin.ts
@@ -21,11 +21,7 @@ export const PENGUIN_RULES: ImprintRules = {
   },
   socials: {
     // Penguin full socials page (follow_penguin.xhtml). Order matters
-    // per Branding Guide §6 — Twitter first, TikTok last. The YA
-    // cut-down variant (follow_penguin_ya.xhtml) is a subset of these
-    // channels and is treated as conformant by the validator's
-    // missing-channel logic (it only flags channels declared here that
-    // don't appear in the page).
+    // per Branding Guide §6 — Twitter first, TikTok last.
     channels: [
       { id: 'twitter', handle: 'twitter.com/penguinukbooks' },
       { id: 'facebook', handle: 'facebook.com/penguinbooks' },
@@ -36,5 +32,15 @@ export const PENGUIN_RULES: ImprintRules = {
       { id: 'tiktok', handle: 'tiktok.com/@penguinukbooks' },
     ],
     strapline: 'Find out more about the author and discover your next read at',
+  },
+  // Penguin YA cut-down socials page (follow_penguin_ya.xhtml). Per
+  // Branding Guide §6: Instagram + YouTube + TikTok only, with the
+  // TikTok handle pointing at @houseofya rather than @penguinukbooks.
+  socialsYa: {
+    channels: [
+      { id: 'instagram', handle: 'instagram.com/penguinukbooks' },
+      { id: 'youtube', handle: 'youtube.com/penguinbooks' },
+      { id: 'tiktok', handle: 'tiktok.com/@houseofya' },
+    ],
   },
 };

--- a/src/services/epub/profiles/prh-uk/imprints/puffin.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/puffin.ts
@@ -49,4 +49,8 @@ export const PUFFIN_RULES: ImprintRules = {
     // that `logoAlt` is absent here.
     imageOnly: true,
   },
+  // Puffin's branding guide doesn't ship a dedicated "Follow us" page;
+  // social mentions appear inline within end-matter ads (`puffin_ad.xhtml`)
+  // rather than on a separate backmatter section. Validator skips.
+  socials: null,
 };

--- a/src/services/epub/profiles/prh-uk/imprints/vintage.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/vintage.ts
@@ -34,14 +34,19 @@ export const VINTAGE_RULES: ImprintRules = {
   titlePage: null,
   socials: {
     // Vintage socials page (`vintage/vin_endpage_socials.xhtml`).
-    // Four channels — note tiktok is `@vintageukbooks` while the other
-    // three are `@vintagebooks`. Order follows the Branding Guide §6
-    // narrative (Twitter, Instagram, TikTok, Facebook).
+    // Three channels share the handle "@vintagebooks", so each
+    // SocialChannel carries a context-aware detector that requires
+    // the channel keyword near the handle (`/\btwitter[^@]{0,40}@vintagebooks/`).
+    // Without those detectors a plain `includes('@vintagebooks')`
+    // would return the same first-occurrence index for twitter,
+    // instagram, and facebook, silently bypassing the order check.
+    // The validator surfaces `handle` in suggestions; `detector` is
+    // only used for presence and ordering.
     channels: [
-      { id: 'twitter', handle: '@vintagebooks' },
-      { id: 'instagram', handle: '@vintagebooks' },
-      { id: 'tiktok', handle: '@vintageukbooks' },
-      { id: 'facebook', handle: '@vintagebooks' },
+      { id: 'twitter', handle: '@vintagebooks', detector: /\btwitter\b[^@]{0,40}@vintagebooks\b/i },
+      { id: 'instagram', handle: '@vintagebooks', detector: /\binstagram\b[^@]{0,40}@vintagebooks\b/i },
+      { id: 'tiktok', handle: '@vintageukbooks', detector: /\btiktok\b[^@]{0,40}@vintageukbooks\b/i },
+      { id: 'facebook', handle: '@vintagebooks', detector: /\bfacebook\b[^@]{0,40}@vintagebooks\b/i },
     ],
     strapline: 'World-class writing. Beautiful design. Ideas that matter.',
   },

--- a/src/services/epub/profiles/prh-uk/imprints/vintage.ts
+++ b/src/services/epub/profiles/prh-uk/imprints/vintage.ts
@@ -32,6 +32,19 @@ export const VINTAGE_RULES: ImprintRules = {
   // Vintage's bespoke template doesn't ship a separate titlepage section;
   // the copyright page carries the imprint header. Validator skips.
   titlePage: null,
+  socials: {
+    // Vintage socials page (`vintage/vin_endpage_socials.xhtml`).
+    // Four channels — note tiktok is `@vintageukbooks` while the other
+    // three are `@vintagebooks`. Order follows the Branding Guide §6
+    // narrative (Twitter, Instagram, TikTok, Facebook).
+    channels: [
+      { id: 'twitter', handle: '@vintagebooks' },
+      { id: 'instagram', handle: '@vintagebooks' },
+      { id: 'tiktok', handle: '@vintageukbooks' },
+      { id: 'facebook', handle: '@vintagebooks' },
+    ],
+    strapline: 'World-class writing. Beautiful design. Ideas that matter.',
+  },
   copyrightContentChecks: [
     // No TDM check — Vintage doesn't use it.
     // No EEA check — Vintage doesn't use it either.

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -19,6 +19,7 @@ import { validatePrhImages } from './validators/image-validator';
 import { validatePrhCopyrightContent } from './validators/copyright-content-validator';
 import { validatePrhBrandPage } from './validators/brand-page-validator';
 import { validatePrhTitlePage } from './validators/title-page-validator';
+import { validatePrhSocials } from './validators/socials-validator';
 import { getImprintRules } from './imprints';
 import type { PublisherProfile } from '../types';
 import type { PrhValidatorIssue, PrhXhtmlFile } from './validators/types';
@@ -85,6 +86,7 @@ export async function runPrhUkValidators(
         ...validatePrhCopyrightContent(imprintInput),
         ...validatePrhBrandPage(imprintInput),
         ...validatePrhTitlePage(imprintInput),
+        ...validatePrhSocials(imprintInput),
       );
     }
 

--- a/src/services/epub/profiles/prh-uk/validators/socials-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/socials-validator.ts
@@ -64,9 +64,17 @@ export function validatePrhSocials(input: SocialsInput): PrhValidatorIssue[] {
 
   // Imprint has no canonical socials page (Puffin / Pelican / Ladybird / Merky).
   if (!input.imprintRules.socials) return issues;
-  const rules = input.imprintRules.socials;
 
   const socialsFile = findSocialsXhtml(input.xhtmlFiles, input.imprintRules.imprint);
+  // Pick the YA ruleset when the YA-variant filename matches AND the
+  // imprint declares one (Penguin only). Otherwise use the full rules.
+  // The YA variant ships a smaller channel set per Branding Guide §6 —
+  // validating it against the full ruleset would emit a flurry of
+  // CHANNEL-MISSING issues for conformant YA builds.
+  const rules = socialsFile && isPenguinYaFile(socialsFile.path) && input.imprintRules.socialsYa
+    ? input.imprintRules.socialsYa
+    : input.imprintRules.socials;
+
   if (!socialsFile) {
     issues.push(buildIssue(
       'PRH-SOCIALS-PAGE-MISSING',
@@ -81,16 +89,18 @@ export function validatePrhSocials(input: SocialsInput): PrhValidatorIssue[] {
 
   // Track which channels are present (handle matches) — order check
   // only considers channels that are actually present, so a missing
-  // channel doesn't double-fire as out-of-order too.
-  const channelsPresent: SocialChannel[] = [];
+  // channel doesn't double-fire as out-of-order too. Each entry
+  // records the channel and its match index in the normalised text
+  // (so the order check uses the actual detector position rather than
+  // recomputing it later).
+  const channelsPresent: Array<{ channel: SocialChannel; index: number }> = [];
   for (const channel of rules.channels) {
-    const handle = channel.handle.toLowerCase();
+    const presentAt = findChannelIndex(channel, normalised);
     const prefix = CHANNEL_URL_PREFIX[channel.id].toLowerCase();
-    const handlePresent = normalised.includes(handle);
     const prefixPresent = prefix.length > 0 && normalised.includes(prefix);
 
-    if (handlePresent) {
-      channelsPresent.push(channel);
+    if (presentAt >= 0) {
+      channelsPresent.push({ channel, index: presentAt });
       continue;
     }
 
@@ -118,9 +128,12 @@ export function validatePrhSocials(input: SocialsInput): PrhValidatorIssue[] {
     ));
   }
 
-  // Order check — compare the FIRST occurrence of each present channel's
-  // url-prefix (or handle, for newsletter) against the declared order.
-  if (channelsPresent.length >= 2 && !isOrderCorrect(channelsPresent, normalised)) {
+  // Order check — the indices were captured per-channel above using
+  // the channel-specific detector (regex or handle substring), so the
+  // check is just "do these indices increase monotonically?". This
+  // gives correct behaviour for Vintage where three channels share
+  // the same plain handle but each has its own context-aware detector.
+  if (channelsPresent.length >= 2 && !isOrderMonotonic(channelsPresent.map((c) => c.index))) {
     issues.push(buildIssue(
       'PRH-SOCIALS-CHANNEL-ORDER-WRONG',
       `Socials channels appear in a different order than ${input.imprintRules.displayName} specifies (expected: ${rules.channels.map((c) => c.id).join(' → ')}).`,
@@ -249,26 +262,60 @@ function normaliseSocialsText(html: string): string {
 }
 
 /**
- * Verify that the channels appear in the page in the declared order.
- * Uses the FIRST occurrence of each channel's distinguishing marker
- * (url-prefix for social channels, the handle itself for newsletter)
- * and asserts the indices increase monotonically.
+ * Locate a channel's first match position in the normalised text.
+ * Preference order:
+ *   1. Channel-specific `detector` regex (used by Vintage to
+ *      disambiguate three @vintagebooks channels).
+ *   2. URL prefix (`twitter.com/` etc.) — used when the channel's
+ *      canonical handle is a URL.
+ *   3. Bare handle substring — used for newsletter or @-only handles
+ *      with no URL prefix.
+ *
+ * Returns -1 when none of these are present in the text.
+ *
+ * IMPORTANT: this function decides BOTH "is the channel present?" AND
+ * "where in the page is it?" — so a channel with a `detector` is
+ * considered missing whenever the detector regex fails, even if the
+ * bare handle string happens to appear elsewhere in the page (e.g. a
+ * stray @vintagebooks mention in body copy). That stricter rule is
+ * intentional: detectors exist precisely to disambiguate ambiguous
+ * handles.
  */
-function isOrderCorrect(channels: SocialChannel[], normalised: string): boolean {
-  const indices: number[] = [];
-  for (const c of channels) {
-    const prefix = CHANNEL_URL_PREFIX[c.id].toLowerCase();
-    const marker = prefix.length > 0 ? prefix : c.handle.toLowerCase();
-    const idx = normalised.indexOf(marker);
-    // All channels we're checking are .channelsPresent, so idx must be ≥0.
-    // Defensive guard kept in case the caller drifts.
-    if (idx < 0) return true;
-    indices.push(idx);
+function findChannelIndex(channel: SocialChannel, normalised: string): number {
+  if (channel.detector) {
+    const m = channel.detector.exec(normalised);
+    return m ? m.index : -1;
   }
+  const prefix = CHANNEL_URL_PREFIX[channel.id].toLowerCase();
+  if (prefix.length > 0) {
+    // For URL-shaped handles, look for the canonical handle first
+    // (so HANDLE-WRONG can still distinguish present-with-wrong-handle
+    // from genuinely-missing). The handle match takes precedence; the
+    // prefix-only check is the fallback decided by the caller.
+    const handleIdx = normalised.indexOf(channel.handle.toLowerCase());
+    if (handleIdx >= 0) return handleIdx;
+    return -1;
+  }
+  // Newsletter (no URL prefix) — handle IS the substring.
+  const idx = normalised.indexOf(channel.handle.toLowerCase());
+  return idx;
+}
+
+/** True when the indices are strictly increasing. Used for the channel-order check. */
+function isOrderMonotonic(indices: number[]): boolean {
   for (let i = 1; i < indices.length; i += 1) {
     if (indices[i] <= indices[i - 1]) return false;
   }
   return true;
+}
+
+/**
+ * Detects the Penguin YA-variant filename.
+ * `follow_penguin_ya.xhtml` is documented in Branding Guide §6 as the
+ * cut-down socials page with 3 channels instead of 7.
+ */
+function isPenguinYaFile(path: string): boolean {
+  return /(?:^|\/)follow_penguin_ya\.x?html?$/i.test(path);
 }
 
 function buildIssue(

--- a/src/services/epub/profiles/prh-uk/validators/socials-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/socials-validator.ts
@@ -1,0 +1,289 @@
+/**
+ * PRH UK socials-page validator (P2/PR3).
+ *
+ * Validates the imprint's "Follow us" / socials page — the backmatter
+ * section that lists the imprint's social handles. Per Branding Guide §6:
+ *
+ *   - Penguin → 7 channels in a fixed order, plus a closing strapline.
+ *     Files: `follow_penguin.xhtml` (full) / `follow_penguin_ya.xhtml` (YA).
+ *   - Vintage → 4 channels (Twitter / Instagram / TikTok / Facebook)
+ *     under `@vintagebooks` (TikTok is `@vintageukbooks`).
+ *     File: `vintage/vin_endpage_socials.xhtml`.
+ *   - Cornerstone Saga → Facebook + Penny Street newsletter URL.
+ *     File: `Cornerstone-saga/saga_socials.xhtml`.
+ *   - Puffin / Pelican / Ladybird / #Merky → no socials page. The
+ *     imprint registry sets `socials: null` and the orchestrator
+ *     short-circuits the validator entirely.
+ *
+ * Issue codes emitted:
+ *   - PRH-SOCIALS-PAGE-MISSING          — no socials page found
+ *   - PRH-SOCIALS-CHANNEL-MISSING       — declared channel handle not in page
+ *   - PRH-SOCIALS-CHANNEL-ORDER-WRONG   — channels present but out of order
+ *   - PRH-SOCIALS-HANDLE-WRONG          — channel referenced with wrong handle
+ *   - PRH-SOCIALS-STRAPLINE-MISSING     — declared strapline absent
+ *
+ * Detection strategy: locate the socials XHTML, then walk the imprint's
+ * channel list checking (1) presence of the canonical handle substring,
+ * (2) order of the FIRST occurrence of each channel's URL prefix
+ * (twitter.com / facebook.com / etc.) against the declared order, and
+ * (3) wrong-handle — when the channel's URL prefix appears but with a
+ * different account name than the imprint specifies (only flagged when
+ * MISSING didn't already fire for the same channel).
+ *
+ * Channels NOT in the imprint registry are intentionally ignored — a
+ * PRH EPUB that adds a Threads handle to the bottom of the Penguin
+ * socials page doesn't get flagged. Detection-only means we don't drive
+ * removal here.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { ImprintRules, SocialChannel } from '../imprints/_types';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+interface SocialsInput extends PrhPerXhtmlInput {
+  imprintRules: ImprintRules;
+}
+
+/** URL prefix used to detect a channel's mention regardless of the
+ *  actual handle (used for ordering + wrong-handle diagnostics). */
+const CHANNEL_URL_PREFIX: Record<SocialChannel['id'], string> = {
+  twitter: 'twitter.com/',
+  facebook: 'facebook.com/',
+  instagram: 'instagram.com/',
+  youtube: 'youtube.com/',
+  pinterest: 'pinterest.com/',
+  linkedin: 'linkedin.com/',
+  tiktok: 'tiktok.com/',
+  // Newsletter is the odd-one-out — no canonical url-prefix; the handle
+  // IS the substring. Detection falls back to the handle field.
+  newsletter: '',
+};
+
+export function validatePrhSocials(input: SocialsInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  // Imprint has no canonical socials page (Puffin / Pelican / Ladybird / Merky).
+  if (!input.imprintRules.socials) return issues;
+  const rules = input.imprintRules.socials;
+
+  const socialsFile = findSocialsXhtml(input.xhtmlFiles, input.imprintRules.imprint);
+  if (!socialsFile) {
+    issues.push(buildIssue(
+      'PRH-SOCIALS-PAGE-MISSING',
+      `Socials page not found. Expected a <body epub:type="backmatter"> file referencing the ${input.imprintRules.displayName} social handles.`,
+      `Add the ${input.imprintRules.displayName} socials page per Branding Guide §6 — backmatter file listing ${rules.channels.map((c) => c.id).join(', ')}.`,
+      'EPUB',
+    ));
+    return issues;
+  }
+
+  const normalised = normaliseSocialsText(socialsFile.content);
+
+  // Track which channels are present (handle matches) — order check
+  // only considers channels that are actually present, so a missing
+  // channel doesn't double-fire as out-of-order too.
+  const channelsPresent: SocialChannel[] = [];
+  for (const channel of rules.channels) {
+    const handle = channel.handle.toLowerCase();
+    const prefix = CHANNEL_URL_PREFIX[channel.id].toLowerCase();
+    const handlePresent = normalised.includes(handle);
+    const prefixPresent = prefix.length > 0 && normalised.includes(prefix);
+
+    if (handlePresent) {
+      channelsPresent.push(channel);
+      continue;
+    }
+
+    if (prefixPresent) {
+      // Channel referenced but with the wrong handle (e.g.
+      // twitter.com/penguinbooks instead of twitter.com/penguinukbooks).
+      // Fire HANDLE-WRONG once per channel — the operator can correct
+      // it without separately being told the canonical handle was
+      // "missing" too.
+      issues.push(buildIssue(
+        'PRH-SOCIALS-HANDLE-WRONG',
+        `${channel.id} channel is referenced on the socials page but with an unexpected handle. ${input.imprintRules.displayName} expects "${channel.handle}".`,
+        `Update the ${channel.id} link/handle to "${channel.handle}".`,
+        socialsFile.path,
+      ));
+      continue;
+    }
+
+    // Channel entirely absent.
+    issues.push(buildIssue(
+      'PRH-SOCIALS-CHANNEL-MISSING',
+      `${channel.id} channel is missing from the socials page. ${input.imprintRules.displayName} expects "${channel.handle}".`,
+      `Add the ${channel.id} entry "${channel.handle}" to the socials page in the canonical order.`,
+      socialsFile.path,
+    ));
+  }
+
+  // Order check — compare the FIRST occurrence of each present channel's
+  // url-prefix (or handle, for newsletter) against the declared order.
+  if (channelsPresent.length >= 2 && !isOrderCorrect(channelsPresent, normalised)) {
+    issues.push(buildIssue(
+      'PRH-SOCIALS-CHANNEL-ORDER-WRONG',
+      `Socials channels appear in a different order than ${input.imprintRules.displayName} specifies (expected: ${rules.channels.map((c) => c.id).join(' → ')}).`,
+      `Reorder the channels on the socials page to: ${rules.channels.map((c) => c.id).join(' → ')}.`,
+      socialsFile.path,
+    ));
+  }
+
+  if (rules.strapline) {
+    const straplineNorm = rules.strapline.toLowerCase().replace(/\s+/g, ' ').trim();
+    if (!normalised.includes(straplineNorm)) {
+      issues.push(buildIssue(
+        'PRH-SOCIALS-STRAPLINE-MISSING',
+        `Socials page is missing the ${input.imprintRules.displayName} strapline: "${rules.strapline}".`,
+        `Add the strapline near the foot of the socials page: "${rules.strapline}".`,
+        socialsFile.path,
+      ));
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+interface XhtmlFile {
+  path: string;
+  content: string;
+}
+
+/**
+ * Locate the socials XHTML. Preference order:
+ *   1. <body epub:type="backmatter"> with a known socials filename hint
+ *      (follow_penguin, vin_endpage_socials, saga_socials, etc.).
+ *   2. <body epub:type="backmatter"> that contains at least one of the
+ *      canonical channel URL prefixes (twitter.com / facebook.com /
+ *      instagram.com etc.) — fingerprint match.
+ *   3. Filename heuristic alone (`*socials*.xhtml`, `follow_*.xhtml`).
+ *
+ * Imprint-specific filename hints help disambiguate when multiple
+ * backmatter files contain channel URLs (e.g. an author bio that links
+ * to twitter shouldn't count as the "socials page").
+ */
+function findSocialsXhtml(
+  files: PrhPerXhtmlInput['xhtmlFiles'],
+  imprintId: string,
+): XhtmlFile | null {
+  const filenameHint = SOCIALS_FILENAME_HINT[imprintId];
+
+  if (filenameHint) {
+    for (const f of files) {
+      if (filenameHint.test(f.path) && isBackmatter(f.content)) {
+        return f;
+      }
+    }
+  }
+
+  // Fingerprint match: backmatter file with channel URL prefixes.
+  for (const f of files) {
+    if (!isBackmatter(f.content)) continue;
+    const text = f.content.toLowerCase();
+    let matched = 0;
+    for (const prefix of Object.values(CHANNEL_URL_PREFIX)) {
+      if (prefix.length > 0 && text.includes(prefix)) matched += 1;
+    }
+    // Two or more channel-URL prefixes makes this likely a socials
+    // page rather than e.g. an author bio with a single twitter link.
+    if (matched >= 2) return f;
+  }
+
+  // Filename fallback: anything that looks like a socials page.
+  for (const f of files) {
+    if (/(?:^|\/)(?:follow[_-][\w-]+|[\w-]*socials[\w-]*)\.x?html?$/i.test(f.path)) {
+      return f;
+    }
+  }
+
+  return null;
+}
+
+/** Per-imprint filename hint for the socials page. */
+const SOCIALS_FILENAME_HINT: Record<string, RegExp> = {
+  penguin: /(?:^|\/)follow_penguin(?:_ya)?\.x?html?$/i,
+  vintage: /(?:^|\/)(?:vin_endpage_socials|vintage[_-]?socials)\.x?html?$/i,
+  'cornerstone-saga': /(?:^|\/)(?:saga[_-]?socials|pennystreet[_-]?socials)\.x?html?$/i,
+};
+
+function isBackmatter(html: string): boolean {
+  return /<body\b[^>]*\bepub:type\s*=\s*["'][^"']*\bbackmatter\b/i.test(html);
+}
+
+/**
+ * Lowercase + whitespace-collapse normalised view of the socials page.
+ * Differs from the copyright-page normaliser in one critical way: we
+ * pull `href` URL values out of `<a>` tags BEFORE stripping the tags.
+ * Without that step, a markup-correct socials page like
+ *   <a href="https://twitter.com/penguinukbooks">Twitter @penguinukbooks</a>
+ * would lose the URL during tag-strip and silently fail the
+ * channel-handle check (the visible text typically reads "Twitter"
+ * rather than the full URL).
+ *
+ * Strategy: collect every `href="…"` value, append them to the visible
+ * text with separating whitespace, then run the standard
+ * tag-strip / whitespace-collapse / lowercase pipeline.
+ */
+function normaliseSocialsText(html: string): string {
+  // Inline-substitute each <a href="X">Y</a> into ` X Y ` so the URL
+  // appears in document order (right where the link sat). Appending
+  // hrefs at the end of the string would break the channel-order
+  // check, because a URL that originally sat at position N would end
+  // up at position end-of-document.
+  const hrefInlined = html.replace(
+    /<a\b[^>]*\bhref\s*=\s*["']([^"']*)["'][^>]*>/gi,
+    ' $1 ',
+  );
+  return hrefInlined
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&#x?[0-9a-f]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Verify that the channels appear in the page in the declared order.
+ * Uses the FIRST occurrence of each channel's distinguishing marker
+ * (url-prefix for social channels, the handle itself for newsletter)
+ * and asserts the indices increase monotonically.
+ */
+function isOrderCorrect(channels: SocialChannel[], normalised: string): boolean {
+  const indices: number[] = [];
+  for (const c of channels) {
+    const prefix = CHANNEL_URL_PREFIX[c.id].toLowerCase();
+    const marker = prefix.length > 0 ? prefix : c.handle.toLowerCase();
+    const idx = normalised.indexOf(marker);
+    // All channels we're checking are .channelsPresent, so idx must be ≥0.
+    // Defensive guard kept in case the caller drifts.
+    if (idx < 0) return true;
+    indices.push(idx);
+  }
+  for (let i = 1; i < indices.length; i += 1) {
+    if (indices[i] <= indices[i - 1]) return false;
+  }
+  return true;
+}
+
+function buildIssue(
+  code: keyof typeof PRH_ISSUE_CODES,
+  message: string,
+  suggestion: string,
+  location: string,
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${message}`,
+    suggestion,
+    location,
+  };
+}

--- a/tests/unit/services/epub/profiles/prh-uk/imprints/registry.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/imprints/registry.test.ts
@@ -140,4 +140,43 @@ describe('getImprintRules', () => {
     expect(getImprintRules('vintage')?.titlePage).toBeNull();
     expect(getImprintRules('cornerstone-saga')?.titlePage).toBeNull();
   });
+
+  // ── Socials rules (P2/PR3) ────────────────────────────────────────────
+  it('Penguin defines the full 7-channel socials list in canonical order', () => {
+    const socials = getImprintRules('penguin')?.socials;
+    expect(socials).not.toBeNull();
+    const ids = socials?.channels.map((c) => c.id) ?? [];
+    expect(ids).toEqual([
+      'twitter', 'facebook', 'instagram', 'youtube', 'pinterest', 'linkedin', 'tiktok',
+    ]);
+  });
+
+  it('Penguin TikTok handle is @penguinukbooks (not @penguinbooks)', () => {
+    const socials = getImprintRules('penguin')?.socials;
+    const tiktok = socials?.channels.find((c) => c.id === 'tiktok');
+    expect(tiktok?.handle).toBe('tiktok.com/@penguinukbooks');
+  });
+
+  it('Vintage TikTok handle differs from the rest (@vintageukbooks)', () => {
+    const socials = getImprintRules('vintage')?.socials;
+    const tiktok = socials?.channels.find((c) => c.id === 'tiktok');
+    expect(tiktok?.handle).toBe('@vintageukbooks');
+  });
+
+  it('Vintage strapline is the Branding Guide §6 verbatim phrase', () => {
+    expect(getImprintRules('vintage')?.socials?.strapline)
+      .toBe('World-class writing. Beautiful design. Ideas that matter.');
+  });
+
+  it('Cornerstone Saga has a slim 2-channel socials list (Facebook + Newsletter)', () => {
+    const ids = getImprintRules('cornerstone-saga')?.socials?.channels.map((c) => c.id) ?? [];
+    expect(ids).toEqual(['facebook', 'newsletter']);
+  });
+
+  it('Puffin / Pelican / Ladybird / #Merky have no socials page', () => {
+    expect(getImprintRules('puffin')?.socials).toBeNull();
+    expect(getImprintRules('pelican')?.socials).toBeNull();
+    expect(getImprintRules('ladybird')?.socials).toBeNull();
+    expect(getImprintRules('merky')?.socials).toBeNull();
+  });
 });

--- a/tests/unit/services/epub/profiles/prh-uk/validators/socials-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/socials-validator.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhSocials } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/socials-validator';
+import { getImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+import type { ImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints/_types';
+
+/** Compliant Penguin socials page — 7 channels in canonical order + strapline. */
+function compliantPenguinSocials(): string {
+  return `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Follow Penguin</title></head>
+<body epub:type="backmatter">
+  <h2>Follow Penguin</h2>
+  <ul>
+    <li><a href="https://twitter.com/penguinukbooks">Twitter @penguinukbooks</a></li>
+    <li><a href="https://facebook.com/penguinbooks">Facebook</a></li>
+    <li><a href="https://instagram.com/penguinukbooks">Instagram</a></li>
+    <li><a href="https://youtube.com/penguinbooks">YouTube</a></li>
+    <li><a href="https://pinterest.com/penguinukbooks">Pinterest</a></li>
+    <li><a href="https://linkedin.com/company/penguin-random-house-uk">LinkedIn</a></li>
+    <li><a href="https://tiktok.com/@penguinukbooks">TikTok</a></li>
+  </ul>
+  <p>Find out more about the author and discover your next read at Penguin.co.uk.</p>
+</body>
+</html>`;
+}
+
+function compliantVintageSocials(): string {
+  return `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Follow Vintage</title></head>
+<body epub:type="backmatter">
+  <h2>Follow Vintage</h2>
+  <p>Twitter @vintagebooks</p>
+  <p>Instagram @vintagebooks</p>
+  <p>TikTok @vintageukbooks</p>
+  <p>Facebook @vintagebooks</p>
+  <p>World-class writing. Beautiful design. Ideas that matter.</p>
+</body>
+</html>`;
+}
+
+function compliantCornerstoneSagaSocials(): string {
+  return `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Saga Socials</title></head>
+<body epub:type="backmatter">
+  <p><a href="https://www.facebook.com/welcometopennystreet/">Welcome to Penny Street on Facebook</a></p>
+  <p>Sign up for the newsletter: www.penguin.co.uk/pennystreet</p>
+</body>
+</html>`;
+}
+
+function input(files: PrhXhtmlFile[], imprintRules: ImprintRules) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test Book',
+    xhtmlFiles: files,
+    imprintRules,
+  };
+}
+
+describe('validatePrhSocials — Penguin (full 7-channel page)', () => {
+  const penguinRules = getImprintRules('penguin')!;
+
+  it('emits zero issues for a fully compliant Penguin socials page', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/follow_penguin.xhtml',
+      content: compliantPenguinSocials(),
+    };
+    expect(validatePrhSocials(input([file], penguinRules))).toEqual([]);
+  });
+
+  it('emits PRH-SOCIALS-PAGE-MISSING when no socials page exists', () => {
+    const issues = validatePrhSocials(input([], penguinRules));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-SOCIALS-PAGE-MISSING');
+  });
+
+  it('emits PRH-SOCIALS-CHANNEL-MISSING when TikTok is absent', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/follow_penguin.xhtml',
+      content: compliantPenguinSocials().replace(/.*tiktok.*\n/, ''),
+    };
+    const issues = validatePrhSocials(input([file], penguinRules));
+    const missing = issues.find((i) => i.code === 'PRH-SOCIALS-CHANNEL-MISSING');
+    expect(missing).toBeDefined();
+    expect(missing?.message).toMatch(/tiktok/i);
+  });
+
+  it('emits PRH-SOCIALS-HANDLE-WRONG when Twitter points at the wrong account', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/follow_penguin.xhtml',
+      // twitter.com URL prefix is present but with the wrong handle:
+      // a HANDLE-WRONG should fire, NOT a CHANNEL-MISSING.
+      content: compliantPenguinSocials().replace('twitter.com/penguinukbooks', 'twitter.com/penguinbooks'),
+    };
+    const issues = validatePrhSocials(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-SOCIALS-HANDLE-WRONG')).toBeDefined();
+    // And NOT a duplicate CHANNEL-MISSING for the same channel.
+    const missingForTwitter = issues.find(
+      (i) => i.code === 'PRH-SOCIALS-CHANNEL-MISSING' && /twitter/i.test(i.message),
+    );
+    expect(missingForTwitter).toBeUndefined();
+  });
+
+  it('emits PRH-SOCIALS-CHANNEL-ORDER-WRONG when LinkedIn and TikTok swap positions', () => {
+    const swapped = compliantPenguinSocials()
+      .replace(
+        /<li><a href="https:\/\/linkedin\.com[^"]*">LinkedIn<\/a><\/li>\s*<li><a href="https:\/\/tiktok\.com[^"]*">TikTok<\/a><\/li>/,
+        '<li><a href="https://tiktok.com/@penguinukbooks">TikTok</a></li><li><a href="https://linkedin.com/company/penguin-random-house-uk">LinkedIn</a></li>',
+      );
+    const file: PrhXhtmlFile = { path: 'EPUB/xhtml/follow_penguin.xhtml', content: swapped };
+    const issues = validatePrhSocials(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-SOCIALS-CHANNEL-ORDER-WRONG')).toBeDefined();
+  });
+
+  it('emits PRH-SOCIALS-STRAPLINE-MISSING when the closing strapline is dropped', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/follow_penguin.xhtml',
+      content: compliantPenguinSocials().replace(/Find out more about the author[^<]*/, ''),
+    };
+    const issues = validatePrhSocials(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-SOCIALS-STRAPLINE-MISSING')).toBeDefined();
+  });
+
+  it('finds the socials page via fingerprint when filename is unconventional', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/end_matter_03.xhtml',
+      content: compliantPenguinSocials(),
+    };
+    expect(validatePrhSocials(input([file], penguinRules))).toEqual([]);
+  });
+});
+
+describe('validatePrhSocials — Vintage (4 channels + bespoke strapline)', () => {
+  const vintageRules = getImprintRules('vintage')!;
+
+  it('emits zero issues for a fully compliant Vintage socials page', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/vintage/vin_endpage_socials.xhtml',
+      content: compliantVintageSocials(),
+    };
+    expect(validatePrhSocials(input([file], vintageRules))).toEqual([]);
+  });
+
+  it('emits PRH-SOCIALS-STRAPLINE-MISSING when the Vintage strapline is dropped', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/vintage/vin_endpage_socials.xhtml',
+      content: compliantVintageSocials().replace(/World-class writing[^<]*/, ''),
+    };
+    const issues = validatePrhSocials(input([file], vintageRules));
+    expect(issues.find((i) => i.code === 'PRH-SOCIALS-STRAPLINE-MISSING')).toBeDefined();
+  });
+
+  it('does not flag Twitter as having the wrong handle when @vintagebooks is present', () => {
+    // Vintage's "handle" is just `@vintagebooks`, not a URL — the
+    // validator should treat the handle string as present even though
+    // no `twitter.com/vintagebooks` URL exists in the page.
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/vintage/vin_endpage_socials.xhtml',
+      content: compliantVintageSocials(),
+    };
+    const issues = validatePrhSocials(input([file], vintageRules));
+    expect(issues.find((i) => i.code === 'PRH-SOCIALS-HANDLE-WRONG')).toBeUndefined();
+    expect(issues.find((i) => i.code === 'PRH-SOCIALS-CHANNEL-MISSING')).toBeUndefined();
+  });
+});
+
+describe('validatePrhSocials — Cornerstone Saga (newsletter + Facebook)', () => {
+  const sagaRules = getImprintRules('cornerstone-saga')!;
+
+  it('emits zero issues for a compliant Saga socials page', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/Cornerstone-saga/saga_socials.xhtml',
+      content: compliantCornerstoneSagaSocials(),
+    };
+    expect(validatePrhSocials(input([file], sagaRules))).toEqual([]);
+  });
+
+  it('emits PRH-SOCIALS-CHANNEL-MISSING when the newsletter URL is missing', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/Cornerstone-saga/saga_socials.xhtml',
+      content: compliantCornerstoneSagaSocials().replace('penguin.co.uk/pennystreet', ''),
+    };
+    const issues = validatePrhSocials(input([file], sagaRules));
+    const missing = issues.find((i) => i.code === 'PRH-SOCIALS-CHANNEL-MISSING');
+    expect(missing).toBeDefined();
+    expect(missing?.message).toMatch(/newsletter/i);
+  });
+});
+
+describe('validatePrhSocials — imprints without a canonical socials page', () => {
+  it('Puffin emits zero socials issues regardless of EPUB content', () => {
+    const puffinRules = getImprintRules('puffin')!;
+    expect(validatePrhSocials(input([], puffinRules))).toEqual([]);
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/follow_penguin.xhtml',
+      content: compliantPenguinSocials(),
+    };
+    expect(validatePrhSocials(input([file], puffinRules))).toEqual([]);
+  });
+
+  it('Pelican, Ladybird, and #Merky emit zero socials issues', () => {
+    for (const imp of ['pelican', 'ladybird', 'merky'] as const) {
+      const rules = getImprintRules(imp)!;
+      expect(validatePrhSocials(input([], rules))).toEqual([]);
+    }
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/socials-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/socials-validator.test.ts
@@ -191,6 +191,108 @@ describe('validatePrhSocials — Cornerstone Saga (newsletter + Facebook)', () =
   });
 });
 
+describe('validatePrhSocials — Vintage ambiguous handle regression', () => {
+  const vintageRules = getImprintRules('vintage')!;
+
+  it('flags order error when twitter and instagram swap positions (detector regression)', () => {
+    // Three Vintage channels share the bare handle "@vintagebooks";
+    // the order check must rely on per-channel detectors, not on
+    // raw indexOf. Swapping twitter and instagram blocks should fire
+    // CHANNEL-ORDER-WRONG even though "@vintagebooks" first occurs
+    // at the same position regardless of which line is first.
+    const swapped = `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Follow Vintage</title></head>
+<body epub:type="backmatter">
+  <p>Instagram @vintagebooks</p>
+  <p>Twitter @vintagebooks</p>
+  <p>TikTok @vintageukbooks</p>
+  <p>Facebook @vintagebooks</p>
+  <p>World-class writing. Beautiful design. Ideas that matter.</p>
+</body>
+</html>`;
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/vintage/vin_endpage_socials.xhtml',
+      content: swapped,
+    };
+    const issues = validatePrhSocials(input([file], vintageRules));
+    expect(issues.find((i) => i.code === 'PRH-SOCIALS-CHANNEL-ORDER-WRONG')).toBeDefined();
+  });
+
+  it('reports twitter as missing when only the bare @vintagebooks appears with no "Twitter" keyword nearby', () => {
+    // The handle string is shared across three channels; without the
+    // channel keyword the detector should not match → twitter shows
+    // up as MISSING rather than silently passing on the shared handle.
+    const noTwitterKeyword = `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<body epub:type="backmatter">
+  <p>Instagram @vintagebooks</p>
+  <p>TikTok @vintageukbooks</p>
+  <p>Facebook @vintagebooks</p>
+  <p>World-class writing. Beautiful design. Ideas that matter.</p>
+</body>
+</html>`;
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/vintage/vin_endpage_socials.xhtml',
+      content: noTwitterKeyword,
+    };
+    const issues = validatePrhSocials(input([file], vintageRules));
+    const missingTwitter = issues.find(
+      (i) => i.code === 'PRH-SOCIALS-CHANNEL-MISSING' && /twitter/i.test(i.message),
+    );
+    expect(missingTwitter).toBeDefined();
+  });
+});
+
+describe('validatePrhSocials — Penguin YA cut-down variant', () => {
+  const penguinRules = getImprintRules('penguin')!;
+
+  function compliantPenguinYaSocials(): string {
+    return `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<body epub:type="backmatter">
+  <h2>Follow Penguin YA</h2>
+  <ul>
+    <li><a href="https://instagram.com/penguinukbooks">Instagram</a></li>
+    <li><a href="https://youtube.com/penguinbooks">YouTube</a></li>
+    <li><a href="https://tiktok.com/@houseofya">TikTok</a></li>
+  </ul>
+</body>
+</html>`;
+  }
+
+  it('emits zero issues for a compliant Penguin YA page (Instagram + YouTube + TikTok @houseofya)', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/follow_penguin_ya.xhtml',
+      content: compliantPenguinYaSocials(),
+    };
+    expect(validatePrhSocials(input([file], penguinRules))).toEqual([]);
+  });
+
+  it('does NOT flag the missing 4 channels that the full Penguin page requires (Twitter, Facebook, Pinterest, LinkedIn)', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/follow_penguin_ya.xhtml',
+      content: compliantPenguinYaSocials(),
+    };
+    const issues = validatePrhSocials(input([file], penguinRules));
+    for (const channelId of ['twitter', 'facebook', 'pinterest', 'linkedin']) {
+      const missing = issues.find(
+        (i) => i.code === 'PRH-SOCIALS-CHANNEL-MISSING' && i.message.toLowerCase().includes(channelId),
+      );
+      expect(missing, `${channelId} should not be flagged on the YA variant`).toBeUndefined();
+    }
+  });
+
+  it('still flags YA-page issues if the TikTok handle uses the full-Penguin account (@penguinukbooks)', () => {
+    const file: PrhXhtmlFile = {
+      path: 'EPUB/xhtml/follow_penguin_ya.xhtml',
+      content: compliantPenguinYaSocials().replace('tiktok.com/@houseofya', 'tiktok.com/@penguinukbooks'),
+    };
+    const issues = validatePrhSocials(input([file], penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-SOCIALS-HANDLE-WRONG')).toBeDefined();
+  });
+});
+
 describe('validatePrhSocials — imprints without a canonical socials page', () => {
   it('Puffin emits zero socials issues regardless of EPUB content', () => {
     const puffinRules = getImprintRules('puffin')!;


### PR DESCRIPTION
## Summary

Adds an imprint-conditional socials-page validator for the PRH UK "Follow us" backmatter page. Validates four concerns: page presence, channel coverage, channel order, and the imprint strapline.

## Per-imprint rules

| Imprint | Channels | Strapline |
|---|---|---|
| Penguin | 7 — Twitter → Facebook → Instagram → YouTube → Pinterest → LinkedIn → TikTok | "Find out more about the author and discover your next read at…" |
| Vintage | 4 — Twitter, Instagram, TikTok, Facebook (TikTok = @vintageukbooks; others = @vintagebooks) | "World-class writing. Beautiful design. Ideas that matter." |
| Cornerstone Saga | 2 — Facebook + Penny Street newsletter URL | — |
| Puffin / Pelican / Ladybird / #Merky | none (no canonical socials page in Branding Guide) | — |

## New PRH issue codes (5)

All detect-only, manual fix. Auto-injection lands in P5.

| Code | Severity | WCAG |
|---|---|---|
| PRH-SOCIALS-PAGE-MISSING | minor | — |
| PRH-SOCIALS-CHANNEL-MISSING | minor | — |
| PRH-SOCIALS-CHANNEL-ORDER-WRONG | minor | — |
| PRH-SOCIALS-HANDLE-WRONG | minor | — |
| PRH-SOCIALS-STRAPLINE-MISSING | minor | — |

## Design notes

- **href inlining**: the normaliser substitutes `<a href="X">` URLs in-place so they appear in document order before tag-strip. Appending hrefs at the end would silently break the order check.
- **HANDLE-WRONG vs CHANNEL-MISSING**: when a channel's URL prefix (e.g. `twitter.com/`) is present but with a non-canonical account, the validator fires HANDLE-WRONG only — the operator gets one actionable issue per channel, not two.
- **Penguin YA cut-down**: the YA-only variant (Instagram + YouTube + TikTok @houseofya) is treated as a subset of the full rules — only the channels declared as required fire missing-channel issues, so a conformant YA build doesn't false-positive.

## Test plan

- [x] 203/203 PRH unit tests passing (14 new socials validator tests + 6 registry assertions)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke test against a real Penguin EPUB
- [ ] Staging smoke test: PRH Branding Guide (multi-imprint demo) still resolves to `unknown` and skips these validators

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added socials-page validation for PRH UK imprints: detects missing socials page, missing channels, wrong handles, incorrect channel order, and missing straplines.
  * Supports Twitter, Facebook, Instagram, YouTube, Pinterest, LinkedIn, TikTok and newsletter; imprint-specific rules and YA variants applied.

* **Tests**
  * Comprehensive tests covering imprint rules, validator behaviors, ambiguous-handle detection, and various compliant/failing scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/367)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->