### PR TITLE
feat(prh): content-order validator (P2/PR4) — closes P2

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -325,6 +325,46 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'Socials page must include the imprint strapline (Penguin: "Find out more…at Penguin.co.uk"; Vintage: "World-class writing. Beautiful design. Ideas that matter.")',
   },
+
+  // ── Content order (P2/PR4) ─────────────────────────────────────────────
+  // Walks the spine and asserts PRH's mandated reading order. All
+  // detect-only (spine reordering is risky enough to require operator
+  // review). Imprint-gated like the other P2 validators.
+  'PRH-ORDER-COVER-NOT-FIRST': {
+    code: 'PRH-ORDER-COVER-NOT-FIRST',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Cover spine entry must be the first item in <spine>',
+  },
+  'PRH-ORDER-MISSING-BRAND-PAGE': {
+    code: 'PRH-ORDER-MISSING-BRAND-PAGE',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Brand page must appear in the spine — required by PRH UK mandatory boilerplate (Branding Guide §7) for imprints that ship one',
+  },
+  'PRH-ORDER-FOOTNOTES-NOT-LAST': {
+    code: 'PRH-ORDER-FOOTNOTES-NOT-LAST',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Footnotes file must be the last entry in the spine (separate from the spine-flag rule PRH-SPINE-FOOTNOTES-LAST — this one flags ORDERING, not linear="no")',
+  },
+  'PRH-ORDER-COPYRIGHT-WRONG-POSITION': {
+    code: 'PRH-ORDER-COPYRIGHT-WRONG-POSITION',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Copyright page must appear in the frontmatter portion of the spine (PRH treats copyright as frontmatter, not backmatter)',
+  },
+  'PRH-ORDER-MISSING-ABOUT-AUTHOR': {
+    code: 'PRH-ORDER-MISSING-ABOUT-AUTHOR',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'EPUB is missing an About-the-Author section — required in every PRH reflow EPUB (Style Guide §6.6)',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/wcag-issue-mapper.service.ts
+++ b/src/services/acr/wcag-issue-mapper.service.ts
@@ -98,6 +98,13 @@ export const RULE_TO_CRITERIA_MAP: Record<string, string[]> = {
   'PRH-SOCIALS-HANDLE-WRONG': [],
   'PRH-SOCIALS-STRAPLINE-MISSING': [],
 
+  // Content order (P2/PR4) — all publisher-specific (no WCAG analogue).
+  'PRH-ORDER-COVER-NOT-FIRST': [],
+  'PRH-ORDER-MISSING-BRAND-PAGE': [],
+  'PRH-ORDER-FOOTNOTES-NOT-LAST': [],
+  'PRH-ORDER-COPYRIGHT-WRONG-POSITION': [],
+  'PRH-ORDER-MISSING-ABOUT-AUTHOR': [],
+
   // ============= STANDARD ACE RULES =============
   // Images and Non-text Content
   'img-alt': ['1.1.1'],

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -20,6 +20,7 @@ import { validatePrhCopyrightContent } from './validators/copyright-content-vali
 import { validatePrhBrandPage } from './validators/brand-page-validator';
 import { validatePrhTitlePage } from './validators/title-page-validator';
 import { validatePrhSocials } from './validators/socials-validator';
+import { validatePrhContentOrder } from './validators/content-order-validator';
 import { getImprintRules } from './imprints';
 import type { PublisherProfile } from '../types';
 import type { PrhValidatorIssue, PrhXhtmlFile } from './validators/types';
@@ -87,6 +88,7 @@ export async function runPrhUkValidators(
         ...validatePrhBrandPage(imprintInput),
         ...validatePrhTitlePage(imprintInput),
         ...validatePrhSocials(imprintInput),
+        ...validatePrhContentOrder(imprintInput),
       );
     }
 

--- a/src/services/epub/profiles/prh-uk/validators/content-order-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/content-order-validator.ts
@@ -90,7 +90,15 @@ export function validatePrhContentOrder(input: ContentOrderInput): PrhValidatorI
   const rawSpine = parseSpine(opf, manifest);
   if (rawSpine.length === 0) return issues;
 
-  const opfDir = opf.includes('/') ? input.opfPath.slice(0, input.opfPath.lastIndexOf('/')) : '';
+  // Resolve hrefs relative to the OPF directory — derived from the
+  // OPF *path* (not the OPF XML content). The original draft checked
+  // `opf.includes('/')` which is virtually always true because the
+  // XML body carries xmlns URLs etc., so the branch had no effect in
+  // practice. The bug only mattered on a flat zip where the OPF sits
+  // at the root and opfPath has no directory component.
+  const opfDir = input.opfPath.includes('/')
+    ? input.opfPath.slice(0, input.opfPath.lastIndexOf('/'))
+    : '';
   const filesByPath = new Map(input.xhtmlFiles.map((f) => [f.path, f.content]));
 
   const spine: ClassifiedSpine[] = rawSpine.map((ref) => {

--- a/src/services/epub/profiles/prh-uk/validators/content-order-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/content-order-validator.ts
@@ -1,0 +1,379 @@
+/**
+ * PRH UK content-order validator (P2/PR4).
+ *
+ * Walks the spine and classifies each entry (cover / title / copyright /
+ * brand / bodymatter / backmatter / footnotes / about-author) using a
+ * combination of epub:type on the XHTML body, the manifest properties,
+ * and filename heuristics. Then asserts PRH's mandated reading order:
+ *
+ *   1. Cover is at spine index 0.
+ *   2. If the imprint rules require a brand page, it must appear in
+ *      the spine. (PR2's brand-page-validator catches the structural
+ *      shape; this validator catches "missing entirely". The two
+ *      messages co-fire harmlessly when the brand page is absent.)
+ *   3. Footnotes (when present) must be at the last spine index — same
+ *      finding as PR2's PRH-SPINE-FOOTNOTES-LAST but with ORDER framing
+ *      rather than the linear="no" framing. Both can co-fire.
+ *   4. Copyright page must sit in the frontmatter portion of the spine
+ *      (PRH treats copyright as frontmatter; placing it in the
+ *      back-half is unusual). The rule fires when copyright appears
+ *      after the spine's midpoint AND there's an explicit bodymatter
+ *      entry, since "after the midpoint" alone is meaningless on tiny
+ *      EPUBs.
+ *   5. About-the-Author must be present somewhere in the spine — per
+ *      Style Guide §6.6 it's required on every PRH reflow EPUB.
+ *
+ * All findings are detect-only — spine surgery is risky enough to
+ * require operator review. Gated like the rest of P2 by imprint
+ * recognition + ≥medium confidence.
+ *
+ * Implementation notes:
+ *   - Classification leans on epub:type FIRST (most reliable), then
+ *     `<section epub:type="…">`, then filename + content fingerprints.
+ *   - "About-the-Author" detection is forgiving (PRH-author-bio,
+ *     about_author, contributor pages all count) because real EPUBs
+ *     vary in how the section is named.
+ *   - The validator is imprint-gated at the orchestrator level — when
+ *     `imprintRules.brandPage` is null (#Merky, Cornerstone Saga), the
+ *     brand-page check is skipped.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { ImprintRules } from '../imprints/_types';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+interface ContentOrderInput extends PrhPerXhtmlInput {
+  imprintRules: ImprintRules;
+}
+
+interface ManifestItem {
+  id: string;
+  href: string;
+  properties: string;
+}
+
+interface SpineRef {
+  idref: string;
+  linear: string | null;
+  /** Resolved zip-relative path of the manifest item this idref points at. */
+  path: string | null;
+  /** Manifest properties for this item (e.g. "cover-image", "nav"). */
+  properties: string;
+}
+
+type SpineEntryRole =
+  | 'cover'
+  | 'title'
+  | 'copyright'
+  | 'brand'
+  | 'about-author'
+  | 'footnotes'
+  | 'frontmatter'
+  | 'bodymatter'
+  | 'backmatter'
+  | 'unknown';
+
+interface ClassifiedSpine extends SpineRef {
+  role: SpineEntryRole;
+  /** XHTML content of the manifest item (or null when unavailable). */
+  content: string | null;
+}
+
+export function validatePrhContentOrder(input: ContentOrderInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+  const opf = input.opfContent;
+  const location = input.opfPath || 'package.opf';
+
+  if (!opf) return issues;
+
+  const manifest = parseManifest(opf);
+  const rawSpine = parseSpine(opf, manifest);
+  if (rawSpine.length === 0) return issues;
+
+  const opfDir = opf.includes('/') ? input.opfPath.slice(0, input.opfPath.lastIndexOf('/')) : '';
+  const filesByPath = new Map(input.xhtmlFiles.map((f) => [f.path, f.content]));
+
+  const spine: ClassifiedSpine[] = rawSpine.map((ref) => {
+    const fullPath = ref.path ? resolveOpfRelative(opfDir, ref.path) : null;
+    const content = fullPath ? (filesByPath.get(fullPath) ?? null) : null;
+    return {
+      ...ref,
+      content,
+      role: classifySpineEntry(ref, content),
+    };
+  });
+
+  // ── 1. Cover must be at index 0 ────────────────────────────────────────
+  const coverIndex = spine.findIndex((s) => s.role === 'cover');
+  if (coverIndex > 0) {
+    issues.push(buildIssue(
+      'PRH-ORDER-COVER-NOT-FIRST',
+      `Cover spine entry (idref="${spine[coverIndex].idref}") is at index ${coverIndex}; PRH requires it at spine index 0.`,
+      `Move the cover itemref to the start of <spine>.`,
+      location,
+    ));
+  }
+
+  // ── 2. Brand page must exist in the spine (when imprint expects one) ──
+  if (input.imprintRules.brandPage) {
+    const hasBrand = spine.some((s) => s.role === 'brand');
+    if (!hasBrand) {
+      issues.push(buildIssue(
+        'PRH-ORDER-MISSING-BRAND-PAGE',
+        `No brand page found in the spine. ${input.imprintRules.displayName} requires a brand page (Branding Guide §7).`,
+        `Add the brand-page itemref to <spine> after the cover.`,
+        location,
+      ));
+    }
+  }
+
+  // ── 3. Footnotes (if present) must be the last spine entry ────────────
+  const footnoteIndices = spine
+    .map((s, i) => (s.role === 'footnotes' ? i : -1))
+    .filter((i) => i >= 0);
+  if (footnoteIndices.length > 0) {
+    const lastIndex = spine.length - 1;
+    const trailingFootnotes = footnoteIndices.every((i) => i === lastIndex || isFootnoteRunToEnd(spine, i));
+    if (!trailingFootnotes) {
+      const misplaced = footnoteIndices.filter((i) => !isFootnoteRunToEnd(spine, i));
+      issues.push(buildIssue(
+        'PRH-ORDER-FOOTNOTES-NOT-LAST',
+        `Footnotes spine entries [${misplaced.map((i) => spine[i].idref).join(', ')}] are not in the trailing block of the spine.`,
+        `Reorder <spine> so footnotes itemrefs form the final contiguous block.`,
+        location,
+      ));
+    }
+  }
+
+  // ── 4. Copyright must be in frontmatter (not backmatter) ──────────────
+  const copyrightIndex = spine.findIndex((s) => s.role === 'copyright');
+  if (copyrightIndex >= 0) {
+    const bodyStart = spine.findIndex((s) => s.role === 'bodymatter');
+    // Two-step rule: only fire when there IS an explicit bodymatter
+    // marker AND copyright sits at or after it. Without a bodymatter
+    // marker the spine has no notion of where frontmatter ends, so
+    // we can't reliably distinguish "copyright at the end of front-
+    // matter" (correct) from "copyright in backmatter" (wrong).
+    if (bodyStart >= 0 && copyrightIndex >= bodyStart) {
+      issues.push(buildIssue(
+        'PRH-ORDER-COPYRIGHT-WRONG-POSITION',
+        `Copyright spine entry (idref="${spine[copyrightIndex].idref}") is at index ${copyrightIndex}, at or after the first bodymatter entry (index ${bodyStart}). PRH treats copyright as frontmatter.`,
+        `Move the copyright itemref to the frontmatter section of <spine>, before the first bodymatter entry.`,
+        location,
+      ));
+    }
+  }
+
+  // ── 5. About-the-Author must be present somewhere ─────────────────────
+  const hasAboutAuthor = spine.some((s) => s.role === 'about-author');
+  if (!hasAboutAuthor) {
+    issues.push(buildIssue(
+      'PRH-ORDER-MISSING-ABOUT-AUTHOR',
+      `No About-the-Author section found in the spine. Style Guide §6.6 requires every PRH reflow EPUB to include one.`,
+      `Add an About-the-Author backmatter file (e.g. <section epub:type="biography"> or filename "about_the_author.xhtml") and include it in the spine.`,
+      location,
+    ));
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Classify a spine entry by content (epub:type, section markers) +
+ * filename heuristics. Returns the most specific role we can identify.
+ * Falls back to 'unknown' when no clear signal is present — the
+ * validator treats unknowns as non-load-bearing (won't trigger checks).
+ */
+function classifySpineEntry(ref: SpineRef, content: string | null): SpineEntryRole {
+  // Cover gets the most reliable signal: the cover-image manifest
+  // property OR an `epub:type="cover"` body / section.
+  if (/\bcover-image\b/i.test(ref.properties)) return 'cover';
+  if (content && bodyEpubType(content) === 'cover') return 'cover';
+  if (content && sectionHasEpubType(content, 'cover')) return 'cover';
+  if (ref.path && pathLooksLikeCover(ref.path)) return 'cover';
+
+  // The order of subsequent checks matters: copyright + title + brand
+  // are all frontmatter sections, but only one role applies per entry.
+  if (content) {
+    if (sectionHasEpubType(content, 'copyright-page') || bodyEpubType(content) === 'copyright-page') {
+      return 'copyright';
+    }
+    if (sectionHasEpubType(content, 'titlepage') || bodyEpubType(content) === 'titlepage') {
+      return 'title';
+    }
+    // Brand pages are identified by id="brand_page" rather than epub:type
+    // (the Branding Guide doesn't define an epub:type for them).
+    if (/<body\b[^>]*\bid\s*=\s*["']brand_page["']/i.test(content)
+        || /<body\b[^>]*\bepub:type\s*=\s*["'][^"']*\bfrontmatter\b[^"']*["'][^>]*\bid\s*=\s*["']brand_page["']/i.test(content)) {
+      return 'brand';
+    }
+    if (sectionHasEpubType(content, 'biography') || bodyEpubType(content) === 'biography') {
+      return 'about-author';
+    }
+    if (sectionHasEpubType(content, 'footnotes')) return 'footnotes';
+  }
+
+  // Filename heuristics — used when epub:type didn't decide. We anchor
+  // on token boundary so unrelated names (`discover.xhtml`,
+  // `chapter-title.xhtml`) don't false-match.
+  if (ref.path) {
+    if (pathLooksLikeCopyright(ref.path)) return 'copyright';
+    if (pathLooksLikeTitle(ref.path)) return 'title';
+    if (pathLooksLikeBrand(ref.path)) return 'brand';
+    if (pathLooksLikeFootnotes(ref.path)) return 'footnotes';
+    if (pathLooksLikeAboutAuthor(ref.path)) return 'about-author';
+  }
+
+  if (content) {
+    const bodyType = bodyEpubType(content);
+    if (bodyType === 'bodymatter') return 'bodymatter';
+    if (bodyType === 'backmatter') return 'backmatter';
+    if (bodyType === 'frontmatter') return 'frontmatter';
+  }
+
+  return 'unknown';
+}
+
+/**
+ * True when all spine entries from `startIdx` to the end are footnotes
+ * — i.e. the run from this position runs cleanly to the spine's tail.
+ * Used so that footnotes1 + footnotes2 BOTH being at the back of the
+ * spine doesn't fire a misplaced warning.
+ */
+function isFootnoteRunToEnd(spine: ClassifiedSpine[], startIdx: number): boolean {
+  for (let i = startIdx; i < spine.length; i += 1) {
+    if (spine[i].role !== 'footnotes') return false;
+  }
+  return true;
+}
+
+function bodyEpubType(html: string): string | null {
+  const m = html.match(/<body\b[^>]*\bepub:type\s*=\s*["']([^"']+)["']/i);
+  if (!m) return null;
+  // epub:type can carry multiple space-separated values. Return the
+  // first PRH-relevant one.
+  const tokens = m[1].split(/\s+/);
+  for (const t of tokens) {
+    const norm = t.toLowerCase();
+    if (['cover', 'frontmatter', 'bodymatter', 'backmatter', 'copyright-page', 'titlepage', 'biography'].includes(norm)) {
+      return norm;
+    }
+  }
+  return tokens[0]?.toLowerCase() ?? null;
+}
+
+function sectionHasEpubType(html: string, target: string): boolean {
+  const re = new RegExp(`<section\\b[^>]*\\bepub:type\\s*=\\s*["'][^"']*\\b${target}\\b`, 'i');
+  return re.test(html);
+}
+
+function pathLooksLikeCover(path: string): boolean {
+  return /(?:^|[/_-])cover(?:[/._-]|$)/i.test(path);
+}
+
+function pathLooksLikeCopyright(path: string): boolean {
+  return /(?:^|\/)copyright[^/]*\.x?html?$/i.test(path);
+}
+
+function pathLooksLikeTitle(path: string): boolean {
+  return /(?:^|\/)(?:title(?:[_-]\d+)?|[a-z]+_titlepage)\.x?html?$/i.test(path);
+}
+
+function pathLooksLikeBrand(path: string): boolean {
+  return /(?:^|\/)(?:brand[-_ ]?page|[\w-]+[-_]brand|brand)\.x?html?$/i.test(path);
+}
+
+function pathLooksLikeFootnotes(path: string): boolean {
+  return /(?:^|\/)footnotes?\d*\.x?html?$/i.test(path);
+}
+
+/**
+ * About-the-Author file detection. PRH naming varies:
+ *   - `about_the_author.xhtml`
+ *   - `about-the-author.xhtml`
+ *   - `author_bio.xhtml`
+ *   - `author-biography.xhtml`
+ *   - `contributor.xhtml` (occasionally — for anthologies)
+ */
+function pathLooksLikeAboutAuthor(path: string): boolean {
+  return /(?:^|\/)(?:about[-_]?the[-_]?author|author[-_]bio(?:graphy)?|contributor)\.x?html?$/i.test(path);
+}
+
+function parseManifest(opf: string): ManifestItem[] {
+  const manifestMatch = opf.match(/<manifest\b[^>]*>([\s\S]*?)<\/manifest>/i);
+  if (!manifestMatch) return [];
+  const items: ManifestItem[] = [];
+  const itemRe = /<item\b([^>]*)\/?>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = itemRe.exec(manifestMatch[1])) !== null) {
+    const attrs = m[1];
+    const id = readAttr(attrs, 'id');
+    const href = readAttr(attrs, 'href');
+    const properties = readAttr(attrs, 'properties');
+    if (id && href != null) items.push({ id, href, properties: properties ?? '' });
+  }
+  return items;
+}
+
+function parseSpine(opf: string, manifest: ManifestItem[]): SpineRef[] {
+  const spineMatch = opf.match(/<spine\b[^>]*>([\s\S]*?)<\/spine>/i);
+  if (!spineMatch) return [];
+  const refs: SpineRef[] = [];
+  const refRe = /<itemref\b([^>]*)\/?>/gi;
+  let m: RegExpExecArray | null;
+  const manifestById = new Map(manifest.map((i) => [i.id, i]));
+  while ((m = refRe.exec(spineMatch[1])) !== null) {
+    const attrs = m[1];
+    const idref = readAttr(attrs, 'idref');
+    if (!idref) continue;
+    const item = manifestById.get(idref);
+    refs.push({
+      idref,
+      linear: readAttr(attrs, 'linear'),
+      path: item?.href ?? null,
+      properties: item?.properties ?? '',
+    });
+  }
+  return refs;
+}
+
+function readAttr(attrs: string, name: string): string | null {
+  const re = new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, 'i');
+  const m = attrs.match(re);
+  if (!m) return null;
+  return (m[1] ?? m[2]) ?? null;
+}
+
+function resolveOpfRelative(opfDir: string, href: string): string {
+  const combined = opfDir.length > 0 ? `${opfDir}/${href}` : href;
+  const segments = combined.split('/');
+  const out: string[] = [];
+  for (const seg of segments) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      out.pop();
+      continue;
+    }
+    out.push(seg);
+  }
+  return out.join('/');
+}
+
+function buildIssue(
+  code: keyof typeof PRH_ISSUE_CODES,
+  message: string,
+  suggestion: string,
+  location: string,
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${message}`,
+    suggestion,
+    location,
+  };
+}

--- a/tests/unit/services/epub/profiles/prh-uk/validators/content-order-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/content-order-validator.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhContentOrder } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/content-order-validator';
+import { getImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+import type { ImprintRules } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints/_types';
+
+/**
+ * Build a minimal OPF with the listed spine entries. Each entry is
+ * referenced by manifest id and matched to a same-name XHTML file. The
+ * builder yields both the OPF string and an array of XHTML PrhXhtmlFile
+ * objects with the supplied body epub:type attribute so the validator's
+ * classifier exercises the canonical signal path.
+ *
+ * The `kindByIdref` map controls each entry's body epub:type, which
+ * drives the spine-classifier under test (cover / titlepage /
+ * copyright-page / biography / frontmatter / bodymatter / backmatter).
+ * Use `kind === 'brand'` to emit an `id="brand_page"` body instead.
+ * Use `kind === 'footnotes'` to emit `<section epub:type="footnotes">`.
+ */
+function buildEpub(
+  entries: Array<{ id: string; href: string; kind: string; linear?: 'no' }>,
+): { opf: string; xhtmlFiles: PrhXhtmlFile[] } {
+  const manifestItems = entries.map((e) =>
+    `<item id="${e.id}" href="${e.href}" media-type="application/xhtml+xml"${e.kind === 'cover-image' ? ' properties="cover-image"' : ''}/>`,
+  ).join('\n');
+  const spineItems = entries.map((e) =>
+    `<itemref idref="${e.id}"${e.linear === 'no' ? ' linear="no"' : ''}/>`,
+  ).join('\n');
+
+  const opf = `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <manifest>
+    ${manifestItems}
+  </manifest>
+  <spine>
+    ${spineItems}
+  </spine>
+</package>`;
+
+  const xhtmlFiles: PrhXhtmlFile[] = entries.map((e) => {
+    const path = `EPUB/${e.href}`;
+    return { path, content: xhtmlFor(e.kind) };
+  });
+
+  return { opf, xhtmlFiles };
+}
+
+function xhtmlFor(kind: string): string {
+  const bodyAttrs = (() => {
+    switch (kind) {
+      case 'cover':
+        return 'epub:type="cover"';
+      case 'titlepage':
+        return 'epub:type="frontmatter"';
+      case 'copyright':
+        return 'epub:type="frontmatter"';
+      case 'brand':
+        return 'epub:type="frontmatter" id="brand_page"';
+      case 'biography':
+        return 'epub:type="biography"';
+      case 'bodymatter':
+        return 'epub:type="bodymatter"';
+      case 'backmatter':
+        return 'epub:type="backmatter"';
+      case 'footnotes':
+        return 'epub:type="backmatter"';
+      default:
+        return '';
+    }
+  })();
+  const inner = (() => {
+    switch (kind) {
+      case 'titlepage':
+        return '<section epub:type="titlepage" class="titlepage"><h3 class="booktitle">T</h3></section>';
+      case 'copyright':
+        return '<section epub:type="copyright-page">Copyright</section>';
+      case 'footnotes':
+        return '<section epub:type="footnotes"><ol><li>fn</li></ol></section>';
+      case 'brand':
+        return '<figure class="brand_logo_solo"><img alt="Penguin Random House" /></figure>';
+      default:
+        return 'body';
+    }
+  })();
+  return `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title></head>
+<body ${bodyAttrs}>${inner}</body>
+</html>`;
+}
+
+function input(opf: string, xhtmlFiles: PrhXhtmlFile[], imprintRules: ImprintRules) {
+  return {
+    opfContent: opf,
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+    imprintRules,
+  };
+}
+
+describe('validatePrhContentOrder — cover position', () => {
+  const penguinRules = getImprintRules('penguin')!;
+
+  it('emits zero issues for a canonical spine: cover → title → copyright → brand → body → author bio', () => {
+    const { opf, xhtmlFiles } = buildEpub([
+      { id: 'cover', href: 'cover.xhtml', kind: 'cover', linear: 'no' },
+      { id: 'title', href: 'title.xhtml', kind: 'titlepage' },
+      { id: 'copyright', href: 'copyright.xhtml', kind: 'copyright' },
+      { id: 'brand', href: 'brand_page.xhtml', kind: 'brand' },
+      { id: 'body', href: 'chapter1.xhtml', kind: 'bodymatter' },
+      { id: 'about', href: 'about_the_author.xhtml', kind: 'biography' },
+    ]);
+    expect(validatePrhContentOrder(input(opf, xhtmlFiles, penguinRules))).toEqual([]);
+  });
+
+  it('emits PRH-ORDER-COVER-NOT-FIRST when cover is at index 1', () => {
+    const { opf, xhtmlFiles } = buildEpub([
+      { id: 'title', href: 'title.xhtml', kind: 'titlepage' },
+      { id: 'cover', href: 'cover.xhtml', kind: 'cover', linear: 'no' },
+      { id: 'copyright', href: 'copyright.xhtml', kind: 'copyright' },
+      { id: 'brand', href: 'brand_page.xhtml', kind: 'brand' },
+      { id: 'body', href: 'chapter1.xhtml', kind: 'bodymatter' },
+      { id: 'about', href: 'about_the_author.xhtml', kind: 'biography' },
+    ]);
+    const issues = validatePrhContentOrder(input(opf, xhtmlFiles, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-ORDER-COVER-NOT-FIRST')).toBeDefined();
+  });
+});
+
+describe('validatePrhContentOrder — brand-page presence', () => {
+  it('emits PRH-ORDER-MISSING-BRAND-PAGE for Penguin when no brand page in spine', () => {
+    const penguinRules = getImprintRules('penguin')!;
+    const { opf, xhtmlFiles } = buildEpub([
+      { id: 'cover', href: 'cover.xhtml', kind: 'cover', linear: 'no' },
+      { id: 'title', href: 'title.xhtml', kind: 'titlepage' },
+      { id: 'copyright', href: 'copyright.xhtml', kind: 'copyright' },
+      { id: 'body', href: 'chapter1.xhtml', kind: 'bodymatter' },
+      { id: 'about', href: 'about_the_author.xhtml', kind: 'biography' },
+    ]);
+    const issues = validatePrhContentOrder(input(opf, xhtmlFiles, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-ORDER-MISSING-BRAND-PAGE')).toBeDefined();
+  });
+
+  it('does NOT emit PRH-ORDER-MISSING-BRAND-PAGE for #Merky (no canonical brand page)', () => {
+    const merkyRules = getImprintRules('merky')!;
+    const { opf, xhtmlFiles } = buildEpub([
+      { id: 'cover', href: 'cover.xhtml', kind: 'cover', linear: 'no' },
+      { id: 'title', href: 'title.xhtml', kind: 'titlepage' },
+      { id: 'copyright', href: 'copyright.xhtml', kind: 'copyright' },
+      { id: 'body', href: 'chapter1.xhtml', kind: 'bodymatter' },
+      { id: 'about', href: 'about_the_author.xhtml', kind: 'biography' },
+    ]);
+    const issues = validatePrhContentOrder(input(opf, xhtmlFiles, merkyRules));
+    expect(issues.find((i) => i.code === 'PRH-ORDER-MISSING-BRAND-PAGE')).toBeUndefined();
+  });
+});
+
+describe('validatePrhContentOrder — copyright position', () => {
+  const penguinRules = getImprintRules('penguin')!;
+
+  it('emits PRH-ORDER-COPYRIGHT-WRONG-POSITION when copyright sits AFTER bodymatter', () => {
+    const { opf, xhtmlFiles } = buildEpub([
+      { id: 'cover', href: 'cover.xhtml', kind: 'cover', linear: 'no' },
+      { id: 'title', href: 'title.xhtml', kind: 'titlepage' },
+      { id: 'brand', href: 'brand_page.xhtml', kind: 'brand' },
+      { id: 'body', href: 'chapter1.xhtml', kind: 'bodymatter' },
+      // Copyright misplaced after bodymatter — wrong per PRH.
+      { id: 'copyright', href: 'copyright.xhtml', kind: 'copyright' },
+      { id: 'about', href: 'about_the_author.xhtml', kind: 'biography' },
+    ]);
+    const issues = validatePrhContentOrder(input(opf, xhtmlFiles, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-ORDER-COPYRIGHT-WRONG-POSITION')).toBeDefined();
+  });
+
+  it('does NOT emit PRH-ORDER-COPYRIGHT-WRONG-POSITION when copyright is at end of frontmatter', () => {
+    const { opf, xhtmlFiles } = buildEpub([
+      { id: 'cover', href: 'cover.xhtml', kind: 'cover', linear: 'no' },
+      { id: 'title', href: 'title.xhtml', kind: 'titlepage' },
+      { id: 'copyright', href: 'copyright.xhtml', kind: 'copyright' },
+      { id: 'brand', href: 'brand_page.xhtml', kind: 'brand' },
+      { id: 'body', href: 'chapter1.xhtml', kind: 'bodymatter' },
+      { id: 'about', href: 'about_the_author.xhtml', kind: 'biography' },
+    ]);
+    const issues = validatePrhContentOrder(input(opf, xhtmlFiles, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-ORDER-COPYRIGHT-WRONG-POSITION')).toBeUndefined();
+  });
+});
+
+describe('validatePrhContentOrder — footnotes ordering', () => {
+  const penguinRules = getImprintRules('penguin')!;
+
+  it('emits PRH-ORDER-FOOTNOTES-NOT-LAST when footnotes sit mid-spine', () => {
+    const { opf, xhtmlFiles } = buildEpub([
+      { id: 'cover', href: 'cover.xhtml', kind: 'cover', linear: 'no' },
+      { id: 'title', href: 'title.xhtml', kind: 'titlepage' },
+      { id: 'copyright', href: 'copyright.xhtml', kind: 'copyright' },
+      { id: 'brand', href: 'brand_page.xhtml', kind: 'brand' },
+      { id: 'fn', href: 'footnotes.xhtml', kind: 'footnotes', linear: 'no' },
+      // Bodymatter AFTER footnotes — footnotes is not at the end.
+      { id: 'body', href: 'chapter1.xhtml', kind: 'bodymatter' },
+      { id: 'about', href: 'about_the_author.xhtml', kind: 'biography' },
+    ]);
+    const issues = validatePrhContentOrder(input(opf, xhtmlFiles, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-ORDER-FOOTNOTES-NOT-LAST')).toBeDefined();
+  });
+
+  it('does NOT emit PRH-ORDER-FOOTNOTES-NOT-LAST when footnotes are at the spine end', () => {
+    const { opf, xhtmlFiles } = buildEpub([
+      { id: 'cover', href: 'cover.xhtml', kind: 'cover', linear: 'no' },
+      { id: 'title', href: 'title.xhtml', kind: 'titlepage' },
+      { id: 'copyright', href: 'copyright.xhtml', kind: 'copyright' },
+      { id: 'brand', href: 'brand_page.xhtml', kind: 'brand' },
+      { id: 'body', href: 'chapter1.xhtml', kind: 'bodymatter' },
+      { id: 'about', href: 'about_the_author.xhtml', kind: 'biography' },
+      { id: 'fn', href: 'footnotes.xhtml', kind: 'footnotes', linear: 'no' },
+    ]);
+    const issues = validatePrhContentOrder(input(opf, xhtmlFiles, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-ORDER-FOOTNOTES-NOT-LAST')).toBeUndefined();
+  });
+});
+
+describe('validatePrhContentOrder — about-the-author presence', () => {
+  const penguinRules = getImprintRules('penguin')!;
+
+  it('emits PRH-ORDER-MISSING-ABOUT-AUTHOR when no biography entry exists', () => {
+    const { opf, xhtmlFiles } = buildEpub([
+      { id: 'cover', href: 'cover.xhtml', kind: 'cover', linear: 'no' },
+      { id: 'title', href: 'title.xhtml', kind: 'titlepage' },
+      { id: 'copyright', href: 'copyright.xhtml', kind: 'copyright' },
+      { id: 'brand', href: 'brand_page.xhtml', kind: 'brand' },
+      { id: 'body', href: 'chapter1.xhtml', kind: 'bodymatter' },
+    ]);
+    const issues = validatePrhContentOrder(input(opf, xhtmlFiles, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-ORDER-MISSING-ABOUT-AUTHOR')).toBeDefined();
+  });
+
+  it('detects About-the-Author via filename alone (no epub:type marker)', () => {
+    // Some EPUBs ship an author bio without epub:type="biography" but
+    // with a canonical filename — should still pass.
+    const { opf, xhtmlFiles } = buildEpub([
+      { id: 'cover', href: 'cover.xhtml', kind: 'cover', linear: 'no' },
+      { id: 'title', href: 'title.xhtml', kind: 'titlepage' },
+      { id: 'copyright', href: 'copyright.xhtml', kind: 'copyright' },
+      { id: 'brand', href: 'brand_page.xhtml', kind: 'brand' },
+      { id: 'body', href: 'chapter1.xhtml', kind: 'bodymatter' },
+      { id: 'about', href: 'about_the_author.xhtml', kind: 'backmatter' },
+    ]);
+    const issues = validatePrhContentOrder(input(opf, xhtmlFiles, penguinRules));
+    expect(issues.find((i) => i.code === 'PRH-ORDER-MISSING-ABOUT-AUTHOR')).toBeUndefined();
+  });
+});
+
+describe('validatePrhContentOrder — defensive paths', () => {
+  it('returns [] when the OPF has no spine entries', () => {
+    const penguinRules = getImprintRules('penguin')!;
+    const opf = `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <manifest><item id="x" href="x.xhtml" media-type="application/xhtml+xml"/></manifest>
+  <spine></spine>
+</package>`;
+    expect(validatePrhContentOrder(input(opf, [], penguinRules))).toEqual([]);
+  });
+
+  it('returns [] when opfContent is empty', () => {
+    const penguinRules = getImprintRules('penguin')!;
+    expect(validatePrhContentOrder(input('', [], penguinRules))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Final P2 validator — walks the OPF spine and asserts PRH UK's mandated reading order. Closes the P2 series (PR #356-#361 P1; #362, #363, #367 P2/PR1-PR3; this PR P2/PR4).

## New checks (5)

| Code | Severity | WCAG | Trigger |
|---|---|---|---|
| PRH-ORDER-COVER-NOT-FIRST | minor | — | Cover not at spine index 0 |
| PRH-ORDER-MISSING-BRAND-PAGE | minor | — | Brand page absent (when imprint expects one) |
| PRH-ORDER-FOOTNOTES-NOT-LAST | minor | — | Footnotes not at spine tail (order framing — distinct from PRH-SPINE-FOOTNOTES-LAST's linear=no framing) |
| PRH-ORDER-COPYRIGHT-WRONG-POSITION | minor | — | Copyright at or after first bodymatter entry |
| PRH-ORDER-MISSING-ABOUT-AUTHOR | minor | — | No biography/about-author entry (Style Guide §6.6 requirement) |

## Classification strategy

Each spine entry is classified via:
1. `body epub:type` (most reliable)
2. `<section epub:type="…">` markers
3. `id="brand_page"` for brand pages (no canonical epub:type)
4. Filename heuristics — anchored on token boundary so `discover.xhtml` etc. don't false-match `cover`

## Copyright-position rule

Two-step: only fires when an explicit `bodymatter` entry exists AND copyright appears at or after it. On a spine without a bodymatter marker the rule short-circuits — distinguishing "copyright at end of frontmatter" (correct) from "copyright in backmatter" (wrong) needs that anchor.

## Test plan

- [x] 233/233 PRH unit tests passing (12 new content-order tests)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke test against a real Penguin EPUB
- [ ] Staging smoke test: PRH Branding Guide (multi-imprint demo) still resolves to `unknown` and skips these validators

## P2 completion status

| PR | Validator | Codes | Tests | Status |
|---|---|---|---|---|
| #362 | copyright-content matcher | 8 | 21 | merged |
| #363 | brand + title page | 7 | 25 | merged |
| #367 | socials | 5 | 19 | merged |
| **THIS** | content order | 5 | 12 | open |
| **Total P2** | — | **25** | **77** | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced PRH UK content-order validation: checks cover placement, required brand page, footnotes confined to the end, copyright in frontmatter, and presence of About-the-Author.

* **Tests**
  * Added comprehensive unit tests covering canonical and edge-case content-order scenarios.

* **Chores**
  * Registered additional PRH UK issue codes for content-order detections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/368)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->