### PR TITLE
feat(prh): footnote ref↔id parity + page-break shape (P3/PR3)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -451,6 +451,24 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'Likely layout <table> (no <th>, ≥6 cells, not marked role="presentation") — PRH requires layout tables to declare role="presentation"',
   },
+
+  // ── Notes + page-break shape (P3/PR3) ─────────────────────────────────
+  // Publisher-gated. Detect-only — auto-fix lands in P5 where we can
+  // safely insert/repair role attributes on the relevant elements.
+  'PRH-FOOTNOTE-ID-MISMATCH': {
+    code: 'PRH-FOOTNOTE-ID-MISMATCH',
+    severity: 'moderate',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: '<a epub:type="noteref"> references an id that doesn\'t exist on any <aside epub:type="footnote"> or <li> inside <section epub:type="endnotes">. Kindle popup behaviour breaks silently on these mismatches',
+  },
+  'PRH-PAGEBREAK-MALFORMED': {
+    code: 'PRH-PAGEBREAK-MALFORMED',
+    severity: 'minor',
+    wcag: ['2.4.5'],
+    fixType: 'manual',
+    summary: '<span epub:type="pagebreak"> must carry role="doc-pagebreak" AND a numeric-only aria-label (no "page"/"pg" prefix, no roman-numeral text)',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/wcag-issue-mapper.service.ts
+++ b/src/services/acr/wcag-issue-mapper.service.ts
@@ -120,6 +120,10 @@ export const RULE_TO_CRITERIA_MAP: Record<string, string[]> = {
   'PRH-MARKUP-INLINE-STYLE': [],
   'PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION': ['1.3.1'],
 
+  // Notes + page-break shape (P3/PR3)
+  'PRH-FOOTNOTE-ID-MISMATCH': ['1.3.1'],
+  'PRH-PAGEBREAK-MALFORMED': ['2.4.5'],
+
   // ============= STANDARD ACE RULES =============
   // Images and Non-text Content
   'img-alt': ['1.1.1'],

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -27,6 +27,8 @@ import { validatePrhBodyPurity } from './validators/body-purity-validator';
 import { validatePrhForbiddenTags } from './validators/forbidden-tags-validator';
 import { validatePrhInlineStyles } from './validators/inline-style-validator';
 import { validatePrhLayoutTables } from './validators/layout-table-validator';
+import { validatePrhFootnoteIdParity } from './validators/footnote-id-parity-validator';
+import { validatePrhPageBreakShape } from './validators/page-break-shape-validator';
 import { getImprintRules } from './imprints';
 import type { PublisherProfile } from '../types';
 import type { PrhValidatorIssue, PrhXhtmlFile } from './validators/types';
@@ -96,6 +98,8 @@ export async function runPrhUkValidators(
         ...validatePrhForbiddenTags(perXhtmlInput),
         ...validatePrhInlineStyles(perXhtmlInput),
         ...validatePrhLayoutTables(perXhtmlInput),
+        ...validatePrhFootnoteIdParity(perXhtmlInput),
+        ...validatePrhPageBreakShape(perXhtmlInput),
       );
     }
 

--- a/src/services/epub/profiles/prh-uk/validators/footnote-id-parity-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/footnote-id-parity-validator.ts
@@ -1,0 +1,154 @@
+/**
+ * PRH UK footnote ref↔dest id parity validator (P3/PR3).
+ *
+ * Per Technical Guide §6.3, footnote references must round-trip
+ * cleanly between the in-text ref and the destination element:
+ *
+ *   <p>… see footnote.<a epub:type="noteref" href="#fn12">12</a></p>
+ *
+ *   <aside epub:type="footnote" id="fn12" role="doc-footnote">…</aside>
+ *   OR
+ *   <section epub:type="endnotes">
+ *     <ol>
+ *       <li id="fn12">…</li>
+ *     </ol>
+ *   </section>
+ *
+ * Kindle popup behaviour relies on the ref's `href="#X"` matching an
+ * `id="X"` on a `<aside epub:type="footnote">` OR a `<li>` inside
+ * `<section epub:type="endnotes">`. A broken ref degrades silently on
+ * web (the anchor jumps to nowhere) but produces a confusing "no
+ * popup" experience in Kindle — operators rarely notice without an
+ * explicit check.
+ *
+ * Strategy:
+ *   1. Walk every XHTML to build a global id-set: every id on an
+ *      `<aside epub:type="footnote">` plus every id on `<li>` inside
+ *      `<section epub:type="endnotes">`.
+ *   2. Walk every XHTML to find `<a epub:type="noteref">` elements.
+ *      For each, extract the href fragment (`#fn12`) and check
+ *      membership in the id-set.
+ *
+ * One issue per orphan ref. Detect-only.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput, PrhXhtmlFile } from './types';
+
+export function validatePrhFootnoteIdParity(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  // 1. Build the destination id-set across the entire EPUB.
+  const destIds = collectDestinationIds(input.xhtmlFiles);
+
+  // 2. Walk every XHTML for `<a epub:type="noteref">` refs.
+  for (const file of input.xhtmlFiles) {
+    const refRe = /<a\b([^>]*\bepub:type\s*=\s*["'][^"']*\bnoteref\b[^"']*["'][^>]*)>/gi;
+    let m: RegExpExecArray | null;
+    while ((m = refRe.exec(file.content)) !== null) {
+      const attrs = m[1];
+      const hrefMatch = attrs.match(/(?:^|\s)href\s*=\s*["']([^"']*)["']/i);
+      if (!hrefMatch) {
+        // noteref without an href — broken in a different way. Flag
+        // it as a mismatch so the operator notices.
+        issues.push(buildIssue(
+          file.path,
+          '(no href)',
+          'Add an href="#…" to the <a epub:type="noteref"> pointing at the matching footnote/endnote id.',
+        ));
+        continue;
+      }
+      const href = hrefMatch[1];
+      const idTarget = parseFragmentId(href);
+      if (!idTarget) {
+        // href present but no `#` fragment — also broken (web link?).
+        issues.push(buildIssue(
+          file.path,
+          href,
+          'Noteref href must reference an in-EPUB fragment (e.g. href="#fn12"), not an external URL.',
+        ));
+        continue;
+      }
+      if (!destIds.has(idTarget)) {
+        issues.push(buildIssue(
+          file.path,
+          href,
+          `Add id="${idTarget}" to the matching <aside epub:type="footnote"> or <li> inside <section epub:type="endnotes">, OR correct the ref's href to point at an existing footnote id.`,
+        ));
+      }
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Build a global id-set covering every legal noteref destination.
+ *
+ * Sources:
+ *   - <aside epub:type="footnote" id="…"> — inline-style PRH footnotes.
+ *   - <li id="…"> inside <section epub:type="endnotes"> — endnotes
+ *     pattern (Kindle popups still match these via the ol/li id).
+ *
+ * Returns a Set of bare ids (no `#` prefix). Operates on the WHOLE
+ * EPUB so cross-file references work (a chapter's ref → the
+ * standalone footnotes file).
+ */
+function collectDestinationIds(files: PrhXhtmlFile[]): Set<string> {
+  const ids = new Set<string>();
+
+  for (const file of files) {
+    // Footnote asides — match <aside …> opening tags that carry the
+    // canonical epub:type="footnote" marker, then extract id.
+    const asideRe = /<aside\b([^>]*\bepub:type\s*=\s*["'][^"']*\bfootnote\b[^"']*["'][^>]*)>/gi;
+    let am: RegExpExecArray | null;
+    while ((am = asideRe.exec(file.content)) !== null) {
+      const idMatch = am[1].match(/(?:^|\s)id\s*=\s*["']([^"']+)["']/i);
+      if (idMatch) ids.add(idMatch[1]);
+    }
+
+    // Endnotes sections — collect every <li id="…"> within each
+    // <section epub:type="endnotes">…</section> block. Using a
+    // section-scoped scan avoids picking up <li id="…"> from
+    // unrelated lists (e.g. a chapter's bullet list).
+    const sectionRe = /<section\b[^>]*\bepub:type\s*=\s*["'][^"']*\bendnotes\b[^"']*["'][^>]*>([\s\S]*?)<\/section>/gi;
+    let sm: RegExpExecArray | null;
+    while ((sm = sectionRe.exec(file.content)) !== null) {
+      const sectionBody = sm[1];
+      const liRe = /<li\b[^>]*\bid\s*=\s*["']([^"']+)["']/gi;
+      let lm: RegExpExecArray | null;
+      while ((lm = liRe.exec(sectionBody)) !== null) {
+        ids.add(lm[1]);
+      }
+    }
+  }
+
+  return ids;
+}
+
+/**
+ * Pull the fragment identifier from an href. Returns null if the
+ * href has no fragment (external URL, plain path). For `#fn12` we
+ * return `fn12`; for `chapter1.xhtml#fn12` we also return `fn12`
+ * (cross-file refs are common when footnotes are externalised).
+ */
+function parseFragmentId(href: string): string | null {
+  const hashIdx = href.indexOf('#');
+  if (hashIdx < 0) return null;
+  const frag = href.slice(hashIdx + 1).trim();
+  return frag.length > 0 ? frag : null;
+}
+
+function buildIssue(location: string, hrefValue: string, fixHint: string): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES['PRH-FOOTNOTE-ID-MISMATCH'];
+  return {
+    code: 'PRH-FOOTNOTE-ID-MISMATCH',
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location} contains a <a epub:type="noteref" href="${hrefValue}"> whose destination id is missing across the EPUB.`,
+    suggestion: fixHint,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/footnote-id-parity-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/footnote-id-parity-validator.ts
@@ -43,7 +43,11 @@ export function validatePrhFootnoteIdParity(input: PrhPerXhtmlInput): PrhValidat
 
   // 2. Walk every XHTML for `<a epub:type="noteref">` refs.
   for (const file of input.xhtmlFiles) {
-    const refRe = /<a\b([^>]*\bepub:type\s*=\s*["'][^"']*\bnoteref\b[^"']*["'][^>]*)>/gi;
+    // `(?:^|\s)epub:type` (NOT \b): `\b` matches inside
+    // `data-epub:type` because the boundary lands between `-` and `e`,
+    // so a custom prefixed attribute would silently look like a real
+    // noteref. Whitespace anchor mirrors how HTML attributes serialise.
+    const refRe = /<a\b([^>]*(?:^|\s)epub:type\s*=\s*["'][^"']*\bnoteref\b[^"']*["'][^>]*)>/gi;
     let m: RegExpExecArray | null;
     while ((m = refRe.exec(file.content)) !== null) {
       const attrs = m[1];
@@ -59,13 +63,27 @@ export function validatePrhFootnoteIdParity(input: PrhPerXhtmlInput): PrhValidat
         continue;
       }
       const href = hrefMatch[1];
-      const idTarget = parseFragmentId(href);
-      if (!idTarget) {
-        // href present but no `#` fragment — also broken (web link?).
+
+      // Reject hrefs that carry a URL scheme (http:, https:, mailto:,
+      // tel:, data:, etc.) OR protocol-relative URLs ("//host/path").
+      // Without this check `https://example.com#fn1` would extract
+      // the fragment "fn1" and silently match a legitimate in-EPUB
+      // footnote id, hiding a real broken-link bug.
+      if (isExternalHref(href)) {
         issues.push(buildIssue(
           file.path,
           href,
-          'Noteref href must reference an in-EPUB fragment (e.g. href="#fn12"), not an external URL.',
+          'Noteref href must reference an in-EPUB fragment (e.g. href="#fn12" or "footnotes.xhtml#fn12"), not an external URL.',
+        ));
+        continue;
+      }
+
+      const idTarget = parseFragmentId(href);
+      if (!idTarget) {
+        issues.push(buildIssue(
+          file.path,
+          href,
+          'Noteref href has no fragment identifier. Add "#<footnote-id>" so the link targets a specific footnote.',
         ));
         continue;
       }
@@ -102,7 +120,9 @@ function collectDestinationIds(files: PrhXhtmlFile[]): Set<string> {
   for (const file of files) {
     // Footnote asides — match <aside …> opening tags that carry the
     // canonical epub:type="footnote" marker, then extract id.
-    const asideRe = /<aside\b([^>]*\bepub:type\s*=\s*["'][^"']*\bfootnote\b[^"']*["'][^>]*)>/gi;
+    // Whitespace-anchored epub:type per the attribute-regex rule
+    // (see memory: feedback_attribute_regex_anchor.md).
+    const asideRe = /<aside\b([^>]*(?:^|\s)epub:type\s*=\s*["'][^"']*\bfootnote\b[^"']*["'][^>]*)>/gi;
     let am: RegExpExecArray | null;
     while ((am = asideRe.exec(file.content)) !== null) {
       const idMatch = am[1].match(/(?:^|\s)id\s*=\s*["']([^"']+)["']/i);
@@ -113,11 +133,11 @@ function collectDestinationIds(files: PrhXhtmlFile[]): Set<string> {
     // <section epub:type="endnotes">…</section> block. Using a
     // section-scoped scan avoids picking up <li id="…"> from
     // unrelated lists (e.g. a chapter's bullet list).
-    const sectionRe = /<section\b[^>]*\bepub:type\s*=\s*["'][^"']*\bendnotes\b[^"']*["'][^>]*>([\s\S]*?)<\/section>/gi;
+    const sectionRe = /<section\b[^>]*(?:^|\s)epub:type\s*=\s*["'][^"']*\bendnotes\b[^"']*["'][^>]*>([\s\S]*?)<\/section>/gi;
     let sm: RegExpExecArray | null;
     while ((sm = sectionRe.exec(file.content)) !== null) {
       const sectionBody = sm[1];
-      const liRe = /<li\b[^>]*\bid\s*=\s*["']([^"']+)["']/gi;
+      const liRe = /<li\b[^>]*(?:^|\s)id\s*=\s*["']([^"']+)["']/gi;
       let lm: RegExpExecArray | null;
       while ((lm = liRe.exec(sectionBody)) !== null) {
         ids.add(lm[1]);
@@ -126,6 +146,24 @@ function collectDestinationIds(files: PrhXhtmlFile[]): Set<string> {
   }
 
   return ids;
+}
+
+/**
+ * True when the href carries a URL scheme or is protocol-relative —
+ * i.e. an external URL rather than an in-EPUB reference.
+ *
+ * Patterns matched:
+ *   - `<scheme>:` followed by anything (http:, https:, mailto:, tel:,
+ *     data:, javascript:, etc.) — the scheme rule per RFC 3986 is a
+ *     letter followed by letters/digits/`+`/`-`/`.`.
+ *   - `//host/path` (protocol-relative).
+ *
+ * In-EPUB refs like `#fn1` and `footnotes.xhtml#fn1` both return
+ * false — those are local fragments / relative paths.
+ */
+function isExternalHref(href: string): boolean {
+  if (href.startsWith('//')) return true;
+  return /^[a-z][a-z0-9+.-]*:/i.test(href);
 }
 
 /**

--- a/src/services/epub/profiles/prh-uk/validators/page-break-shape-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/page-break-shape-validator.ts
@@ -44,7 +44,14 @@ export function validatePrhPageBreakShape(input: PrhPerXhtmlInput): PrhValidator
     // Match <span …epub:type="pagebreak"…> opening tags (self-closing
     // variant `<span … />` and explicit-close `<span …></span>` both
     // pass — the validator only reads the open tag's attributes).
-    const tagRe = /<span\b([^>]*\bepub:type\s*=\s*["'][^"']*\bpagebreak\b[^"']*["'][^>]*)\/?>/gi;
+    //
+    // The leading anchor on epub:type MUST be whitespace, NOT `\b`:
+    // a `\b` between `-` and `e` lets `data-epub:type="pagebreak"`
+    // false-match a real epub:type attribute (the validator would
+    // then try to verify the role + aria-label and fire a spurious
+    // PRH-PAGEBREAK-MALFORMED issue against a metadata-only span).
+    // See memory: feedback_attribute_regex_anchor.md.
+    const tagRe = /<span\b([^>]*(?:^|\s)epub:type\s*=\s*["'][^"']*\bpagebreak\b[^"']*["'][^>]*)\/?>/gi;
     let m: RegExpExecArray | null;
     while ((m = tagRe.exec(file.content)) !== null) {
       const attrs = m[1];

--- a/src/services/epub/profiles/prh-uk/validators/page-break-shape-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/page-break-shape-validator.ts
@@ -1,0 +1,102 @@
+/**
+ * PRH UK page-break shape validator (P3/PR3).
+ *
+ * Per Technical Guide §6.1, every print-page break placeholder in
+ * reflowable content must carry:
+ *
+ *   <span epub:type="pagebreak" role="doc-pagebreak" aria-label="12"/>
+ *
+ * Rules enforced:
+ *   - role="doc-pagebreak" MUST be present (and exactly that value
+ *     among the role tokens).
+ *   - aria-label MUST be present.
+ *   - aria-label MUST be a bare digit sequence ("12", "203"). Variants
+ *     like "page 12", "pg 12", or roman-numeral text ("xii", "iv")
+ *     fail the rule. Real screen-reader behaviour is sensitive to
+ *     the format — Apple Books reads "page page 12" out loud when
+ *     the label carries the word "page", and roman text isn't
+ *     normalised consistently across reading systems.
+ *
+ * Issue code: PRH-PAGEBREAK-MALFORMED. One issue per malformed
+ * pagebreak (these can stack — a book with 300 print pages can fire
+ * 300 instances if the format is wrong, which is exactly what the FE
+ * grouping prompt is designed for).
+ *
+ * Detect-only. Auto-fix (insert role / rewrite aria-label) lands in P5.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+/**
+ * aria-label values that satisfy the "bare digit sequence" rule.
+ * Leading zeros tolerated ("012" — unusual but valid). The rule
+ * deliberately rejects roman numerals as text — roman page numbers
+ * still need to surface as digits in aria-label so reading systems
+ * announce them numerically.
+ */
+const NUMERIC_LABEL_REGEX = /^\d+$/;
+
+export function validatePrhPageBreakShape(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  for (const file of input.xhtmlFiles) {
+    // Match <span …epub:type="pagebreak"…> opening tags (self-closing
+    // variant `<span … />` and explicit-close `<span …></span>` both
+    // pass — the validator only reads the open tag's attributes).
+    const tagRe = /<span\b([^>]*\bepub:type\s*=\s*["'][^"']*\bpagebreak\b[^"']*["'][^>]*)\/?>/gi;
+    let m: RegExpExecArray | null;
+    while ((m = tagRe.exec(file.content)) !== null) {
+      const attrs = m[1];
+
+      // 1. role must include doc-pagebreak. Whitespace anchor (not \b)
+      //    so data-role doesn't false-match — see memory:
+      //    feedback_attribute_regex_anchor.md.
+      const roleMatch = attrs.match(/(?:^|\s)role\s*=\s*["']([^"']+)["']/i);
+      const hasDocPagebreakRole =
+        !!roleMatch && roleMatch[1].split(/\s+/).map((t) => t.toLowerCase()).includes('doc-pagebreak');
+
+      // 2. aria-label must be present AND must be a bare digit sequence.
+      const ariaLabelMatch = attrs.match(/(?:^|\s)aria-label\s*=\s*["']([^"']*)["']/i);
+      const labelValue = ariaLabelMatch ? ariaLabelMatch[1].trim() : null;
+      const hasNumericLabel = labelValue !== null && NUMERIC_LABEL_REGEX.test(labelValue);
+
+      if (hasDocPagebreakRole && hasNumericLabel) continue;
+
+      // Aggregate the problems into one message per malformed
+      // pagebreak so operators see the full picture per instance.
+      const problems: string[] = [];
+      if (!hasDocPagebreakRole) {
+        problems.push(roleMatch
+          ? `role="${roleMatch[1]}" is missing the doc-pagebreak token`
+          : 'role attribute is missing (need role="doc-pagebreak")');
+      }
+      if (!hasNumericLabel) {
+        if (labelValue === null) {
+          problems.push('aria-label is missing (need aria-label="N" where N is a bare digit sequence)');
+        } else {
+          problems.push(`aria-label="${labelValue}" is not a bare digit sequence (no "page"/"pg" prefix, no roman-numeral text)`);
+        }
+      }
+
+      issues.push(buildIssue(file.path, problems.join('; ')));
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function buildIssue(location: string, details: string): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES['PRH-PAGEBREAK-MALFORMED'];
+  return {
+    code: 'PRH-PAGEBREAK-MALFORMED',
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location} — ${details}.`,
+    suggestion:
+      `Use <span epub:type="pagebreak" role="doc-pagebreak" aria-label="N"/> where N is the print page number as a bare digit sequence (e.g. "12", not "page 12" or "xii").`,
+    location,
+  };
+}

--- a/tests/unit/services/epub/profiles/prh-uk/validators/footnote-id-parity-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/footnote-id-parity-validator.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhFootnoteIdParity } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/footnote-id-parity-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function chapterWithRef(refHref: string): PrhXhtmlFile {
+  return {
+    path: 'chapter1.xhtml',
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<body epub:type="bodymatter">
+  <p>See note.<a epub:type="noteref" href="${refHref}">1</a></p>
+</body>
+</html>`,
+  };
+}
+
+function footnotesFileWithIds(ids: string[]): PrhXhtmlFile {
+  const items = ids.map((id) => `<aside epub:type="footnote" id="${id}" role="doc-footnote">Note ${id}</aside>`).join('\n');
+  return {
+    path: 'footnotes.xhtml',
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<body epub:type="backmatter">${items}</body>
+</html>`,
+  };
+}
+
+function endnotesFileWithIds(ids: string[]): PrhXhtmlFile {
+  const items = ids.map((id) => `<li id="${id}">Endnote ${id}</li>`).join('\n');
+  return {
+    path: 'endnotes.xhtml',
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<body epub:type="backmatter">
+  <section epub:type="endnotes">
+    <ol>${items}</ol>
+  </section>
+</body>
+</html>`,
+  };
+}
+
+describe('validatePrhFootnoteIdParity — happy paths', () => {
+  it('emits zero issues when noteref points at an existing footnote aside id', () => {
+    const files = [chapterWithRef('#fn1'), footnotesFileWithIds(['fn1', 'fn2'])];
+    expect(validatePrhFootnoteIdParity(input(files))).toEqual([]);
+  });
+
+  it('emits zero issues when noteref points at an endnotes <li> id', () => {
+    const files = [chapterWithRef('#en1'), endnotesFileWithIds(['en1', 'en2'])];
+    expect(validatePrhFootnoteIdParity(input(files))).toEqual([]);
+  });
+
+  it('accepts cross-file refs (chapter1.xhtml#fn1 style)', () => {
+    const files = [chapterWithRef('footnotes.xhtml#fn1'), footnotesFileWithIds(['fn1'])];
+    expect(validatePrhFootnoteIdParity(input(files))).toEqual([]);
+  });
+});
+
+describe('validatePrhFootnoteIdParity — orphan detection', () => {
+  it('emits PRH-FOOTNOTE-ID-MISMATCH when ref points at a missing id', () => {
+    const files = [chapterWithRef('#fn99'), footnotesFileWithIds(['fn1', 'fn2'])];
+    const issues = validatePrhFootnoteIdParity(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-FOOTNOTE-ID-MISMATCH');
+    expect(issues[0].location).toBe('chapter1.xhtml');
+    expect(issues[0].message).toMatch(/#fn99/);
+  });
+
+  it('emits one issue PER orphan ref (high-volume rule)', () => {
+    const chapter: PrhXhtmlFile = {
+      path: 'chapter1.xhtml',
+      content: `<html xmlns:epub="http://www.idpf.org/2007/ops"><body epub:type="bodymatter">
+        <p><a epub:type="noteref" href="#fn1">1</a></p>
+        <p><a epub:type="noteref" href="#fn99">99</a></p>
+        <p><a epub:type="noteref" href="#fn100">100</a></p>
+      </body></html>`,
+    };
+    const files = [chapter, footnotesFileWithIds(['fn1'])];
+    const issues = validatePrhFootnoteIdParity(input(files));
+    expect(issues).toHaveLength(2);
+    expect(issues.every((i) => i.code === 'PRH-FOOTNOTE-ID-MISMATCH')).toBe(true);
+  });
+
+  it('emits PRH-FOOTNOTE-ID-MISMATCH when noteref has no href at all', () => {
+    const broken: PrhXhtmlFile = {
+      path: 'chapter1.xhtml',
+      content: `<html xmlns:epub="http://www.idpf.org/2007/ops"><body><p><a epub:type="noteref">1</a></p></body></html>`,
+    };
+    const files = [broken, footnotesFileWithIds(['fn1'])];
+    const issues = validatePrhFootnoteIdParity(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/no href/i);
+  });
+
+  it('emits PRH-FOOTNOTE-ID-MISMATCH when noteref href is an external URL (no fragment)', () => {
+    const files = [chapterWithRef('https://example.com/notes'), footnotesFileWithIds(['fn1'])];
+    const issues = validatePrhFootnoteIdParity(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/example\.com/);
+  });
+});
+
+describe('validatePrhFootnoteIdParity — id-set scope', () => {
+  it('does NOT add <li id="…"> from non-endnotes sections to the id-set', () => {
+    // A regular bullet-list <li id="something"> shouldn't satisfy a
+    // noteref pointing at "something". Only <li> inside
+    // <section epub:type="endnotes"> count.
+    const chapter: PrhXhtmlFile = {
+      path: 'chapter1.xhtml',
+      content: `<html xmlns:epub="http://www.idpf.org/2007/ops"><body><p><a epub:type="noteref" href="#bullet1">1</a></p>
+        <ul><li id="bullet1">Just a regular list item</li></ul></body></html>`,
+    };
+    const issues = validatePrhFootnoteIdParity(input([chapter]));
+    expect(issues.find((i) => i.code === 'PRH-FOOTNOTE-ID-MISMATCH')).toBeDefined();
+  });
+
+  it('accepts a footnote that lives in the SAME file as the ref', () => {
+    const file: PrhXhtmlFile = {
+      path: 'chapter1.xhtml',
+      content: `<html xmlns:epub="http://www.idpf.org/2007/ops"><body epub:type="bodymatter">
+        <p>see note<a epub:type="noteref" href="#fn1">1</a></p>
+        <aside epub:type="footnote" id="fn1" role="doc-footnote">A footnote.</aside>
+      </body></html>`,
+    };
+    expect(validatePrhFootnoteIdParity(input([file]))).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/footnote-id-parity-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/footnote-id-parity-validator.test.ts
@@ -108,6 +108,24 @@ describe('validatePrhFootnoteIdParity — orphan detection', () => {
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toMatch(/example\.com/);
   });
+
+  it('emits PRH-FOOTNOTE-ID-MISMATCH for external URL + fragment (https://…#fn1) — regression', () => {
+    // Without an external-URL guard, parseFragmentId would extract
+    // "fn1" from the URL and silently match an in-EPUB footnote
+    // with id="fn1", hiding the real broken-link bug.
+    const files = [chapterWithRef('https://example.com/notes#fn1'), footnotesFileWithIds(['fn1'])];
+    const issues = validatePrhFootnoteIdParity(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-FOOTNOTE-ID-MISMATCH');
+    expect(issues[0].message).toMatch(/example\.com/);
+  });
+
+  it('rejects protocol-relative URLs (//host/path)', () => {
+    const files = [chapterWithRef('//example.com/notes#fn1'), footnotesFileWithIds(['fn1'])];
+    const issues = validatePrhFootnoteIdParity(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-FOOTNOTE-ID-MISMATCH');
+  });
 });
 
 describe('validatePrhFootnoteIdParity — id-set scope', () => {

--- a/tests/unit/services/epub/profiles/prh-uk/validators/page-break-shape-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/page-break-shape-validator.test.ts
@@ -110,4 +110,14 @@ describe('validatePrhPageBreakShape — malformed cases', () => {
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toMatch(/role attribute is missing/i);
   });
+
+  it('does NOT treat `data-epub:type="pagebreak"` as a real pagebreak (regression)', () => {
+    // Prefixed attributes like data-epub:type are author-defined
+    // metadata, not the canonical epub:type. The validator must skip
+    // the span entirely so it doesn't fire spurious malformed-pagebreak
+    // issues against arbitrary metadata-only spans.
+    const files = [file('<span data-epub:type="pagebreak">12</span>')];
+    const issues = validatePrhPageBreakShape(input(files));
+    expect(issues).toEqual([]);
+  });
 });

--- a/tests/unit/services/epub/profiles/prh-uk/validators/page-break-shape-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/page-break-shape-validator.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhPageBreakShape } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/page-break-shape-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function file(body: string): PrhXhtmlFile {
+  return {
+    path: 'chapter1.xhtml',
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+describe('validatePrhPageBreakShape — happy paths', () => {
+  it('emits zero issues for canonical pagebreak markup', () => {
+    const files = [file('<p>page <span epub:type="pagebreak" role="doc-pagebreak" aria-label="12"/> here</p>')];
+    expect(validatePrhPageBreakShape(input(files))).toEqual([]);
+  });
+
+  it('accepts self-closing and explicit-close variants identically', () => {
+    const files = [
+      file('<span epub:type="pagebreak" role="doc-pagebreak" aria-label="1"/>'),
+      file('<span epub:type="pagebreak" role="doc-pagebreak" aria-label="2"></span>'),
+    ];
+    expect(validatePrhPageBreakShape(input(files))).toEqual([]);
+  });
+
+  it('accepts role="doc-pagebreak region" (multi-value role)', () => {
+    const files = [file('<span epub:type="pagebreak" role="doc-pagebreak region" aria-label="12"/>')];
+    expect(validatePrhPageBreakShape(input(files))).toEqual([]);
+  });
+
+  it('does NOT fire on files with no pagebreak spans', () => {
+    const files = [file('<p>plain content</p>')];
+    expect(validatePrhPageBreakShape(input(files))).toEqual([]);
+  });
+});
+
+describe('validatePrhPageBreakShape — malformed cases', () => {
+  it('emits PRH-PAGEBREAK-MALFORMED when role is missing entirely', () => {
+    const files = [file('<span epub:type="pagebreak" aria-label="12"/>')];
+    const issues = validatePrhPageBreakShape(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-PAGEBREAK-MALFORMED');
+    expect(issues[0].message).toMatch(/role attribute is missing/i);
+  });
+
+  it('emits PRH-PAGEBREAK-MALFORMED when role lacks doc-pagebreak token', () => {
+    const files = [file('<span epub:type="pagebreak" role="region" aria-label="12"/>')];
+    const issues = validatePrhPageBreakShape(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/missing the doc-pagebreak token/i);
+  });
+
+  it('emits PRH-PAGEBREAK-MALFORMED when aria-label is missing', () => {
+    const files = [file('<span epub:type="pagebreak" role="doc-pagebreak"/>')];
+    const issues = validatePrhPageBreakShape(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/aria-label is missing/i);
+  });
+
+  it('emits PRH-PAGEBREAK-MALFORMED when aria-label has "page " prefix', () => {
+    const files = [file('<span epub:type="pagebreak" role="doc-pagebreak" aria-label="page 12"/>')];
+    const issues = validatePrhPageBreakShape(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/not a bare digit sequence/i);
+  });
+
+  it('emits PRH-PAGEBREAK-MALFORMED for roman-numeral aria-label ("xii")', () => {
+    const files = [file('<span epub:type="pagebreak" role="doc-pagebreak" aria-label="xii"/>')];
+    const issues = validatePrhPageBreakShape(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/not a bare digit sequence/i);
+  });
+
+  it('emits one issue per malformed pagebreak (high-volume rule)', () => {
+    const files = [file(`
+      <span epub:type="pagebreak" aria-label="1"/>
+      <span epub:type="pagebreak" role="doc-pagebreak" aria-label="page 2"/>
+      <span epub:type="pagebreak" role="doc-pagebreak" aria-label="3"/>
+    `)];
+    const issues = validatePrhPageBreakShape(input(files));
+    expect(issues).toHaveLength(2);
+  });
+
+  it('aggregates BOTH role-and-aria-label problems into the same issue when both are wrong', () => {
+    const files = [file('<span epub:type="pagebreak" role="region" aria-label="page 12"/>')];
+    const issues = validatePrhPageBreakShape(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/doc-pagebreak/i);
+    expect(issues[0].message).toMatch(/bare digit/i);
+  });
+
+  it('does NOT false-match `data-role="doc-pagebreak"` (regex anchor regression)', () => {
+    // Whitespace-anchored regex prevents `data-role` from satisfying
+    // the role check. Without that anchor, the pagebreak would
+    // silently pass and a real malformed pagebreak goes unflagged.
+    const files = [file('<span epub:type="pagebreak" data-role="doc-pagebreak" aria-label="12"/>')];
+    const issues = validatePrhPageBreakShape(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/role attribute is missing/i);
+  });
+});


### PR DESCRIPTION
## Summary

Third P3 PR — adds the note-system + page-break markup layer. Two publisher-gated validators, 2 new codes.

## New validators

| Validator | Code | Severity | WCAG |
|---|---|---|---|
| `validatePrhFootnoteIdParity` | `PRH-FOOTNOTE-ID-MISMATCH` | moderate | 1.3.1 |
| `validatePrhPageBreakShape` | `PRH-PAGEBREAK-MALFORMED` | minor | 2.4.5 |

## Rules enforced

- **Footnote id parity**: builds a global id-set across every XHTML in the EPUB containing `<aside epub:type="footnote" id="…">` AND `<li id="…">` inside `<section epub:type="endnotes">`. Each `<a epub:type="noteref">` ref is checked against the global set — covers cross-file refs (`chapter1.xhtml#fn12`), no-href refs, and external-URL refs.
- **Page-break shape**: every `<span epub:type="pagebreak">` must carry `role="doc-pagebreak"` AND `aria-label="N"` where N is a bare digit sequence. Rejects `"page 12"`, `"xii"`, missing role, missing aria-label.

## Design notes

- Footnote validator uses a **global** id-set (one pass over all xhtmlFiles), then a **second pass** for the refs themselves. Avoids the O(n²) trap of "for each ref, scan every file for the destination".
- Page-break validator aggregates role + aria-label problems into a **single issue per malformed pagebreak**. A book with 300 print pages and a global aria-label format bug fires 300 separate issues — exactly the high-volume case the FE grouping prompt (Prompt 7) is designed for.
- All attribute regexes use the `(?:^|\s)<attr>=` whitespace anchor (not `\b`) per the standing pitfall from earlier P3 PRs.

## Test plan

- [x] 300/300 PRH unit tests passing (21 new across the two validators)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for footnote/endnote reference integrity, detecting broken or malformed noteref targets (WCAG 1.3.1).
  * Added validation for page-break markup structure, ensuring required accessibility attributes and numeric labels (WCAG 2.4.5).

* **Tests**
  * Added comprehensive unit test coverage for both validators, including happy paths and multiple malformed/regression scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/372)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->