### PR TITLE
feat(prh): forbidden tags + inline-style + layout-table (P3/PR2)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -425,6 +425,32 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: '<body> must NOT carry role / aria-label / aria-labelledby (PRH explicitly prohibits)',
   },
+
+  // ── Forbidden constructs (P3/PR2) ─────────────────────────────────────
+  // Publisher-gated. Detect-only — auto-fix (swap <b>→<strong>, etc.)
+  // is a P5 concern because the semantic intent isn't always
+  // mechanically recoverable.
+  'PRH-MARKUP-DEPRECATED-TAG': {
+    code: 'PRH-MARKUP-DEPRECATED-TAG',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Body contains deprecated presentational tags (<b>, <i>, <big>, <small>, <u>, <strike>, <center>, <font>) — PRH requires semantic tags (<strong>, <em>) instead',
+  },
+  'PRH-MARKUP-INLINE-STYLE': {
+    code: 'PRH-MARKUP-INLINE-STYLE',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Body element carries inline style attribute — PRH requires styles in CSS, not inline (Technical Guide §15 allows one demo per book; we flag every instance)',
+  },
+  'PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION': {
+    code: 'PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION',
+    severity: 'minor',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'Likely layout <table> (no <th>, ≥6 cells, not marked role="presentation") — PRH requires layout tables to declare role="presentation"',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/wcag-issue-mapper.service.ts
+++ b/src/services/acr/wcag-issue-mapper.service.ts
@@ -115,6 +115,11 @@ export const RULE_TO_CRITERIA_MAP: Record<string, string[]> = {
   'PRH-ARIA-APPENDIX-ROLE-MISSING': ['1.3.1'],
   'PRH-BODY-HAS-ARIA': ['4.1.2'],
 
+  // Forbidden constructs (P3/PR2)
+  'PRH-MARKUP-DEPRECATED-TAG': [],
+  'PRH-MARKUP-INLINE-STYLE': [],
+  'PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION': ['1.3.1'],
+
   // ============= STANDARD ACE RULES =============
   // Images and Non-text Content
   'img-alt': ['1.1.1'],

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -24,6 +24,9 @@ import { validatePrhContentOrder } from './validators/content-order-validator';
 import { validatePrhEpubTypePlacement } from './validators/epub-type-placement-validator';
 import { validatePrhDocAriaRoles } from './validators/doc-aria-roles-validator';
 import { validatePrhBodyPurity } from './validators/body-purity-validator';
+import { validatePrhForbiddenTags } from './validators/forbidden-tags-validator';
+import { validatePrhInlineStyles } from './validators/inline-style-validator';
+import { validatePrhLayoutTables } from './validators/layout-table-validator';
 import { getImprintRules } from './imprints';
 import type { PublisherProfile } from '../types';
 import type { PrhValidatorIssue, PrhXhtmlFile } from './validators/types';
@@ -90,6 +93,9 @@ export async function runPrhUkValidators(
         ...validatePrhEpubTypePlacement(perXhtmlInput),
         ...validatePrhDocAriaRoles(perXhtmlInput),
         ...validatePrhBodyPurity(perXhtmlInput),
+        ...validatePrhForbiddenTags(perXhtmlInput),
+        ...validatePrhInlineStyles(perXhtmlInput),
+        ...validatePrhLayoutTables(perXhtmlInput),
       );
     }
 

--- a/src/services/epub/profiles/prh-uk/validators/forbidden-tags-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/forbidden-tags-validator.ts
@@ -1,0 +1,93 @@
+/**
+ * PRH UK forbidden-tags validator (P3/PR2).
+ *
+ * Per Technical Guide §6.2, PRH bans the following presentational
+ * tags everywhere in body content:
+ *   <b>     — use <strong>
+ *   <i>     — use <em>
+ *   <big>   — drop or restyle via CSS
+ *   <small> — drop or restyle via CSS
+ *   <u>     — discouraged (looks like a link); restyle via CSS class
+ *   <strike>/<s> — use <del> with explanatory text where semantically valid
+ *   <center>— layout via CSS
+ *   <font>  — layout via CSS
+ *
+ * Real PRH books that pre-date the current Style Guide carry these
+ * legacy tags routinely — a single book can fire 50–300 instances.
+ * To keep the issue list manageable we emit ONE issue per offending
+ * file with the aggregate count, not one issue per tag occurrence.
+ * The FE grouping prompt (P2-P3-Frontend-Followups Prompt 7) will
+ * collapse multiple files into a single header row.
+ *
+ * Issue code: PRH-MARKUP-DEPRECATED-TAG. Detect-only (auto-swap
+ * <b>→<strong> lands in P5 where we can review semantic intent).
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+/** Deprecated / forbidden tags. Order is irrelevant. */
+const FORBIDDEN_TAGS = ['b', 'i', 'big', 'small', 'u', 'strike', 's', 'center', 'font'] as const;
+
+/**
+ * Single regex per tag that matches the opening tag in body content.
+ * Boundary on the character following the tag name so `<b>` matches
+ * but `<body>` / `<br>` / `<blockquote>` don't.
+ *
+ * Self-closing variants (`<i/>`) are uncommon in XHTML but tolerated.
+ */
+const FORBIDDEN_TAG_REGEXES: Record<string, RegExp> = Object.fromEntries(
+  FORBIDDEN_TAGS.map((tag) => [tag, new RegExp(`<${tag}(?=[\\s/>])`, 'gi')]),
+);
+
+export function validatePrhForbiddenTags(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  for (const file of input.xhtmlFiles) {
+    // Strip <head>…</head> before scanning — `<style>` / `<title>`
+    // shouldn't be examined as body content, and head-resident styles
+    // can carry forbidden tag NAMES in CSS selectors (e.g. a stylesheet
+    // that selects `b { font-weight: ... }`). Body-only scope avoids
+    // false positives there.
+    const body = stripHead(file.content);
+
+    const counts: Record<string, number> = {};
+    let total = 0;
+    for (const tag of FORBIDDEN_TAGS) {
+      // Reset the regex `lastIndex` for global regexes between files.
+      FORBIDDEN_TAG_REGEXES[tag].lastIndex = 0;
+      const matches = body.match(FORBIDDEN_TAG_REGEXES[tag]);
+      if (matches && matches.length > 0) {
+        counts[tag] = matches.length;
+        total += matches.length;
+      }
+    }
+    if (total === 0) continue;
+
+    const breakdown = Object.entries(counts)
+      .map(([tag, n]) => `<${tag}>×${n}`)
+      .join(', ');
+    issues.push(buildIssue(file.path, total, breakdown));
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function stripHead(html: string): string {
+  return html.replace(/<head\b[^>]*>[\s\S]*?<\/head>/i, '');
+}
+
+function buildIssue(location: string, total: number, breakdown: string): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES['PRH-MARKUP-DEPRECATED-TAG'];
+  return {
+    code: 'PRH-MARKUP-DEPRECATED-TAG',
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location} contains ${total} deprecated tag(s) — ${breakdown}.`,
+    suggestion:
+      `Replace <b>/<i> with semantic <strong>/<em>; drop <big>/<small>/<font>/<center> and restyle via CSS; reserve <u> for genuine semantic underlines (rare). See Technical Guide §6.2.`,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/inline-style-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/inline-style-validator.ts
@@ -1,0 +1,64 @@
+/**
+ * PRH UK inline-style validator (P3/PR2).
+ *
+ * Per Technical Guide §15, PRH disallows inline `style="…"` attributes
+ * on body content. The spec carves out one demonstration exception
+ * per book, but in practice operators copy patterns across chapters
+ * and the carve-out is hard to enforce. We flag every occurrence and
+ * surface the count — the operator can dismiss expected demo cases
+ * via the FE dismiss workflow (see P2-P3-Frontend-Followups Prompt 9).
+ *
+ * Issue code: PRH-MARKUP-INLINE-STYLE. One issue per offending file
+ * with the aggregate count. Same shape as forbidden-tags-validator so
+ * the FE grouping treatment works identically. Detect-only — auto-fix
+ * (extract to CSS class) is risky and lands in P5.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+/**
+ * Matches `style="…"` (or `style='…'`) on ANY element. The leading
+ * anchor MUST be start-of-string or whitespace — using `\b` alone
+ * would false-match `data-style`/`data-base-style` because the
+ * regex-word-boundary `\b` lands between `-` and `s` (transition
+ * from non-word to word). Whitespace anchoring is how HTML
+ * attributes actually serialise, so this is both stricter and more
+ * accurate.
+ *
+ * The regex deliberately operates on the entire file (head + body)
+ * because PRH bans inline style globally; we don't want to miss head-
+ * level <link rel="stylesheet" style=""> oddities. False positives on
+ * `<style>…</style>` ELEMENTS aren't possible because we require an
+ * `=` sign after `style`.
+ */
+const INLINE_STYLE_REGEX = /(?:^|\s)style\s*=\s*["'][^"']*["']/gi;
+
+export function validatePrhInlineStyles(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  for (const file of input.xhtmlFiles) {
+    INLINE_STYLE_REGEX.lastIndex = 0;
+    const matches = file.content.match(INLINE_STYLE_REGEX);
+    if (!matches || matches.length === 0) continue;
+
+    issues.push(buildIssue(file.path, matches.length));
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function buildIssue(location: string, count: number): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES['PRH-MARKUP-INLINE-STYLE'];
+  return {
+    code: 'PRH-MARKUP-INLINE-STYLE',
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location} contains ${count} inline style attribute(s).`,
+    suggestion:
+      `Move per-element style declarations into a CSS class in your stylesheet (see Technical Guide §15). PRH allows one demonstration inline style per book; dismiss this issue if the affected element is the one demo case.`,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/layout-table-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/layout-table-validator.ts
@@ -41,8 +41,13 @@ export function validatePrhLayoutTables(input: PrhPerXhtmlInput): PrhValidatorIs
       const innerHtml = m[2];
 
       // Skip if the table declares role="presentation" (or "none" —
-      // ARIA treats them as synonyms for "no semantic role").
-      const roleMatch = openAttrs.match(/\brole\s*=\s*["']([^"']+)["']/i);
+      // ARIA treats them as synonyms for "no semantic role"). The
+      // leading anchor MUST be start-of-string or whitespace, NOT
+      // `\b`: `\b` would land between `-` and `r` in `data-role`,
+      // letting a `data-role="presentation"` metadata attribute
+      // silently suppress the issue. Whitespace anchoring is how
+      // HTML attributes actually serialise.
+      const roleMatch = openAttrs.match(/(?:^|\s)role\s*=\s*["']([^"']+)["']/i);
       if (roleMatch) {
         const tokens = roleMatch[1].split(/\s+/).map((t) => t.toLowerCase());
         if (tokens.includes('presentation') || tokens.includes('none')) continue;

--- a/src/services/epub/profiles/prh-uk/validators/layout-table-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/layout-table-validator.ts
@@ -1,0 +1,84 @@
+/**
+ * PRH UK layout-table validator (P3/PR2).
+ *
+ * Per Technical Guide §6.2, layout tables are forbidden EXCEPT when
+ * they declare `role="presentation"` (the dialogue-table pattern is
+ * the canonical example). A `<table>` without any `<th>` AND without
+ * `role="presentation"` is therefore likely a layout table.
+ *
+ * Heuristic + threshold to keep false-positive rate manageable:
+ *   - Skip <table> with `role="presentation"` (or `role="none"`).
+ *   - Skip <table> with at least one `<th>` (legitimate data table —
+ *     ACE's own EPUB-STRUCT-002 covers the "no <th>" case separately,
+ *     so we don't compete with that rule).
+ *   - Require ≥6 cells before flagging. Small 2–3 cell tables in
+ *     fiction (recipe ingredients lists, dedications, ornament rows)
+ *     genuinely lack <th> without being layout tables.
+ *   - One issue per offending table, with the file as the location
+ *     and a 1-based table index in the message.
+ *
+ * Issue code: PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION. Detect-only.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+/** Minimum cell count before a no-<th> table is considered layout. */
+const LAYOUT_TABLE_MIN_CELLS = 6;
+
+export function validatePrhLayoutTables(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  for (const file of input.xhtmlFiles) {
+    // Find each <table>…</table> block. The regex is non-greedy so
+    // nested or sibling tables are handled independently.
+    const tableRe = /<table\b([^>]*)>([\s\S]*?)<\/table>/gi;
+    let m: RegExpExecArray | null;
+    let tableIndex = 0;
+    while ((m = tableRe.exec(file.content)) !== null) {
+      tableIndex += 1;
+      const openAttrs = m[1];
+      const innerHtml = m[2];
+
+      // Skip if the table declares role="presentation" (or "none" —
+      // ARIA treats them as synonyms for "no semantic role").
+      const roleMatch = openAttrs.match(/\brole\s*=\s*["']([^"']+)["']/i);
+      if (roleMatch) {
+        const tokens = roleMatch[1].split(/\s+/).map((t) => t.toLowerCase());
+        if (tokens.includes('presentation') || tokens.includes('none')) continue;
+      }
+
+      // Skip if the table has at least one <th>. The "no <th>" case
+      // is covered by a separate accessibility rule (EPUB-STRUCT-002);
+      // we focus on the layout-table-without-presentation gap PRH
+      // calls out.
+      if (/<th\b/i.test(innerHtml)) continue;
+
+      // Count cells. We treat <td> as the canonical cell tag — a
+      // layout table by definition has no <th>, so <td> count alone
+      // is the heuristic threshold.
+      const cellMatches = innerHtml.match(/<td\b/gi);
+      const cellCount = cellMatches ? cellMatches.length : 0;
+      if (cellCount < LAYOUT_TABLE_MIN_CELLS) continue;
+
+      issues.push(buildIssue(file.path, tableIndex, cellCount));
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function buildIssue(location: string, tableIndex: number, cellCount: number): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES['PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION'];
+  return {
+    code: 'PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION',
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location} table #${tableIndex} (${cellCount} cells, no <th>) is likely a layout table and must declare role="presentation".`,
+    suggestion:
+      `If this is a layout table (e.g. dialogue, sidebar arrangement), add role="presentation" to the <table>. If it's a data table, add header cells with <th scope="col"> / <th scope="row"> per Technical Guide §6.3.`,
+    location,
+  };
+}

--- a/tests/unit/services/epub/profiles/prh-uk/validators/forbidden-tags-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/forbidden-tags-validator.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhForbiddenTags } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/forbidden-tags-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function file(path: string, body: string): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title><style>b { color: red; }</style></head>
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+describe('validatePrhForbiddenTags', () => {
+  it('emits zero issues for clean semantic markup', () => {
+    const files = [file('ch1.xhtml', '<p>Clean <strong>bold</strong> and <em>italic</em>.</p>')];
+    expect(validatePrhForbiddenTags(input(files))).toEqual([]);
+  });
+
+  it('emits PRH-MARKUP-DEPRECATED-TAG for <b> usage', () => {
+    const files = [file('ch1.xhtml', '<p><b>bold</b></p>')];
+    const issues = validatePrhForbiddenTags(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-MARKUP-DEPRECATED-TAG');
+    expect(issues[0].location).toBe('ch1.xhtml');
+    expect(issues[0].message).toMatch(/<b>×1/);
+  });
+
+  it('aggregates counts across multiple deprecated tags in the same file', () => {
+    const files = [file('ch1.xhtml', '<p><b>a</b><i>b</i><b>c</b><font>d</font></p>')];
+    const issues = validatePrhForbiddenTags(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/<b>×2/);
+    expect(issues[0].message).toMatch(/<i>×1/);
+    expect(issues[0].message).toMatch(/<font>×1/);
+  });
+
+  it('emits ONE issue per offending file (not per tag occurrence)', () => {
+    const files = [
+      file('a.xhtml', '<p><b>x</b><b>y</b><b>z</b></p>'),
+      file('b.xhtml', '<p><i>x</i><i>y</i></p>'),
+      file('clean.xhtml', '<p>clean</p>'),
+    ];
+    const issues = validatePrhForbiddenTags(input(files));
+    expect(issues).toHaveLength(2);
+    expect(issues.map((i) => i.location).sort()).toEqual(['a.xhtml', 'b.xhtml']);
+  });
+
+  it('does NOT false-match <body>, <br>, <blockquote> (tag-boundary check)', () => {
+    const files = [file('ch.xhtml', '<blockquote>quote</blockquote><br/>')];
+    expect(validatePrhForbiddenTags(input(files))).toEqual([]);
+  });
+
+  it('does NOT match deprecated tag names inside <style> in head', () => {
+    // The compliance-clean body still uses <strong>; the head has
+    // `b { color: red; }` CSS which the validator MUST ignore.
+    const files = [file('ch.xhtml', '<p><strong>bold</strong></p>')];
+    expect(validatePrhForbiddenTags(input(files))).toEqual([]);
+  });
+
+  it('catches all deprecated tags (b/i/big/small/u/strike/s/center/font)', () => {
+    const files = [
+      file(
+        'ch.xhtml',
+        '<p><b>a</b><i>b</i><big>c</big><small>d</small><u>e</u><strike>f</strike><s>g</s><center>h</center><font>i</font></p>',
+      ),
+    ];
+    const issues = validatePrhForbiddenTags(input(files));
+    expect(issues).toHaveLength(1);
+    // Total should be 9 tags.
+    expect(issues[0].message).toMatch(/9 deprecated tag/);
+  });
+
+  it('matches self-closing tag variants (e.g. <b/>)', () => {
+    const files = [file('ch.xhtml', '<p><b/>empty<i/></p>')];
+    const issues = validatePrhForbiddenTags(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/<b>×1/);
+    expect(issues[0].message).toMatch(/<i>×1/);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/inline-style-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/inline-style-validator.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhInlineStyles } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/inline-style-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function file(path: string, body: string): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title></head>
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+describe('validatePrhInlineStyles', () => {
+  it('emits zero issues for clean markup (no inline styles)', () => {
+    const files = [file('ch.xhtml', '<p class="text">clean</p>')];
+    expect(validatePrhInlineStyles(input(files))).toEqual([]);
+  });
+
+  it('emits PRH-MARKUP-INLINE-STYLE for a single style attribute', () => {
+    const files = [file('ch.xhtml', '<p style="color: red">red</p>')];
+    const issues = validatePrhInlineStyles(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-MARKUP-INLINE-STYLE');
+    expect(issues[0].location).toBe('ch.xhtml');
+    expect(issues[0].message).toMatch(/1 inline style/);
+  });
+
+  it('aggregates count across multiple inline styles in the same file', () => {
+    const files = [file('ch.xhtml', '<p style="a"></p><span style="b"></span><div style="c"></div>')];
+    const issues = validatePrhInlineStyles(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/3 inline style/);
+  });
+
+  it('emits ONE issue per offending file (not per attribute)', () => {
+    const files = [
+      file('a.xhtml', '<p style="a"></p><p style="b"></p>'),
+      file('b.xhtml', '<p style="c"></p>'),
+      file('clean.xhtml', '<p>clean</p>'),
+    ];
+    const issues = validatePrhInlineStyles(input(files));
+    expect(issues).toHaveLength(2);
+    expect(issues.map((i) => i.location).sort()).toEqual(['a.xhtml', 'b.xhtml']);
+  });
+
+  it('does NOT false-match data-style / data-base-style attributes', () => {
+    const files = [file('ch.xhtml', '<p data-style="x" data-base-style="y">text</p>')];
+    expect(validatePrhInlineStyles(input(files))).toEqual([]);
+  });
+
+  it('matches single-quoted style attributes', () => {
+    const files = [file('ch.xhtml', "<p style='color: red'>red</p>")];
+    expect(validatePrhInlineStyles(input(files))).toHaveLength(1);
+  });
+
+  it('does NOT false-match <style> ELEMENTS in <head>', () => {
+    // <style>…</style> doesn't have an `=` after the word "style", so
+    // the regex correctly skips it. But verify defensively.
+    const files: PrhXhtmlFile[] = [
+      {
+        path: 'ch.xhtml',
+        content: '<html><head><style>p { color: red; }</style></head><body><p>x</p></body></html>',
+      },
+    ];
+    expect(validatePrhInlineStyles(input(files))).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/layout-table-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/layout-table-validator.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhLayoutTables } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/layout-table-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function file(path: string, body: string): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title></head>
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+/** Build a <table> with `cells` <td> entries (no <th>). */
+function layoutTable(cells: number, openAttrs: string = ''): string {
+  const rows: string[] = [];
+  for (let i = 0; i < cells; i += 1) rows.push('<td>cell</td>');
+  return `<table${openAttrs}><tbody><tr>${rows.join('')}</tr></tbody></table>`;
+}
+
+describe('validatePrhLayoutTables', () => {
+  it('emits zero issues for a data table with <th>', () => {
+    const body = '<table><thead><tr><th scope="col">A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td></tr></tbody></table>';
+    const files = [file('ch.xhtml', body)];
+    expect(validatePrhLayoutTables(input(files))).toEqual([]);
+  });
+
+  it('emits zero issues for a layout table that declares role="presentation"', () => {
+    const files = [file('dialogue.xhtml', layoutTable(6, ' role="presentation"'))];
+    expect(validatePrhLayoutTables(input(files))).toEqual([]);
+  });
+
+  it('emits zero issues for a layout table with role="none" (ARIA synonym)', () => {
+    const files = [file('dialogue.xhtml', layoutTable(6, ' role="none"'))];
+    expect(validatePrhLayoutTables(input(files))).toEqual([]);
+  });
+
+  it('emits PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION for a 6-cell no-<th>, no-role table', () => {
+    const files = [file('ch.xhtml', layoutTable(6))];
+    const issues = validatePrhLayoutTables(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION');
+    expect(issues[0].location).toBe('ch.xhtml');
+    expect(issues[0].message).toMatch(/6 cells/);
+  });
+
+  it('does NOT fire on small no-<th> tables (<6 cells — likely intentional)', () => {
+    const files = [file('ch.xhtml', layoutTable(3))];
+    expect(validatePrhLayoutTables(input(files))).toEqual([]);
+  });
+
+  it('detects multiple offending tables in the same file independently', () => {
+    const body = layoutTable(6) + '<p>between</p>' + layoutTable(8);
+    const files = [file('ch.xhtml', body)];
+    const issues = validatePrhLayoutTables(input(files));
+    expect(issues).toHaveLength(2);
+    expect(issues[0].message).toMatch(/table #1/);
+    expect(issues[1].message).toMatch(/table #2/);
+  });
+
+  it('handles multi-value role attribute ("presentation region") correctly', () => {
+    const files = [file('ch.xhtml', layoutTable(6, ' role="presentation region"'))];
+    expect(validatePrhLayoutTables(input(files))).toEqual([]);
+  });
+
+  it('uses cell count from <td> only (ignores <th> in case of mixed tables)', () => {
+    // A table with <th> AND ≥6 <td> is treated as a data table — we
+    // SKIP it because <th> means semantic content is present.
+    const body = '<table><tr><th>H</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td></tr></table>';
+    const files = [file('ch.xhtml', body)];
+    expect(validatePrhLayoutTables(input(files))).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/layout-table-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/layout-table-validator.test.ts
@@ -81,4 +81,15 @@ describe('validatePrhLayoutTables', () => {
     const files = [file('ch.xhtml', body)];
     expect(validatePrhLayoutTables(input(files))).toEqual([]);
   });
+
+  it('does NOT skip layout table when only `data-role="presentation"` is present (regression)', () => {
+    // `\b` word-boundary against `role` would false-match inside
+    // `data-role` because `-` to `r` is a word transition. The
+    // validator must anchor on start-of-string or whitespace to
+    // require a REAL role attribute, not data-role metadata.
+    const files = [file('ch.xhtml', layoutTable(6, ' data-role="presentation"'))];
+    const issues = validatePrhLayoutTables(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION');
+  });
 });


### PR DESCRIPTION
## Summary

Second P3 PR — adds the forbidden-constructs layer. Three publisher-gated validators, 3 new codes. Per Technical Guide §6.2.

## New validators

| Validator | Code | Severity |
|---|---|---|
| `validatePrhForbiddenTags` | `PRH-MARKUP-DEPRECATED-TAG` | moderate |
| `validatePrhInlineStyles` | `PRH-MARKUP-INLINE-STYLE` | moderate |
| `validatePrhLayoutTables` | `PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION` | minor |

## Rules enforced

- **Deprecated tags**: flags `<b>`/`<i>`/`<big>`/`<small>`/`<u>`/`<strike>`/`<s>`/`<center>`/`<font>` in body content. Strips `<head>` before scanning so CSS selectors like `b { color: red; }` don't false-match.
- **Inline styles**: flags any `style="…"` attribute. Anchored on start-of-string or whitespace (not `\b`) so `data-style` / `data-base-style` don't false-match.
- **Layout tables**: heuristic — `<table>` with no `<th>`, no `role="presentation"/none`, and ≥6 `<td>` cells is likely a layout table that needs `role="presentation"`. Threshold avoids FPs on small fiction tables.

## High-volume design

Real PRH books pre-dating the current Style Guide carry dozens-to-hundreds of deprecated tags and inline styles per book. Both validators emit **one issue per file with an aggregate count** (e.g. `"<b>×12, <i>×3, <font>×1"`) rather than one issue per occurrence — keeps the issue list manageable until the FE grouping prompt (P2-P3-Frontend-Followups Prompt 7) lands.

## Test plan

- [x] 278/278 PRH unit tests passing (23 new across three validators)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke test against a real Penguin EPUB to validate FP rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect deprecated/presentational HTML tags in EPUB content
  * Detect inline style attributes in EPUB files
  * Detect layout tables missing required accessibility presentation/headers

* **Tests**
  * Added unit tests covering deprecated tags, inline styles, and layout-table detections (various edge cases and aggregation)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/371)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->