### PR TITLE
fix(ml-metrics): normalize operator labels before mAP grouping

### DIFF
--- a/src/routes/ml-metrics.routes.ts
+++ b/src/routes/ml-metrics.routes.ts
@@ -9,6 +9,7 @@ import {
   getMapHistory,
 } from '../services/metrics/map-persistence';
 import { getPhaseGateStatus } from '../services/metrics/phase-gate.service';
+import { normalizeOperatorLabel } from '../services/metrics/operator-label-normalizer';
 import type { AnnotatedZone, PredictedZone } from '../services/metrics/ml-metrics.types';
 import type { BBox } from '../services/calibration/iou';
 import type { CanonicalZoneType } from '../services/zone-extractor/types';
@@ -61,11 +62,22 @@ router.post('/map', async (req: Request, res: Response) => {
       },
     });
 
-    const groundTruth: AnnotatedZone[] = gtZones.map((z) => ({
-      pageNumber: z.pageNumber,
-      bbox: z.bounds as unknown as BBox,
-      zoneType: (z.operatorLabel ?? z.type) as CanonicalZoneType,
-    }));
+    // Normalize operator labels to canonical zone types. The Zone.operatorLabel
+    // column is free-text and the corpus contains at least two non-canonical
+    // conventions (PDF-tag-name like 'LI'/'HDR' and HTML-semantic like 'h1'-'h6').
+    // Without this step every off-canon label leaks through as its own bucket,
+    // produces zero matching predictions, and drags AP to 0 for every class.
+    const groundTruth: AnnotatedZone[] = gtZones.flatMap((z) => {
+      const canonical =
+        normalizeOperatorLabel(z.operatorLabel) ??
+        normalizeOperatorLabel(z.type);
+      if (!canonical) return [];
+      return [{
+        pageNumber: z.pageNumber,
+        bbox: z.bounds as unknown as BBox,
+        zoneType: canonical,
+      }];
+    });
 
     // Fetch docling predictions (same null-bounds guard as ground truth)
     const predZones = await prisma.zone.findMany({

--- a/src/services/metrics/operator-label-normalizer.ts
+++ b/src/services/metrics/operator-label-normalizer.ts
@@ -1,0 +1,107 @@
+import { logger } from '../../lib/logger';
+import type { CanonicalZoneType } from '../zone-extractor/types';
+
+// Operator labels in the wild diverge from CanonicalZoneType because annotation
+// was historically free-text. Two conventions exist in the corpus:
+//   (A) PDF-tag-name style — LI, HDR, TOCI, P, etc. (uppercase)
+//   (B) HTML-semantic style — h1..h6, list-item, toci, paragraph (lowercase)
+// Neither maps cleanly to the 8 canonical types. Without normalization the
+// mAP route bucketed ground-truth zones under non-canonical keys (e.g. "LI"),
+// which have zero matching predictions, so AP=0 for every class. That is the
+// root cause of the 0.0% mAP on Boyd-Hamill and Flanagan (audit 2026-05-12).
+//
+// This map intentionally lives in the metrics layer, not at the data-write
+// boundary: we want to keep raw operator input in the DB column (history)
+// while exposing a canonical view to anything that computes accuracy.
+const LABEL_MAP: Record<string, CanonicalZoneType> = {
+  // ── paragraph (body text + textual list/TOC/code/formula content) ──
+  'paragraph':     'paragraph',
+  'p':             'paragraph',
+  'li':            'paragraph',
+  'list-item':     'paragraph',
+  'list_item':     'paragraph',
+  'lbody':         'paragraph',
+  'lbl':           'paragraph',
+  'toci':          'paragraph',
+  'toc':           'paragraph',
+  'tocitem':       'paragraph',
+  'code':          'paragraph',
+  'formula':       'paragraph',
+  'reference':     'paragraph',
+  'bibentry':      'paragraph',
+  'blockquote':    'paragraph',
+  'quote':         'paragraph',
+  'note':          'paragraph',
+  // ── section-header (all heading levels collapse) ──
+  'section-header': 'section-header',
+  'sectionheader':  'section-header',
+  'section_header': 'section-header',
+  'h':              'section-header',
+  'h1':             'section-header',
+  'h2':             'section-header',
+  'h3':             'section-header',
+  'h4':             'section-header',
+  'h5':             'section-header',
+  'h6':             'section-header',
+  'h7':             'section-header',
+  'title':          'section-header',
+  'heading':        'section-header',
+  // ── table ──
+  'table':          'table',
+  'tr':             'table',
+  'td':             'table',
+  'th':             'table',
+  'thead':          'table',
+  'tbody':          'table',
+  'tfoot':          'table',
+  // ── figure ──
+  'figure':         'figure',
+  'fig':            'figure',
+  'picture':        'figure',
+  'image':          'figure',
+  'img':            'figure',
+  // ── caption ──
+  'caption':        'caption',
+  // ── footnote ──
+  'footnote':       'footnote',
+  'fn':             'footnote',
+  'fenote':         'footnote',
+  // ── running header ──
+  'header':         'header',
+  'page-header':    'header',
+  'page_header':    'header',
+  'pageheader':     'header',
+  'hdr':            'header',
+  // ── running footer ──
+  'footer':         'footer',
+  'page-footer':    'footer',
+  'page_footer':    'footer',
+  'pagefooter':     'footer',
+  'ftr':            'footer',
+};
+
+const warnedUnknowns = new Set<string>();
+
+/**
+ * Normalize a free-text operator label to one of the 8 CanonicalZoneType
+ * values. Returns null when the label is genuinely unrecognizable — caller
+ * should treat that zone as having no usable ground-truth type and skip it
+ * from mAP rather than silently miscount.
+ */
+export function normalizeOperatorLabel(label: string | null | undefined): CanonicalZoneType | null {
+  if (!label) return null;
+  const key = label.trim().toLowerCase();
+  if (!key) return null;
+  const mapped = LABEL_MAP[key];
+  if (mapped) return mapped;
+  if (!warnedUnknowns.has(key)) {
+    warnedUnknowns.add(key);
+    logger.warn(`[OperatorLabelNormalizer] Unknown label "${label}" — excluded from mAP ground truth`);
+  }
+  return null;
+}
+
+// Exported only for tests that want to reset the dedup state between cases.
+export function __resetWarnedUnknownsForTest(): void {
+  warnedUnknowns.clear();
+}

--- a/tests/unit/services/metrics/operator-label-normalizer.test.ts
+++ b/tests/unit/services/metrics/operator-label-normalizer.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../src/lib/logger', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  normalizeOperatorLabel,
+  __resetWarnedUnknownsForTest,
+} from '../../../../src/services/metrics/operator-label-normalizer';
+import { logger } from '../../../../src/lib/logger';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetWarnedUnknownsForTest();
+});
+
+describe('normalizeOperatorLabel', () => {
+  it('returns null for null/undefined/empty', () => {
+    expect(normalizeOperatorLabel(null)).toBeNull();
+    expect(normalizeOperatorLabel(undefined)).toBeNull();
+    expect(normalizeOperatorLabel('')).toBeNull();
+    expect(normalizeOperatorLabel('   ')).toBeNull();
+  });
+
+  it('passes through canonical types unchanged', () => {
+    expect(normalizeOperatorLabel('paragraph')).toBe('paragraph');
+    expect(normalizeOperatorLabel('section-header')).toBe('section-header');
+    expect(normalizeOperatorLabel('table')).toBe('table');
+    expect(normalizeOperatorLabel('figure')).toBe('figure');
+    expect(normalizeOperatorLabel('caption')).toBe('caption');
+    expect(normalizeOperatorLabel('footnote')).toBe('footnote');
+    expect(normalizeOperatorLabel('header')).toBe('header');
+    expect(normalizeOperatorLabel('footer')).toBe('footer');
+  });
+
+  describe('Convention A: PDF-tag-name uppercase (Boyd-Hamill, Flanagan)', () => {
+    it('LI → paragraph', () => {
+      expect(normalizeOperatorLabel('LI')).toBe('paragraph');
+    });
+    it('HDR → header', () => {
+      expect(normalizeOperatorLabel('HDR')).toBe('header');
+    });
+    it('TOCI → paragraph', () => {
+      expect(normalizeOperatorLabel('TOCI')).toBe('paragraph');
+    });
+    it('FTR → footer', () => {
+      expect(normalizeOperatorLabel('FTR')).toBe('footer');
+    });
+  });
+
+  describe('Convention B: HTML-semantic lowercase (BirdingwithAI, Gold)', () => {
+    it('all heading levels collapse to section-header', () => {
+      for (const h of ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']) {
+        expect(normalizeOperatorLabel(h)).toBe('section-header');
+      }
+    });
+    it('list-item → paragraph', () => {
+      expect(normalizeOperatorLabel('list-item')).toBe('paragraph');
+      expect(normalizeOperatorLabel('list_item')).toBe('paragraph');
+    });
+    it('toci (any case) → paragraph', () => {
+      expect(normalizeOperatorLabel('toci')).toBe('paragraph');
+      expect(normalizeOperatorLabel('TOCI')).toBe('paragraph');
+      expect(normalizeOperatorLabel('TocI')).toBe('paragraph');
+    });
+  });
+
+  describe('case + whitespace tolerance', () => {
+    it('normalizes case', () => {
+      expect(normalizeOperatorLabel('Paragraph')).toBe('paragraph');
+      expect(normalizeOperatorLabel('FOOTER')).toBe('footer');
+      expect(normalizeOperatorLabel('h2')).toBe('section-header');
+      expect(normalizeOperatorLabel('H2')).toBe('section-header');
+    });
+    it('trims surrounding whitespace', () => {
+      expect(normalizeOperatorLabel('  table  ')).toBe('table');
+      expect(normalizeOperatorLabel('\tLI\n')).toBe('paragraph');
+    });
+  });
+
+  describe('table/figure variants', () => {
+    it('table row/cell labels collapse to table', () => {
+      for (const t of ['TR', 'TD', 'TH', 'THead', 'TBody', 'tfoot']) {
+        expect(normalizeOperatorLabel(t)).toBe('table');
+      }
+    });
+    it('figure synonyms collapse to figure', () => {
+      for (const t of ['Picture', 'image', 'img', 'fig', 'FIGURE']) {
+        expect(normalizeOperatorLabel(t)).toBe('figure');
+      }
+    });
+  });
+
+  it('returns null for unknown labels and logs once per unknown', () => {
+    expect(normalizeOperatorLabel('weird-label-1')).toBeNull();
+    expect(normalizeOperatorLabel('weird-label-1')).toBeNull(); // second call
+    expect(normalizeOperatorLabel('weird-label-2')).toBeNull();
+    // Two distinct unknowns → exactly two warnings (no duplicates).
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not warn for known labels even on repeated calls', () => {
+    normalizeOperatorLabel('LI');
+    normalizeOperatorLabel('h3');
+    normalizeOperatorLabel('paragraph');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`normalizeOperatorLabel()\` and wires it into the mAP route. Fixes the **root cause** of the 0.0% mAP on Boyd-Hamill and Flanagan (audit 2026-05-12 — not a bbox/coord-space bug).

## What was wrong

\`src/routes/ml-metrics.routes.ts:67\` cast \`(operatorLabel ?? type)\` to \`CanonicalZoneType\`. The corpus contains at least two non-canonical conventions: PDF-tag (\`LI\`, \`HDR\`, \`TOCI\`) on Boyd-Hamill/Flanagan, and HTML-semantic (\`h1\`–\`h6\`, \`list-item\`, \`toci\`) on BirdingwithAI/Gold. Off-canon labels formed their own ground-truth buckets that no Docling prediction matched, so AP=0. 100% of Boyd-Hamill and Flanagan verified zones used Convention A.

## What changed

- NEW \`src/services/metrics/operator-label-normalizer.ts\` (15-test module)
- MODIFIED \`src/routes/ml-metrics.routes.ts\` (replace cast; flatMap drops unrecognized)

## Expected impact

| Doc | Old | Projected |
|-----|----:|----------:|
| Boyd-Hamill | 0.0% | non-zero |
| Flanagan | 0.0% | non-zero |
| Gold | 36.4% | ~40-50% |
| BirdingwithAI | 70.7% | ~75-80% |

## Test plan

- [x] tsc --noEmit clean
- [x] 28/28 vitest pass (normalizer + phase-gate)
- [ ] After merge + deploy: batch mAP rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented zone label normalization in metrics calculations to map incoming labels to canonical zone types.

* **Improvements**
  * Ground-truth zone data construction now handles various label formats and gracefully processes unrecognizable labels without disrupting calculations.

* **Tests**
  * Added extensive test coverage for label normalization, including edge cases and multiple label format conventions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/373)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->