### PR TITLE
feat(prh): epub:type placement + doc-* ARIA + body purity (P3/PR1)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -365,6 +365,66 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'EPUB is missing an About-the-Author section — required in every PRH reflow EPUB (Style Guide §6.6)',
   },
+
+  // ── Body epub:type + doc-* ARIA (P3/PR1) ──────────────────────────────
+  // Publisher-gated (not imprint-gated) — these markup rules apply to
+  // every PRH UK build regardless of imprint. Detect-only in P3.
+  'PRH-MARKUP-EPUB-TYPE-MISPLACED': {
+    code: 'PRH-MARKUP-EPUB-TYPE-MISPLACED',
+    severity: 'moderate',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'epub:type is allowed on <body> only for cover/frontmatter/bodymatter/backmatter; on <section> chapter/part/dedication/epigraph/appendix are forbidden (use ARIA doc-* role instead)',
+  },
+  'PRH-MARKUP-EPUB-TYPE-DUPLICATE': {
+    code: 'PRH-MARKUP-EPUB-TYPE-DUPLICATE',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Each of cover/frontmatter/bodymatter/backmatter must appear on at most one <body> across the EPUB',
+  },
+  'PRH-ARIA-CHAPTER-ROLE-MISSING': {
+    code: 'PRH-ARIA-CHAPTER-ROLE-MISSING',
+    severity: 'minor',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'First chapter section should carry role="doc-chapter" instead of epub:type="chapter"',
+  },
+  'PRH-ARIA-PART-ROLE-MISSING': {
+    code: 'PRH-ARIA-PART-ROLE-MISSING',
+    severity: 'minor',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'First part section should carry role="doc-part" instead of epub:type="part"',
+  },
+  'PRH-ARIA-DEDICATION-ROLE-MISSING': {
+    code: 'PRH-ARIA-DEDICATION-ROLE-MISSING',
+    severity: 'minor',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'Dedication section should carry role="doc-dedication" instead of epub:type="dedication"',
+  },
+  'PRH-ARIA-EPIGRAPH-ROLE-MISSING': {
+    code: 'PRH-ARIA-EPIGRAPH-ROLE-MISSING',
+    severity: 'minor',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'Epigraph block should be a <blockquote role="doc-epigraph">',
+  },
+  'PRH-ARIA-APPENDIX-ROLE-MISSING': {
+    code: 'PRH-ARIA-APPENDIX-ROLE-MISSING',
+    severity: 'minor',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'Appendix section should carry role="doc-appendix" instead of epub:type="appendix"',
+  },
+  'PRH-BODY-HAS-ARIA': {
+    code: 'PRH-BODY-HAS-ARIA',
+    severity: 'moderate',
+    wcag: ['4.1.2'],
+    fixType: 'manual',
+    summary: '<body> must NOT carry role / aria-label / aria-labelledby (PRH explicitly prohibits)',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/wcag-issue-mapper.service.ts
+++ b/src/services/acr/wcag-issue-mapper.service.ts
@@ -105,6 +105,16 @@ export const RULE_TO_CRITERIA_MAP: Record<string, string[]> = {
   'PRH-ORDER-COPYRIGHT-WRONG-POSITION': [],
   'PRH-ORDER-MISSING-ABOUT-AUTHOR': [],
 
+  // Body epub:type + doc-* ARIA (P3/PR1)
+  'PRH-MARKUP-EPUB-TYPE-MISPLACED': ['1.3.1'],
+  'PRH-MARKUP-EPUB-TYPE-DUPLICATE': [],
+  'PRH-ARIA-CHAPTER-ROLE-MISSING': ['1.3.1'],
+  'PRH-ARIA-PART-ROLE-MISSING': ['1.3.1'],
+  'PRH-ARIA-DEDICATION-ROLE-MISSING': ['1.3.1'],
+  'PRH-ARIA-EPIGRAPH-ROLE-MISSING': ['1.3.1'],
+  'PRH-ARIA-APPENDIX-ROLE-MISSING': ['1.3.1'],
+  'PRH-BODY-HAS-ARIA': ['4.1.2'],
+
   // ============= STANDARD ACE RULES =============
   // Images and Non-text Content
   'img-alt': ['1.1.1'],

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -21,6 +21,9 @@ import { validatePrhBrandPage } from './validators/brand-page-validator';
 import { validatePrhTitlePage } from './validators/title-page-validator';
 import { validatePrhSocials } from './validators/socials-validator';
 import { validatePrhContentOrder } from './validators/content-order-validator';
+import { validatePrhEpubTypePlacement } from './validators/epub-type-placement-validator';
+import { validatePrhDocAriaRoles } from './validators/doc-aria-roles-validator';
+import { validatePrhBodyPurity } from './validators/body-purity-validator';
 import { getImprintRules } from './imprints';
 import type { PublisherProfile } from '../types';
 import type { PrhValidatorIssue, PrhXhtmlFile } from './validators/types';
@@ -73,6 +76,22 @@ export async function runPrhUkValidators(
       ...validatePrhPerXhtml(perXhtmlInput),
       ...validatePrhImages(perXhtmlInput),
     ];
+
+    // Publisher-gated P3 validators run when the publisher is PRH-UK
+    // AND confidence is medium-or-high. P3 rules are markup-level and
+    // apply to every PRH-UK build regardless of imprint — multi-imprint
+    // demo docs (PRH Technical Guide / Branding Guide) still get these
+    // checks because the markup conventions are imprint-agnostic.
+    const isPrhAtMediumConfidence =
+      publisherProfile?.publisher === 'PRH-UK'
+      && publisherProfile.confidence !== 'low';
+    if (isPrhAtMediumConfidence) {
+      issues.push(
+        ...validatePrhEpubTypePlacement(perXhtmlInput),
+        ...validatePrhDocAriaRoles(perXhtmlInput),
+        ...validatePrhBodyPurity(perXhtmlInput),
+      );
+    }
 
     // Imprint-gated P2 validators run only when we have a recognised
     // imprint (not 'unknown' / null) AND confidence is medium-or-high.

--- a/src/services/epub/profiles/prh-uk/validators/body-purity-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/body-purity-validator.ts
@@ -1,0 +1,76 @@
+/**
+ * PRH UK <body> purity validator (P3/PR1).
+ *
+ * Per Technical Guide §6.1, the `<body>` element MUST NOT carry any
+ * of the following ARIA attributes:
+ *   - role
+ *   - aria-label
+ *   - aria-labelledby
+ *
+ * PRH's reasoning: reading systems differ in how they treat ARIA on
+ * the body element, so PRH suppresses the variation by banning it
+ * entirely. Roles + labels belong on inner sections instead.
+ *
+ * Issue code: PRH-BODY-HAS-ARIA (one per offending file).
+ *
+ * Detect-only. Auto-fix (strip the attribute) lands in P5.
+ *
+ * Implementation note: Ninja's existing `addAriaLandmarks` remediator
+ * has historically been able to write `role="main"` on `<body>`. When
+ * we add the auto-fix in P5, that remediator needs a safety guard so
+ * it never targets <body> on a PRH-UK build. Until then, this
+ * validator will fire on remediated output — which is correct, because
+ * the remediator itself is non-conformant for PRH.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+/** Attributes banned on <body> per PRH spec. */
+const BANNED_BODY_ATTRS = ['role', 'aria-label', 'aria-labelledby'] as const;
+
+export function validatePrhBodyPurity(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  for (const file of input.xhtmlFiles) {
+    const bodyOpenMatch = file.content.match(/<body\b([^>]*)>/i);
+    if (!bodyOpenMatch) continue;
+    const bodyAttrs = bodyOpenMatch[1];
+
+    const offenders: string[] = [];
+    for (const attr of BANNED_BODY_ATTRS) {
+      // Match the attribute only when preceded by start-of-string or
+      // whitespace. `\b` alone would false-match inside `data-role` /
+      // `data-aria-label` because the boundary lands between `-` and
+      // `r`. Requiring a whitespace anchor is stricter and tighter to
+      // how HTML attributes actually serialise.
+      const re = new RegExp(`(?:^|\\s)${attr}\\s*=`, 'i');
+      if (re.test(bodyAttrs)) {
+        offenders.push(attr);
+      }
+    }
+    if (offenders.length === 0) continue;
+
+    issues.push(buildIssue(
+      file.path,
+      `<body> in ${file.path} carries forbidden attribute(s): ${offenders.join(', ')}. PRH explicitly prohibits ARIA on the body element.`,
+      `Remove ${offenders.join(' / ')} from <body>. If you need a landmark role, move it to an inner <section> or <main>.`,
+    ));
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function buildIssue(location: string, message: string, suggestion: string): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES['PRH-BODY-HAS-ARIA'];
+  return {
+    code: 'PRH-BODY-HAS-ARIA',
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${message}`,
+    suggestion,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/doc-aria-roles-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/doc-aria-roles-validator.ts
@@ -1,0 +1,171 @@
+/**
+ * PRH UK doc-* ARIA role validator (P3/PR1).
+ *
+ * Per Technical Guide §6.1, chapter / part / dedication / epigraph /
+ * appendix sections should carry an ARIA `role="doc-*"` attribute
+ * instead of `epub:type` (the latter is forbidden for these types
+ * — see epub-type-placement-validator).
+ *
+ * Detection is filename-driven (heuristic) — we look for the file
+ * whose path matches a section pattern, then check whether its first
+ * `<section>` or `<blockquote>` carries the matching doc-* role.
+ *
+ * Scoping decisions baked in (per P3 plan Q4 + Q5):
+ *   - FIRST-ONLY: emit at most one issue per section type per EPUB. The
+ *     first chapter section without `role="doc-chapter"` fires; later
+ *     chapter files don't get nagged repeatedly. PRH's rule is that the
+ *     role goes on Chapter 1 / Part 1 only.
+ *   - SLIM BOOK GUARD: when the EPUB has zero or one bodymatter
+ *     candidate, skip the chapter role check. A single-section
+ *     bodymatter book (essay, memoir, novella) probably doesn't have
+ *     an explicit chapter division at all, so emitting a "missing
+ *     chapter role" issue would be noise.
+ *
+ * Issue codes:
+ *   - PRH-ARIA-CHAPTER-ROLE-MISSING
+ *   - PRH-ARIA-PART-ROLE-MISSING
+ *   - PRH-ARIA-DEDICATION-ROLE-MISSING
+ *   - PRH-ARIA-EPIGRAPH-ROLE-MISSING
+ *   - PRH-ARIA-APPENDIX-ROLE-MISSING
+ *
+ * Detect-only. Auto-fix (insert role attribute) lands in P5.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput, PrhXhtmlFile } from './types';
+
+interface SectionKindRule {
+  /** Code to emit when the role is missing. */
+  code: keyof typeof PRH_ISSUE_CODES;
+  /** Required ARIA role value. */
+  docRole: string;
+  /** Filename pattern that flags candidate files. Anchored token. */
+  pathPattern: RegExp;
+  /** Element type to scope the role check to. */
+  element: 'section' | 'blockquote';
+}
+
+/**
+ * Per-section-type rules. Keep this list short and conservative — each
+ * entry represents one issue code that can fire AT MOST once per EPUB.
+ */
+const SECTION_RULES: SectionKindRule[] = [
+  {
+    code: 'PRH-ARIA-CHAPTER-ROLE-MISSING',
+    docRole: 'doc-chapter',
+    pathPattern: /(?:^|\/)(?:chapter|chap)[_-]?\d*\.x?html?$/i,
+    element: 'section',
+  },
+  {
+    code: 'PRH-ARIA-PART-ROLE-MISSING',
+    docRole: 'doc-part',
+    pathPattern: /(?:^|\/)part[_-]?\d*\.x?html?$/i,
+    element: 'section',
+  },
+  {
+    code: 'PRH-ARIA-DEDICATION-ROLE-MISSING',
+    docRole: 'doc-dedication',
+    pathPattern: /(?:^|\/)dedication\.x?html?$/i,
+    element: 'section',
+  },
+  {
+    code: 'PRH-ARIA-EPIGRAPH-ROLE-MISSING',
+    docRole: 'doc-epigraph',
+    pathPattern: /(?:^|\/)epigraph\.x?html?$/i,
+    element: 'blockquote',
+  },
+  {
+    code: 'PRH-ARIA-APPENDIX-ROLE-MISSING',
+    docRole: 'doc-appendix',
+    pathPattern: /(?:^|\/)appendix[_-]?\d*\.x?html?$/i,
+    element: 'section',
+  },
+];
+
+export function validatePrhDocAriaRoles(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  // SLIM BOOK GUARD: count files that LOOK like chapter sections.
+  // When we have zero or one chapter-shaped file, skip the chapter
+  // check entirely (Q5 default).
+  const chapterCandidateCount = input.xhtmlFiles.filter((f) =>
+    SECTION_RULES[0].pathPattern.test(f.path),
+  ).length;
+
+  for (const rule of SECTION_RULES) {
+    if (rule.docRole === 'doc-chapter' && chapterCandidateCount <= 1) {
+      continue;
+    }
+
+    // FIRST-ONLY: find the first file matching the pattern. Files are
+    // walked in their natural xhtmlFiles order, which mirrors the zip
+    // entry order — close enough to "first by spine" without dragging
+    // OPF parsing into this validator.
+    const candidate = firstMatch(input.xhtmlFiles, rule.pathPattern);
+    if (!candidate) continue;
+
+    if (!hasDocRole(candidate.content, rule.element, rule.docRole)) {
+      issues.push(buildIssue(
+        rule.code,
+        `${candidate.path} does not carry role="${rule.docRole}" on its first <${rule.element}>. PRH requires ${rule.docRole} on the first ${rule.element === 'blockquote' ? 'epigraph blockquote' : 'section of this type'}.`,
+        `Add role="${rule.docRole}" to the first <${rule.element}> in ${candidate.path} (drop any epub:type="${rule.docRole.replace(/^doc-/, '')}" attribute on the same element).`,
+        candidate.path,
+      ));
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function firstMatch(
+  files: PrhXhtmlFile[],
+  pattern: RegExp,
+): PrhXhtmlFile | null {
+  for (const f of files) {
+    if (pattern.test(f.path)) return f;
+  }
+  return null;
+}
+
+/**
+ * True when the first occurrence of the target element carries the
+ * required `role="doc-*"`. We pick the FIRST match because PRH's
+ * rule is about the opening element (the "Chapter 1" container);
+ * later siblings inherit by convention.
+ *
+ * Multiple values in `role="…"` are supported (space-separated). We
+ * accept any value that includes the target token.
+ */
+function hasDocRole(html: string, element: 'section' | 'blockquote', docRole: string): boolean {
+  const openTagRe = new RegExp(`<${element}\\b([^>]*)>`, 'i');
+  const m = openTagRe.exec(html);
+  if (!m) {
+    // Element doesn't appear at all — can't enforce the role. Don't
+    // emit (would be a noise issue against an unrelated XHTML).
+    return true;
+  }
+  const attrs = m[1];
+  const roleAttr = attrs.match(/\brole\s*=\s*["']([^"']+)["']/i);
+  if (!roleAttr) return false;
+  const roleTokens = roleAttr[1].split(/\s+/).map((t) => t.toLowerCase());
+  return roleTokens.includes(docRole.toLowerCase());
+}
+
+function buildIssue(
+  code: keyof typeof PRH_ISSUE_CODES,
+  message: string,
+  suggestion: string,
+  location: string,
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${message}`,
+    suggestion,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/doc-aria-roles-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/doc-aria-roles-validator.ts
@@ -34,6 +34,87 @@
 import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
 import type { PrhValidatorIssue, PrhPerXhtmlInput, PrhXhtmlFile } from './types';
 
+/**
+ * Order the XHTML files by the EPUB spine when possible. The "first
+ * chapter section" check needs the AUTHORITATIVE first chapter — zip
+ * entry order is usually a good proxy (zips are typically built from
+ * spine order) but a re-zipped EPUB could have a different on-disk
+ * order than its declared reading order. Spine wins when we have it.
+ *
+ * Falls back to the raw `xhtmlFiles` order when:
+ *   - opfContent has no <spine>
+ *   - spine itemrefs don't reference any manifest items
+ *   - manifest doesn't carry an href we can resolve to an xhtmlFiles path
+ *
+ * Files that aren't in the spine (orphans) are appended at the end in
+ * their original order, so the SLIM BOOK GUARD's count of
+ * chapter-shaped files stays consistent across both code paths.
+ */
+function orderFilesBySpine(
+  opfContent: string,
+  opfPath: string,
+  xhtmlFiles: PrhXhtmlFile[],
+): PrhXhtmlFile[] {
+  const manifestMatch = opfContent.match(/<manifest\b[^>]*>([\s\S]*?)<\/manifest>/i);
+  const spineMatch = opfContent.match(/<spine\b[^>]*>([\s\S]*?)<\/spine>/i);
+  if (!manifestMatch || !spineMatch) return xhtmlFiles;
+
+  // Build idref → resolved zip path.
+  const manifest = new Map<string, string>();
+  const itemRe = /<item\b([^>]*)\/?>/gi;
+  let im: RegExpExecArray | null;
+  const opfDir = opfPath.includes('/') ? opfPath.slice(0, opfPath.lastIndexOf('/')) : '';
+  while ((im = itemRe.exec(manifestMatch[1])) !== null) {
+    const idMatch = im[1].match(/\bid\s*=\s*["']([^"']+)["']/i);
+    const hrefMatch = im[1].match(/\bhref\s*=\s*["']([^"']+)["']/i);
+    if (!idMatch || !hrefMatch) continue;
+    manifest.set(idMatch[1], resolveOpfRelative(opfDir, hrefMatch[1]));
+  }
+
+  // Walk spine itemrefs, collecting resolved paths in spine order.
+  const spineOrderedPaths: string[] = [];
+  const refRe = /<itemref\b([^>]*)\/?>/gi;
+  let rm: RegExpExecArray | null;
+  while ((rm = refRe.exec(spineMatch[1])) !== null) {
+    const idrefMatch = rm[1].match(/\bidref\s*=\s*["']([^"']+)["']/i);
+    if (!idrefMatch) continue;
+    const resolved = manifest.get(idrefMatch[1]);
+    if (resolved) spineOrderedPaths.push(resolved);
+  }
+  if (spineOrderedPaths.length === 0) return xhtmlFiles;
+
+  const filesByPath = new Map(xhtmlFiles.map((f) => [f.path, f]));
+  const seen = new Set<string>();
+  const ordered: PrhXhtmlFile[] = [];
+  for (const p of spineOrderedPaths) {
+    const f = filesByPath.get(p);
+    if (f && !seen.has(p)) {
+      ordered.push(f);
+      seen.add(p);
+    }
+  }
+  // Append any xhtml files not referenced by the spine (orphans).
+  for (const f of xhtmlFiles) {
+    if (!seen.has(f.path)) ordered.push(f);
+  }
+  return ordered;
+}
+
+function resolveOpfRelative(opfDir: string, href: string): string {
+  const combined = opfDir.length > 0 ? `${opfDir}/${href}` : href;
+  const segments = combined.split('/');
+  const out: string[] = [];
+  for (const seg of segments) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      out.pop();
+      continue;
+    }
+    out.push(seg);
+  }
+  return out.join('/');
+}
+
 interface SectionKindRule {
   /** Code to emit when the role is missing. */
   code: keyof typeof PRH_ISSUE_CODES;
@@ -85,10 +166,14 @@ const SECTION_RULES: SectionKindRule[] = [
 export function validatePrhDocAriaRoles(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
   const issues: PrhValidatorIssue[] = [];
 
+  // Order files by EPUB spine (authoritative reading order). Falls
+  // back to xhtmlFiles order when the spine can't be parsed.
+  const ordered = orderFilesBySpine(input.opfContent, input.opfPath, input.xhtmlFiles);
+
   // SLIM BOOK GUARD: count files that LOOK like chapter sections.
   // When we have zero or one chapter-shaped file, skip the chapter
   // check entirely (Q5 default).
-  const chapterCandidateCount = input.xhtmlFiles.filter((f) =>
+  const chapterCandidateCount = ordered.filter((f) =>
     SECTION_RULES[0].pathPattern.test(f.path),
   ).length;
 
@@ -97,11 +182,10 @@ export function validatePrhDocAriaRoles(input: PrhPerXhtmlInput): PrhValidatorIs
       continue;
     }
 
-    // FIRST-ONLY: find the first file matching the pattern. Files are
-    // walked in their natural xhtmlFiles order, which mirrors the zip
-    // entry order — close enough to "first by spine" without dragging
-    // OPF parsing into this validator.
-    const candidate = firstMatch(input.xhtmlFiles, rule.pathPattern);
+    // FIRST-ONLY: find the first file matching the pattern, in spine
+    // order. PRH's "Chapter 1 only" rule depends on reading-order
+    // "first", not zip-order "first".
+    const candidate = firstMatch(ordered, rule.pathPattern);
     if (!candidate) continue;
 
     if (!hasDocRole(candidate.content, rule.element, rule.docRole)) {

--- a/src/services/epub/profiles/prh-uk/validators/epub-type-placement-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/epub-type-placement-validator.ts
@@ -1,0 +1,159 @@
+/**
+ * PRH UK epub:type placement validator (P3/PR1).
+ *
+ * Per the Technical Guide §6.1, PRH's `epub:type` rules are stricter
+ * than the EPUB 3 spec:
+ *
+ *   - On `<body>`: only ONE of `cover` / `frontmatter` / `bodymatter` /
+ *     `backmatter` is allowed (the four transition points). Each of
+ *     those four MUST appear at most once across the entire EPUB.
+ *   - On `<section>`: the following values are FORBIDDEN — `chapter`,
+ *     `part`, `dedication`, `epigraph`, `appendix`, `prologue`,
+ *     `preface`, `acknowledgements`. PRH wants these expressed via
+ *     ARIA `role="doc-*"` instead (see doc-aria-roles-validator).
+ *   - Other section types (titlepage, copyright-page, footnotes,
+ *     endnotes, glossary, bibliography, index, toc, page-list, etc.)
+ *     are allowed.
+ *
+ * Issue codes:
+ *   - PRH-MARKUP-EPUB-TYPE-MISPLACED  — bad value on body or section
+ *   - PRH-MARKUP-EPUB-TYPE-DUPLICATE  — same transition type on multiple <body>
+ *
+ * Detect-only. Auto-fix (swap epub:type → role) lands in P5.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+/** epub:type values allowed on <body> per PRH spec. */
+const ALLOWED_BODY_EPUB_TYPES = new Set([
+  'cover',
+  'frontmatter',
+  'bodymatter',
+  'backmatter',
+]);
+
+/**
+ * epub:type values FORBIDDEN on <section>. PRH wants these expressed
+ * via `role="doc-*"` instead. Not exhaustive — only the values PRH
+ * explicitly calls out in Technical Guide §6.1.
+ */
+const FORBIDDEN_SECTION_EPUB_TYPES = new Set([
+  'chapter',
+  'part',
+  'dedication',
+  'epigraph',
+  'appendix',
+  'prologue',
+  'preface',
+  'acknowledgements',
+  'acknowledgments', // tolerate US spelling
+]);
+
+export function validatePrhEpubTypePlacement(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  /**
+   * Track which transition types we've seen on <body> across the EPUB.
+   * Used to fire DUPLICATE when the same transition appears twice
+   * (e.g. two files marked `<body epub:type="frontmatter">`).
+   */
+  const transitionTypeSeenIn = new Map<string, string[]>();
+
+  for (const file of input.xhtmlFiles) {
+    // ── <body epub:type="…"> ───────────────────────────────────────────
+    const bodyTypes = extractBodyEpubTypes(file.content);
+    if (bodyTypes !== null) {
+      for (const tok of bodyTypes) {
+        if (!ALLOWED_BODY_EPUB_TYPES.has(tok)) {
+          issues.push(buildIssue(
+            'PRH-MARKUP-EPUB-TYPE-MISPLACED',
+            `<body epub:type="${tok}"> is not allowed. PRH restricts body epub:type to one of: cover, frontmatter, bodymatter, backmatter.`,
+            `Move "${tok}" to the section level if it's a section type, or remove it if it duplicates the surrounding transition. Use role="doc-${tok.replace(/-page$/, '')}" if a doc-* ARIA role exists for this semantic.`,
+            file.path,
+          ));
+          continue;
+        }
+        // Track for duplicate detection.
+        const existing = transitionTypeSeenIn.get(tok);
+        if (existing) {
+          existing.push(file.path);
+        } else {
+          transitionTypeSeenIn.set(tok, [file.path]);
+        }
+      }
+    }
+
+    // ── <section epub:type="…"> ────────────────────────────────────────
+    // We don't want to walk every section node — that's costly on big
+    // books. A simple regex scan over <section ...> opening tags is
+    // sufficient for the forbidden-type check, because forbidden
+    // values only appear in `epub:type` attribute syntax. False
+    // positives from these values appearing INSIDE element text (e.g. a
+    // chapter title that contains the word "chapter") are not possible
+    // because we anchor on `epub:type="…"`.
+    const sectionOpenRe = /<section\b[^>]*\bepub:type\s*=\s*["']([^"']+)["']/gi;
+    let m: RegExpExecArray | null;
+    while ((m = sectionOpenRe.exec(file.content)) !== null) {
+      const tokens = m[1].split(/\s+/);
+      for (const tok of tokens) {
+        if (FORBIDDEN_SECTION_EPUB_TYPES.has(tok.toLowerCase())) {
+          issues.push(buildIssue(
+            'PRH-MARKUP-EPUB-TYPE-MISPLACED',
+            `<section epub:type="${tok}"> is forbidden by PRH. Replace with role="doc-${tok.toLowerCase()}" (no epub:type).`,
+            `Change <section epub:type="${tok}"> to <section role="doc-${tok.toLowerCase()}">. See Technical Guide §6.1.`,
+            file.path,
+          ));
+        }
+      }
+    }
+  }
+
+  // ── Duplicate transition types across <body> elements ────────────────
+  for (const [tok, paths] of transitionTypeSeenIn) {
+    if (paths.length > 1) {
+      // Emit one issue per duplicate occurrence (skip the first
+      // canonical use). The operator can keep one, drop the others.
+      for (let i = 1; i < paths.length; i += 1) {
+        issues.push(buildIssue(
+          'PRH-MARKUP-EPUB-TYPE-DUPLICATE',
+          `<body epub:type="${tok}"> appears in multiple files (${paths.join(', ')}). Each transition type must appear on at most one <body> across the EPUB.`,
+          `Keep <body epub:type="${tok}"> on ${paths[0]} and remove the attribute from ${paths[i]}.`,
+          paths[i],
+        ));
+      }
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Pull the lowercase token list from a `<body epub:type="…">` attribute.
+ * Returns `null` when the file has no body epub:type attribute (common
+ * for files that don't carry a transition marker — nav.xhtml, etc.).
+ */
+function extractBodyEpubTypes(html: string): string[] | null {
+  const m = html.match(/<body\b[^>]*\bepub:type\s*=\s*["']([^"']+)["']/i);
+  if (!m) return null;
+  return m[1].split(/\s+/).map((s) => s.toLowerCase()).filter(Boolean);
+}
+
+function buildIssue(
+  code: keyof typeof PRH_ISSUE_CODES,
+  message: string,
+  suggestion: string,
+  location: string,
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${message}`,
+    suggestion,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/epub-type-placement-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/epub-type-placement-validator.ts
@@ -64,7 +64,21 @@ export function validatePrhEpubTypePlacement(input: PrhPerXhtmlInput): PrhValida
     // ── <body epub:type="…"> ───────────────────────────────────────────
     const bodyTypes = extractBodyEpubTypes(file.content);
     if (bodyTypes !== null) {
-      for (const tok of bodyTypes) {
+      // Multi-token body epub:type ("frontmatter bodymatter") is
+      // nonsensical — a single file is either frontmatter OR
+      // bodymatter, not both — so reject it as MISPLACED before the
+      // per-token whitelist check. Without this guard, a
+      // `<body epub:type="cover bodymatter">` would silently pass
+      // because both tokens are in the whitelist.
+      if (bodyTypes.length !== 1) {
+        issues.push(buildIssue(
+          'PRH-MARKUP-EPUB-TYPE-MISPLACED',
+          `<body epub:type="${bodyTypes.join(' ')}"> declares ${bodyTypes.length} transition tokens. PRH requires exactly one of: cover, frontmatter, bodymatter, backmatter.`,
+          `Reduce <body epub:type="…"> to a single value matching the file's actual role (cover, frontmatter, bodymatter, or backmatter).`,
+          file.path,
+        ));
+      } else {
+        const tok = bodyTypes[0];
         if (!ALLOWED_BODY_EPUB_TYPES.has(tok)) {
           issues.push(buildIssue(
             'PRH-MARKUP-EPUB-TYPE-MISPLACED',
@@ -72,14 +86,16 @@ export function validatePrhEpubTypePlacement(input: PrhPerXhtmlInput): PrhValida
             `Move "${tok}" to the section level if it's a section type, or remove it if it duplicates the surrounding transition. Use role="doc-${tok.replace(/-page$/, '')}" if a doc-* ARIA role exists for this semantic.`,
             file.path,
           ));
-          continue;
-        }
-        // Track for duplicate detection.
-        const existing = transitionTypeSeenIn.get(tok);
-        if (existing) {
-          existing.push(file.path);
         } else {
-          transitionTypeSeenIn.set(tok, [file.path]);
+          // Track for duplicate detection (only when the value is
+          // valid — otherwise we'd track misplaced/multi-token values
+          // and spuriously fire DUPLICATE on the same file twice).
+          const existing = transitionTypeSeenIn.get(tok);
+          if (existing) {
+            existing.push(file.path);
+          } else {
+            transitionTypeSeenIn.set(tok, [file.path]);
+          }
         }
       }
     }

--- a/tests/unit/services/epub/profiles/prh-uk/validators/body-purity-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/body-purity-validator.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhBodyPurity } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/body-purity-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function file(path: string, bodyAttrs: string): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title></head>
+<body ${bodyAttrs}>body</body>
+</html>`,
+  };
+}
+
+describe('validatePrhBodyPurity', () => {
+  it('emits zero issues for a clean <body epub:type="bodymatter">', () => {
+    const files = [file('ch1.xhtml', 'epub:type="bodymatter"')];
+    expect(validatePrhBodyPurity(input(files))).toEqual([]);
+  });
+
+  it('emits PRH-BODY-HAS-ARIA when <body role="main">', () => {
+    const files = [file('ch1.xhtml', 'role="main"')];
+    const issues = validatePrhBodyPurity(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-BODY-HAS-ARIA');
+    expect(issues[0].location).toBe('ch1.xhtml');
+  });
+
+  it('emits PRH-BODY-HAS-ARIA when <body aria-label="…">', () => {
+    const files = [file('ch1.xhtml', 'aria-label="Chapter 1"')];
+    const issues = validatePrhBodyPurity(input(files));
+    expect(issues.find((i) => i.code === 'PRH-BODY-HAS-ARIA')).toBeDefined();
+  });
+
+  it('emits PRH-BODY-HAS-ARIA when <body aria-labelledby="…">', () => {
+    const files = [file('ch1.xhtml', 'aria-labelledby="title"')];
+    const issues = validatePrhBodyPurity(input(files));
+    expect(issues.find((i) => i.code === 'PRH-BODY-HAS-ARIA')).toBeDefined();
+  });
+
+  it('lists ALL offending attributes in the message when multiple are present', () => {
+    const files = [file('ch1.xhtml', 'role="main" aria-label="Chapter 1"')];
+    const issues = validatePrhBodyPurity(input(files));
+    expect(issues[0].message).toMatch(/role/);
+    expect(issues[0].message).toMatch(/aria-label/);
+  });
+
+  it('does NOT false-match data-role (must be exact word boundary)', () => {
+    const files = [file('ch1.xhtml', 'data-role="container"')];
+    expect(validatePrhBodyPurity(input(files))).toEqual([]);
+  });
+
+  it('skips files with no <body> element (defensive — malformed input)', () => {
+    const files: PrhXhtmlFile[] = [
+      { path: 'broken.xhtml', content: '<html><head></head></html>' },
+    ];
+    expect(validatePrhBodyPurity(input(files))).toEqual([]);
+  });
+
+  it('emits one issue per offending file (not per attribute)', () => {
+    const files = [
+      file('a.xhtml', 'role="main" aria-label="A"'),
+      file('b.xhtml', 'role="region"'),
+      file('c.xhtml', 'epub:type="bodymatter"'),
+    ];
+    const issues = validatePrhBodyPurity(input(files));
+    expect(issues).toHaveLength(2);
+    expect(issues.map((i) => i.location).sort()).toEqual(['a.xhtml', 'b.xhtml']);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/doc-aria-roles-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/doc-aria-roles-validator.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhDocAriaRoles } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/doc-aria-roles-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function fileWith(path: string, inner: string): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title></head>
+<body epub:type="bodymatter">${inner}</body>
+</html>`,
+  };
+}
+
+describe('validatePrhDocAriaRoles — chapter detection', () => {
+  it('emits PRH-ARIA-CHAPTER-ROLE-MISSING when first chapter section lacks role="doc-chapter"', () => {
+    const files = [
+      fileWith('chapter1.xhtml', '<section><h1>Chapter 1</h1></section>'),
+      fileWith('chapter2.xhtml', '<section><h1>Chapter 2</h1></section>'),
+    ];
+    const issues = validatePrhDocAriaRoles(input(files));
+    const issue = issues.find((i) => i.code === 'PRH-ARIA-CHAPTER-ROLE-MISSING');
+    expect(issue).toBeDefined();
+    expect(issue?.location).toBe('chapter1.xhtml');
+  });
+
+  it('does NOT emit when chapter1.xhtml has role="doc-chapter"', () => {
+    const files = [
+      fileWith('chapter1.xhtml', '<section role="doc-chapter"><h1>Chapter 1</h1></section>'),
+      fileWith('chapter2.xhtml', '<section><h1>Chapter 2</h1></section>'),
+    ];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues.find((i) => i.code === 'PRH-ARIA-CHAPTER-ROLE-MISSING')).toBeUndefined();
+  });
+
+  it('emits chapter issue AT MOST ONCE per EPUB (first-only rule)', () => {
+    const files = [
+      fileWith('chapter1.xhtml', '<section><h1>Chapter 1</h1></section>'),
+      fileWith('chapter2.xhtml', '<section><h1>Chapter 2</h1></section>'),
+      fileWith('chapter3.xhtml', '<section><h1>Chapter 3</h1></section>'),
+    ];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues.filter((i) => i.code === 'PRH-ARIA-CHAPTER-ROLE-MISSING')).toHaveLength(1);
+  });
+
+  it('SKIPS chapter check when only one chapter-shaped file exists (slim book guard)', () => {
+    const files = [fileWith('chapter1.xhtml', '<section><h1>Chapter 1</h1></section>')];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues.find((i) => i.code === 'PRH-ARIA-CHAPTER-ROLE-MISSING')).toBeUndefined();
+  });
+
+  it('SKIPS chapter check when no chapter-shaped files exist (essay / memoir)', () => {
+    const files = [fileWith('content.xhtml', '<section><h1>Body</h1></section>')];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues.find((i) => i.code === 'PRH-ARIA-CHAPTER-ROLE-MISSING')).toBeUndefined();
+  });
+});
+
+describe('validatePrhDocAriaRoles — part / dedication / appendix detection', () => {
+  it('emits PRH-ARIA-PART-ROLE-MISSING when part1.xhtml lacks role="doc-part"', () => {
+    const files = [fileWith('part1.xhtml', '<section><h1>Part 1</h1></section>')];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues.find((i) => i.code === 'PRH-ARIA-PART-ROLE-MISSING')).toBeDefined();
+  });
+
+  it('emits PRH-ARIA-DEDICATION-ROLE-MISSING when dedication.xhtml lacks role', () => {
+    const files = [fileWith('dedication.xhtml', '<section>To my mother</section>')];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues.find((i) => i.code === 'PRH-ARIA-DEDICATION-ROLE-MISSING')).toBeDefined();
+  });
+
+  it('emits PRH-ARIA-APPENDIX-ROLE-MISSING when appendix.xhtml lacks role', () => {
+    const files = [fileWith('appendix.xhtml', '<section>Appendix A</section>')];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues.find((i) => i.code === 'PRH-ARIA-APPENDIX-ROLE-MISSING')).toBeDefined();
+  });
+
+  it('does NOT emit when the role is correctly set on each section', () => {
+    const files = [
+      fileWith('part1.xhtml', '<section role="doc-part"><h1>Part 1</h1></section>'),
+      fileWith('dedication.xhtml', '<section role="doc-dedication">To my mother</section>'),
+      fileWith('appendix.xhtml', '<section role="doc-appendix">Appendix A</section>'),
+    ];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('validatePrhDocAriaRoles — epigraph (blockquote, not section)', () => {
+  it('emits PRH-ARIA-EPIGRAPH-ROLE-MISSING when epigraph.xhtml blockquote lacks role', () => {
+    const files = [fileWith('epigraph.xhtml', '<blockquote>“Quote.”</blockquote>')];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues.find((i) => i.code === 'PRH-ARIA-EPIGRAPH-ROLE-MISSING')).toBeDefined();
+  });
+
+  it('does NOT emit when blockquote carries role="doc-epigraph"', () => {
+    const files = [fileWith('epigraph.xhtml', '<blockquote role="doc-epigraph">“Quote.”</blockquote>')];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues.find((i) => i.code === 'PRH-ARIA-EPIGRAPH-ROLE-MISSING')).toBeUndefined();
+  });
+
+  it('does NOT emit when epigraph.xhtml has no <blockquote> at all (different layout)', () => {
+    // If the file doesn't contain the target element, the validator
+    // can't enforce — emitting would be noise. Better to stay silent.
+    const files = [fileWith('epigraph.xhtml', '<p>quote</p>')];
+    const issues = validatePrhDocAriaRoles(input(files));
+    expect(issues.find((i) => i.code === 'PRH-ARIA-EPIGRAPH-ROLE-MISSING')).toBeUndefined();
+  });
+});
+
+describe('validatePrhDocAriaRoles — multi-value role attributes', () => {
+  it('accepts role="doc-chapter region" (multi-value)', () => {
+    const files = [
+      fileWith('chapter1.xhtml', '<section role="doc-chapter region"><h1>C1</h1></section>'),
+      fileWith('chapter2.xhtml', '<section role="doc-chapter region"><h1>C2</h1></section>'),
+    ];
+    expect(validatePrhDocAriaRoles(input(files))).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/doc-aria-roles-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/doc-aria-roles-validator.test.ts
@@ -127,3 +127,43 @@ describe('validatePrhDocAriaRoles — multi-value role attributes', () => {
     expect(validatePrhDocAriaRoles(input(files))).toEqual([]);
   });
 });
+
+describe('validatePrhDocAriaRoles — spine-order "first" detection (regression)', () => {
+  it('uses spine order, not zip order, when picking the FIRST chapter', () => {
+    // Zip order: chapter2.xhtml first, then chapter1.xhtml.
+    // Spine order: chapter1 → chapter2.
+    // The validator should flag chapter1.xhtml (spine "first"), not
+    // chapter2.xhtml (zip "first").
+    const opf = `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <manifest>
+    <item id="ch1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ch2" href="chapter2.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+    <itemref idref="ch2"/>
+  </spine>
+</package>`;
+    const input = {
+      opfContent: opf,
+      opfPath: 'EPUB/package.opf',
+      bookTitle: 'Test',
+      xhtmlFiles: [
+        // Reversed order — zip puts chapter2 first.
+        {
+          path: 'EPUB/chapter2.xhtml',
+          content: '<html xmlns:epub="http://www.idpf.org/2007/ops"><body epub:type="bodymatter"><section role="doc-chapter"><h1>Ch 2</h1></section></body></html>',
+        },
+        {
+          path: 'EPUB/chapter1.xhtml',
+          content: '<html xmlns:epub="http://www.idpf.org/2007/ops"><body epub:type="bodymatter"><section><h1>Ch 1</h1></section></body></html>',
+        },
+      ],
+    };
+    const issues = validatePrhDocAriaRoles(input);
+    const issue = issues.find((i) => i.code === 'PRH-ARIA-CHAPTER-ROLE-MISSING');
+    expect(issue).toBeDefined();
+    expect(issue?.location).toBe('EPUB/chapter1.xhtml');
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/epub-type-placement-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/epub-type-placement-validator.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhEpubTypePlacement } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/epub-type-placement-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function file(path: string, bodyAttrs: string, inner: string = ''): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title></head>
+<body ${bodyAttrs}>${inner}</body>
+</html>`,
+  };
+}
+
+describe('validatePrhEpubTypePlacement — body epub:type whitelist', () => {
+  it('emits zero issues for canonical transition types on <body>', () => {
+    const files = [
+      file('cover.xhtml', 'epub:type="cover"'),
+      file('title.xhtml', 'epub:type="frontmatter"'),
+      file('chapter1.xhtml', 'epub:type="bodymatter"'),
+      file('about.xhtml', 'epub:type="backmatter"'),
+    ];
+    expect(validatePrhEpubTypePlacement(input(files))).toEqual([]);
+  });
+
+  it('emits PRH-MARKUP-EPUB-TYPE-MISPLACED for non-transition values on <body>', () => {
+    const files = [file('chapter1.xhtml', 'epub:type="chapter"')];
+    const issues = validatePrhEpubTypePlacement(input(files));
+    expect(issues.find((i) => i.code === 'PRH-MARKUP-EPUB-TYPE-MISPLACED')).toBeDefined();
+  });
+
+  it('emits MISPLACED for "titlepage" on <body> (should be on section)', () => {
+    const files = [file('title.xhtml', 'epub:type="titlepage"')];
+    const issues = validatePrhEpubTypePlacement(input(files));
+    expect(issues.find((i) => i.code === 'PRH-MARKUP-EPUB-TYPE-MISPLACED')).toBeDefined();
+  });
+
+  it('does NOT fire on files with no body epub:type', () => {
+    const files = [file('nav.xhtml', '')];
+    expect(validatePrhEpubTypePlacement(input(files))).toEqual([]);
+  });
+});
+
+describe('validatePrhEpubTypePlacement — duplicate transitions across <body>', () => {
+  it('emits PRH-MARKUP-EPUB-TYPE-DUPLICATE when frontmatter appears twice', () => {
+    const files = [
+      file('cover.xhtml', 'epub:type="frontmatter"'),
+      file('title.xhtml', 'epub:type="frontmatter"'),
+    ];
+    const issues = validatePrhEpubTypePlacement(input(files));
+    const dup = issues.find((i) => i.code === 'PRH-MARKUP-EPUB-TYPE-DUPLICATE');
+    expect(dup).toBeDefined();
+    expect(dup?.location).toBe('title.xhtml');
+  });
+
+  it('emits one DUPLICATE per extra occurrence (not just one issue regardless of count)', () => {
+    const files = [
+      file('cover.xhtml', 'epub:type="frontmatter"'),
+      file('a.xhtml', 'epub:type="frontmatter"'),
+      file('b.xhtml', 'epub:type="frontmatter"'),
+    ];
+    const issues = validatePrhEpubTypePlacement(input(files));
+    const dups = issues.filter((i) => i.code === 'PRH-MARKUP-EPUB-TYPE-DUPLICATE');
+    expect(dups).toHaveLength(2);
+  });
+
+  it('does NOT emit DUPLICATE when each transition appears once', () => {
+    const files = [
+      file('cover.xhtml', 'epub:type="cover"'),
+      file('title.xhtml', 'epub:type="frontmatter"'),
+      file('chapter1.xhtml', 'epub:type="bodymatter"'),
+      file('about.xhtml', 'epub:type="backmatter"'),
+    ];
+    const issues = validatePrhEpubTypePlacement(input(files));
+    expect(issues.find((i) => i.code === 'PRH-MARKUP-EPUB-TYPE-DUPLICATE')).toBeUndefined();
+  });
+});
+
+describe('validatePrhEpubTypePlacement — section epub:type forbidden list', () => {
+  it('emits MISPLACED for <section epub:type="chapter">', () => {
+    const files = [file('chapter1.xhtml', 'epub:type="bodymatter"', '<section epub:type="chapter"><h1>Ch 1</h1></section>')];
+    const issues = validatePrhEpubTypePlacement(input(files));
+    expect(issues.find((i) => i.code === 'PRH-MARKUP-EPUB-TYPE-MISPLACED' && /section epub:type="chapter"/.test(i.message))).toBeDefined();
+  });
+
+  it('emits MISPLACED for each forbidden section type: part, dedication, epigraph, appendix', () => {
+    const files = [
+      file('part1.xhtml', 'epub:type="bodymatter"', '<section epub:type="part"><h1>Part 1</h1></section>'),
+      file('dedication.xhtml', 'epub:type="frontmatter"', '<section epub:type="dedication">To my mother</section>'),
+      file('epigraph.xhtml', 'epub:type="frontmatter"', '<section epub:type="epigraph"><blockquote>quote</blockquote></section>'),
+      file('appendix.xhtml', 'epub:type="backmatter"', '<section epub:type="appendix">Appendix A</section>'),
+    ];
+    const issues = validatePrhEpubTypePlacement(input(files));
+    const misplaced = issues.filter((i) => i.code === 'PRH-MARKUP-EPUB-TYPE-MISPLACED');
+    expect(misplaced.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('does NOT emit on allowed section types (titlepage, copyright-page, footnotes)', () => {
+    // Use one file per transition type — duplicates on body would
+    // fire PRH-MARKUP-EPUB-TYPE-DUPLICATE which is a separate rule.
+    const files = [
+      file('title.xhtml', 'epub:type="frontmatter"', '<section epub:type="titlepage">T</section><section epub:type="copyright-page">C</section>'),
+      file('notes.xhtml', 'epub:type="backmatter"', '<section epub:type="footnotes">F</section>'),
+    ];
+    expect(validatePrhEpubTypePlacement(input(files))).toEqual([]);
+  });
+
+  it('tolerates US spelling "acknowledgments" as forbidden too', () => {
+    const files = [file('ack.xhtml', 'epub:type="backmatter"', '<section epub:type="acknowledgments">Thanks</section>')];
+    const issues = validatePrhEpubTypePlacement(input(files));
+    expect(issues.find((i) => i.code === 'PRH-MARKUP-EPUB-TYPE-MISPLACED')).toBeDefined();
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/epub-type-placement-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/epub-type-placement-validator.test.ts
@@ -49,6 +49,29 @@ describe('validatePrhEpubTypePlacement — body epub:type whitelist', () => {
     const files = [file('nav.xhtml', '')];
     expect(validatePrhEpubTypePlacement(input(files))).toEqual([]);
   });
+
+  it('rejects multi-token body epub:type ("frontmatter bodymatter") even when each token is in the whitelist (regression)', () => {
+    // A single body can't simultaneously be two transitions. Without
+    // the multi-token guard, both whitelisted tokens would silently
+    // pass and inflate the duplicate-detection state.
+    const files = [file('weird.xhtml', 'epub:type="frontmatter bodymatter"')];
+    const issues = validatePrhEpubTypePlacement(input(files));
+    const misplaced = issues.find((i) => i.code === 'PRH-MARKUP-EPUB-TYPE-MISPLACED');
+    expect(misplaced).toBeDefined();
+    expect(misplaced?.message).toMatch(/2 transition tokens/i);
+  });
+
+  it('multi-token rejection does NOT also fire DUPLICATE on later legitimate uses', () => {
+    // Regression: the duplicate tracker should not count the
+    // multi-token file's tokens — otherwise a subsequent
+    // <body epub:type="frontmatter"> would falsely fire DUPLICATE.
+    const files = [
+      file('weird.xhtml', 'epub:type="frontmatter bodymatter"'),
+      file('legitimate.xhtml', 'epub:type="frontmatter"'),
+    ];
+    const issues = validatePrhEpubTypePlacement(input(files));
+    expect(issues.find((i) => i.code === 'PRH-MARKUP-EPUB-TYPE-DUPLICATE')).toBeUndefined();
+  });
 });
 
 describe('validatePrhEpubTypePlacement — duplicate transitions across <body>', () => {


### PR DESCRIPTION
## Summary

First P3 PR — adds the **publisher-gated** markup-conventions layer. Three validators, 8 new codes. Per Technical Guide §6.1.

This is the first PRH validator family that gates on `publisher === 'PRH-UK'` ALONE (not imprint). Markup rules apply equally to every PRH UK build, including multi-imprint demo docs that resolve to `imprint: unknown`.

## New validators

| Validator | Codes |
|---|---|
| `validatePrhEpubTypePlacement` | `PRH-MARKUP-EPUB-TYPE-MISPLACED`, `PRH-MARKUP-EPUB-TYPE-DUPLICATE` |
| `validatePrhDocAriaRoles` | `PRH-ARIA-CHAPTER-ROLE-MISSING`, `PRH-ARIA-PART-ROLE-MISSING`, `PRH-ARIA-DEDICATION-ROLE-MISSING`, `PRH-ARIA-EPIGRAPH-ROLE-MISSING`, `PRH-ARIA-APPENDIX-ROLE-MISSING` |
| `validatePrhBodyPurity` | `PRH-BODY-HAS-ARIA` |

## Rules enforced

- **`<body>` epub:type whitelist**: only `cover` / `frontmatter` / `bodymatter` / `backmatter`. Each transition allowed at most once across the entire EPUB.
- **`<section>` epub:type forbidden list**: `chapter`, `part`, `dedication`, `epigraph`, `appendix`, `prologue`, `preface`, `acknowledg(e)ments`. Use the matching `role="doc-*"` ARIA role instead.
- **First-of-type doc-\* ARIA roles**: chapter / part / dedication / appendix sections need their respective `doc-*` role on the FIRST section file. Epigraph needs it on a `<blockquote>`.
- **`<body>` purity**: no `role`, `aria-label`, or `aria-labelledby` on `<body>` ever.

## Scoping decisions baked in

| Decision | Implementation |
|---|---|
| Publisher gate (not imprint) | New conditional in `run-validators.ts` gated on `publisher === 'PRH-UK' && confidence !== 'low'` |
| First-only ARIA rule | At most one issue per section type per EPUB |
| Slim-book guard | Chapter check skipped when ≤1 chapter-shaped file exists |
| FP tolerance | Conservative filename anchors with token boundaries (no false-match on `discover.xhtml`, `data-role`, etc.) |

## Test plan

- [x] 252/252 PRH unit tests passing (32 new across the three validators)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke test against a real Penguin EPUB
- [ ] Staging smoke test: PRH Branding Guide (multi-imprint demo) — should NOW fire these validators (unlike P2) and the count should be small for a Branding Guide reference doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced EPUB validation for PRH UK: detects misplaced/duplicate epub:type on body/section, checks required doc-* ARIA roles (chapter, part, dedication, epigraph, appendix), and enforces body purity (disallowing role/aria-label/aria-labelledby on <body>).
  * Added WCAG mappings for all new PRH checks.

* **Tests**
  * Comprehensive unit tests covering placement, duplication, role presence, body-attribute purity, and spine-order behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/369)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->