### PR TITLE
feat(prh): text-pattern heuristics — inline-lang + hashtag + acronym (P3/PR4) — closes P3

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -469,6 +469,34 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: '<span epub:type="pagebreak"> must carry role="doc-pagebreak" AND a numeric-only aria-label (no "page"/"pg" prefix, no roman-numeral text)',
   },
+
+  // ── Text-pattern heuristics (P3/PR4) ──────────────────────────────────
+  // All publisher-gated and explicitly HEURISTIC. False positives are
+  // expected on real content — the FE renders these with an info
+  // "review manually" marker (P2-P3 frontend follow-up Prompt 8) so
+  // operators don't treat them as definitive bugs. Severity stays at
+  // `minor` to keep the FP cost low.
+  'PRH-LANG-INLINE-NOT-MARKED': {
+    code: 'PRH-LANG-INLINE-NOT-MARKED',
+    severity: 'minor',
+    wcag: ['3.1.2'],
+    fixType: 'manual',
+    summary: 'Body contains a run of non-Latin-script text not wrapped in <span lang="…"> — screen readers may mispronounce. Heuristic; review manually before fixing',
+  },
+  'PRH-HASHTAG-NOT-CAMEL-CASE': {
+    code: 'PRH-HASHTAG-NOT-CAMEL-CASE',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Hashtag tokens (#example) must be PascalCase/camelCase so screen readers can pronounce them. Heuristic; review manually',
+  },
+  'PRH-ACRONYM-INSERTED-SEPARATORS': {
+    code: 'PRH-ACRONYM-INSERTED-SEPARATORS',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'ALL-CAPS sequence with inserted separators (N.A.S.A. / F, B, I) — PRH wants compact form (NASA / FBI). Heuristic; review manually for legitimate formal abbreviations',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/wcag-issue-mapper.service.ts
+++ b/src/services/acr/wcag-issue-mapper.service.ts
@@ -124,6 +124,11 @@ export const RULE_TO_CRITERIA_MAP: Record<string, string[]> = {
   'PRH-FOOTNOTE-ID-MISMATCH': ['1.3.1'],
   'PRH-PAGEBREAK-MALFORMED': ['2.4.5'],
 
+  // Text-pattern heuristics (P3/PR4)
+  'PRH-LANG-INLINE-NOT-MARKED': ['3.1.2'],
+  'PRH-HASHTAG-NOT-CAMEL-CASE': [],
+  'PRH-ACRONYM-INSERTED-SEPARATORS': [],
+
   // ============= STANDARD ACE RULES =============
   // Images and Non-text Content
   'img-alt': ['1.1.1'],

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -29,6 +29,9 @@ import { validatePrhInlineStyles } from './validators/inline-style-validator';
 import { validatePrhLayoutTables } from './validators/layout-table-validator';
 import { validatePrhFootnoteIdParity } from './validators/footnote-id-parity-validator';
 import { validatePrhPageBreakShape } from './validators/page-break-shape-validator';
+import { validatePrhInlineLang } from './validators/inline-lang-validator';
+import { validatePrhHashtags } from './validators/hashtag-validator';
+import { validatePrhAcronyms } from './validators/acronym-validator';
 import { getImprintRules } from './imprints';
 import type { PublisherProfile } from '../types';
 import type { PrhValidatorIssue, PrhXhtmlFile } from './validators/types';
@@ -100,6 +103,9 @@ export async function runPrhUkValidators(
         ...validatePrhLayoutTables(perXhtmlInput),
         ...validatePrhFootnoteIdParity(perXhtmlInput),
         ...validatePrhPageBreakShape(perXhtmlInput),
+        ...validatePrhInlineLang(perXhtmlInput),
+        ...validatePrhHashtags(perXhtmlInput),
+        ...validatePrhAcronyms(perXhtmlInput),
       );
     }
 

--- a/src/services/epub/profiles/prh-uk/validators/acronym-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/acronym-validator.ts
@@ -23,6 +23,7 @@
  */
 
 import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import { stripHtmlMarkup } from './text-utils';
 import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
 
 /**
@@ -63,15 +64,6 @@ export function validatePrhAcronyms(input: PrhPerXhtmlInput): PrhValidatorIssue[
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────
-
-function stripHtmlMarkup(html: string): string {
-  return html
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&[a-z]+;/gi, ' ')
-    .replace(/&#x?[0-9a-f]+;/gi, ' ');
-}
 
 function buildIssue(location: string, offenders: string[]): PrhValidatorIssue {
   const def = PRH_ISSUE_CODES['PRH-ACRONYM-INSERTED-SEPARATORS'];

--- a/src/services/epub/profiles/prh-uk/validators/acronym-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/acronym-validator.ts
@@ -1,0 +1,89 @@
+/**
+ * PRH UK acronym separator detector (P3/PR4).
+ *
+ * Per Style Guide §13, acronyms must appear in compact form
+ * (`NASA`, `USA`, `FBI`), not with separators between each letter
+ * (`N.A.S.A.`, `U S A`, `F.B.I.`). Reading systems often re-announce
+ * separator-inserted acronyms letter-by-letter twice (once for each
+ * separator, once for the letter group), producing audio like
+ * "n dot a dot s dot a dot".
+ *
+ * The rule is the HIGHEST false-positive risk of P3 — formal English
+ * abbreviations legitimately use periods (`U.S.`, `e.g.`, `Ph.D.`).
+ * We minimise FPs with two thresholds:
+ *   - REQUIRE ≥3 letters with separators between EACH pair. Two-letter
+ *     sequences with separators (`U.S.`, `J.K.`) are skipped — those
+ *     are routine and rarely cause TTS problems.
+ *   - Accepted separators: `.`, `,`, single space.
+ *   - One issue per file with the full list of offenders (up to 5
+ *     shown). Same high-volume design as hashtag-validator.
+ *
+ * Issue code: PRH-ACRONYM-INSERTED-SEPARATORS. Heuristic — severity
+ * minor, surfaced with the "review manually" FE cue. Detect-only.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+/**
+ * Match runs of ≥3 capital letters separated by `.`, `,`, or single
+ * space between each pair. Examples that match:
+ *   N.A.S.A.   F.B.I.   U S A    A,B,C    R.S.V.P.
+ * Examples that DON'T match (rejected by thresholds):
+ *   U.S.    J.K.    e.g.    a.m.    NASA    N.A.    A B C D
+ *                                                        ^ runs of >1 space break it
+ *
+ * Pattern: letter, then 2+ groups of (separator + letter). After
+ * the leading letter we require an OPTIONAL trailing separator. The
+ * `\b` boundary at the start prevents matching the middle of a
+ * longer word.
+ */
+const ACRONYM_REGEX = /\b([A-Z])([.,] |[.,]|\s)([A-Z])(?:\2([A-Z]))+\2?/g;
+
+export function validatePrhAcronyms(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  for (const file of input.xhtmlFiles) {
+    const text = stripHtmlMarkup(file.content);
+    ACRONYM_REGEX.lastIndex = 0;
+
+    const offenders: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = ACRONYM_REGEX.exec(text)) !== null) {
+      offenders.push(m[0].trim());
+    }
+
+    if (offenders.length === 0) continue;
+
+    const unique = Array.from(new Set(offenders));
+    issues.push(buildIssue(file.path, unique));
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function stripHtmlMarkup(html: string): string {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z]+;/gi, ' ')
+    .replace(/&#x?[0-9a-f]+;/gi, ' ');
+}
+
+function buildIssue(location: string, offenders: string[]): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES['PRH-ACRONYM-INSERTED-SEPARATORS'];
+  const sample = offenders.slice(0, 5).map((o) => `"${o}"`).join(', ');
+  const moreNote = offenders.length > 5 ? ` (+${offenders.length - 5} more)` : '';
+  return {
+    code: 'PRH-ACRONYM-INSERTED-SEPARATORS',
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location} — ${offenders.length} acronym(s) with inserted separators: ${sample}${moreNote}.`,
+    suggestion:
+      `Rewrite each acronym in compact form: e.g. "N.A.S.A." → "NASA", "F, B, I" → "FBI". Two-letter abbreviations (U.S., J.K.) are not flagged; review individually if your house style differs.`,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/hashtag-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/hashtag-validator.ts
@@ -24,6 +24,7 @@
  */
 
 import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import { stripHtmlMarkup } from './text-utils';
 import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
 
 /**
@@ -84,15 +85,6 @@ function isPascalOrCamelCase(token: string): boolean {
   const hasUpper = /[A-Z]/.test(letterPart);
   // Need BOTH cases present. All-lower or all-upper fails.
   return hasLower && hasUpper;
-}
-
-function stripHtmlMarkup(html: string): string {
-  return html
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&[a-z]+;/gi, ' ')
-    .replace(/&#x?[0-9a-f]+;/gi, ' ');
 }
 
 function buildIssue(location: string, offenders: string[]): PrhValidatorIssue {

--- a/src/services/epub/profiles/prh-uk/validators/hashtag-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/hashtag-validator.ts
@@ -1,0 +1,111 @@
+/**
+ * PRH UK hashtag camelCase validator (P3/PR4).
+ *
+ * Per Style Guide §13, hashtags in body text must use PascalCase or
+ * camelCase so screen readers can split the token into pronounceable
+ * words. A lowercase hashtag like `#womenintech` is announced as one
+ * un-parseable string; `#WomenInTech` lets the screen reader read
+ * "women in tech" word-by-word.
+ *
+ * Detection rule:
+ *   - Strip HTML markup. Then scan visible text for `#<token>`
+ *     occurrences where <token> is alphanumeric (no spaces).
+ *   - Skip tokens that are all-digits (`#1`, `#42` — page refs and
+ *     numbers, not hashtags).
+ *   - A token PASSES when it contains at least one internal capital
+ *     letter at position ≥1 (so `#WomenInTech`, `#nytBestseller`,
+ *     `#PRHUK` all pass). Tokens that are all-lower / all-upper
+ *     (`#womenintech`, `#NYTBESTSELLER`) FAIL.
+ *   - One issue per file with the full list of offending tokens (up
+ *     to 5 shown in the message).
+ *
+ * Issue code: PRH-HASHTAG-NOT-CAMEL-CASE. Heuristic — severity minor,
+ * surfaced with a "review manually" cue (FE Prompt 8). Detect-only.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+/**
+ * Hashtag token: `#` followed by ≥2 alphanumeric characters. The
+ * minimum-length guard avoids matching `#1` (page number style) and
+ * single-letter fragments. The token continues through letters /
+ * digits / underscores; it terminates at the first character that
+ * isn't part of `\w`.
+ */
+const HASHTAG_TOKEN_REGEX = /#(\w{2,})/g;
+
+export function validatePrhHashtags(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  for (const file of input.xhtmlFiles) {
+    const text = stripHtmlMarkup(file.content);
+    HASHTAG_TOKEN_REGEX.lastIndex = 0;
+
+    const offenders: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = HASHTAG_TOKEN_REGEX.exec(text)) !== null) {
+      const token = m[1];
+      // Skip all-digit tokens (e.g. "#42" — a page reference, not a
+      // hashtag).
+      if (/^\d+$/.test(token)) continue;
+      if (!isPascalOrCamelCase(token)) {
+        offenders.push(`#${token}`);
+      }
+    }
+
+    if (offenders.length === 0) continue;
+
+    // De-duplicate — same hashtag appearing multiple times shouldn't
+    // inflate the count.
+    const unique = Array.from(new Set(offenders));
+    issues.push(buildIssue(file.path, unique));
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * True when the token is camelCase or PascalCase — i.e. contains a
+ * mix of lower and upper case letters with at least one capital at
+ * position ≥1 (or is an Acronym-style mixed-case token like `PRHUK`).
+ *
+ * We treat ALL-UPPER as a fail because screen readers don't get a
+ * pronunciation hint from it — Style Guide §13 example is
+ * `#WomenInTech` not `#WOMENINTECH`. ALL-LOWER also fails.
+ */
+function isPascalOrCamelCase(token: string): boolean {
+  // Strip leading digits (rare but possible, e.g. `#1stPlace`).
+  const letterPart = token.replace(/^\d+/, '');
+  if (letterPart.length < 2) return true; // too short to assess
+  const hasLower = /[a-z]/.test(letterPart);
+  const hasUpper = /[A-Z]/.test(letterPart);
+  // Need BOTH cases present. All-lower or all-upper fails.
+  return hasLower && hasUpper;
+}
+
+function stripHtmlMarkup(html: string): string {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z]+;/gi, ' ')
+    .replace(/&#x?[0-9a-f]+;/gi, ' ');
+}
+
+function buildIssue(location: string, offenders: string[]): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES['PRH-HASHTAG-NOT-CAMEL-CASE'];
+  const sample = offenders.slice(0, 5).join(', ');
+  const moreNote = offenders.length > 5 ? ` (+${offenders.length - 5} more)` : '';
+  return {
+    code: 'PRH-HASHTAG-NOT-CAMEL-CASE',
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location} — ${offenders.length} unique non-camelCase hashtag(s): ${sample}${moreNote}.`,
+    suggestion:
+      `Rewrite each hashtag using internal capitals so a screen reader can split words: e.g. "#womenintech" → "#WomenInTech", "#nytbestseller" → "#nytBestseller".`,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/inline-lang-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/inline-lang-validator.ts
@@ -30,6 +30,7 @@
  */
 
 import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import { stripHtmlMarkup } from './text-utils';
 import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
 
 /**
@@ -123,15 +124,6 @@ function stripLangBearingElements(html: string): string {
     /<(?!html\b|body\b)([a-z][a-z0-9]*)\b[^>]*(?:^|\s)(?:lang|xml:lang)\s*=\s*["'][^"']*["'][^>]*>[\s\S]*?<\/\1>/gi,
     ' ',
   );
-}
-
-function stripHtmlMarkup(html: string): string {
-  return html
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&[a-z]+;/gi, ' ')
-    .replace(/&#x?[0-9a-f]+;/gi, ' ');
 }
 
 function buildIssue(location: string, runCount: number, samples: string[]): PrhValidatorIssue {

--- a/src/services/epub/profiles/prh-uk/validators/inline-lang-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/inline-lang-validator.ts
@@ -1,0 +1,149 @@
+/**
+ * PRH UK inline-language detector (P3/PR4).
+ *
+ * Per Technical Guide §6.3, body content in a non-document language
+ * must be wrapped in `<span lang="…">` so screen readers switch
+ * pronunciation rules at the run boundary. Real EPUBs frequently
+ * forget to mark inline foreign phrases — a single Russian quote in
+ * an English novel will be mispronounced as English without the
+ * wrapper.
+ *
+ * SCOPE: this validator detects NON-LATIN-SCRIPT runs only. Latin-
+ * script foreign content (French, German, Spanish, etc.) shares the
+ * Latin Unicode range with English and can't be distinguished by
+ * Unicode block alone — that would need a language-detection model.
+ * Latin-script detection is explicitly out of scope (P4 territory).
+ *
+ * Detection rule:
+ *   - Strip HTML markup. Strip text inside any element that already
+ *     carries `lang="…"` (those are already marked).
+ *   - Scan the remaining visible text for runs of ≥3 characters in
+ *     one of the targeted non-Latin Unicode blocks (Cyrillic,
+ *     Devanagari, Arabic, Hebrew, Greek, CJK Han, Hiragana, Katakana,
+ *     Hangul, Thai). Three-char threshold avoids FPs on stray special
+ *     characters (em-dashes, smart quotes, single emoji).
+ *   - One issue per file, regardless of how many runs are found
+ *     (high-volume rule — the FE grouping prompt collapses these).
+ *
+ * Issue code: PRH-LANG-INLINE-NOT-MARKED. Heuristic; severity minor.
+ * Detect-only.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+/**
+ * Per-script minimum-run thresholds:
+ *
+ *   - Logographic / syllabic scripts (Han / Hiragana / Katakana /
+ *     Hangul) carry one full word per 1–2 glyphs. A 2-character run
+ *     like `北京` (Beijing) is a real word; demanding 3 would miss
+ *     most realistic inline-CJK cases in English text.
+ *   - Alphabetic scripts (Cyrillic, Devanagari, Arabic, Hebrew, Greek,
+ *     Thai) need ≥3 letters to represent a meaningful run. The 3-char
+ *     gate excludes stray special-character noise (single emoji,
+ *     transliterated diacritics) without missing real phrases.
+ *
+ * Two regexes, OR-combined per scan. `u` flag is required for the
+ * Unicode-property classes.
+ */
+const NON_LATIN_HIGH_DENSITY_REGEX = new RegExp(
+  '[\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}\\p{Script=Hangul}]{2,}',
+  'gu',
+);
+const NON_LATIN_ALPHABETIC_REGEX = new RegExp(
+  '[\\p{Script=Cyrillic}\\p{Script=Devanagari}\\p{Script=Arabic}\\p{Script=Hebrew}\\p{Script=Greek}\\p{Script=Thai}]{3,}',
+  'gu',
+);
+
+export function validatePrhInlineLang(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  for (const file of input.xhtmlFiles) {
+    // Strip elements that already carry a lang attribute — anything
+    // inside is correctly marked, so it shouldn't count toward the
+    // "missing wrap" heuristic. We do this by removing the entire
+    // element-content span between a lang-bearing open tag and its
+    // matching close tag. The regex is intentionally non-greedy AND
+    // shallow (single-level): nested lang attributes are rare enough
+    // that ignoring them is acceptable for a heuristic detector.
+    const withoutLangWraps = stripLangBearingElements(file.content);
+    const withoutMarkup = stripHtmlMarkup(withoutLangWraps);
+
+    NON_LATIN_HIGH_DENSITY_REGEX.lastIndex = 0;
+    NON_LATIN_ALPHABETIC_REGEX.lastIndex = 0;
+    // Two independent scans — one per threshold class — then merge.
+    // Han/Hiragana/Katakana/Hangul match at 2+ chars; the alphabetic
+    // scripts at 3+. Runs from each regex are stable substrings so
+    // a simple concat is fine.
+    const matches = [
+      ...(withoutMarkup.match(NON_LATIN_HIGH_DENSITY_REGEX) ?? []),
+      ...(withoutMarkup.match(NON_LATIN_ALPHABETIC_REGEX) ?? []),
+    ];
+    if (matches.length === 0) continue;
+
+    // Show up to 3 sample runs in the message so operators can find
+    // the offending text quickly. Trim each sample so a multi-line
+    // run doesn't bloat the message.
+    const samples = matches
+      .slice(0, 3)
+      .map((m) => m.trim().slice(0, 40))
+      .filter((s) => s.length > 0);
+
+    issues.push(buildIssue(file.path, matches.length, samples));
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Remove the content of every INNER element that opens with a
+ * `lang=` attribute (or `xml:lang=`). Document-level lang on `<html>`
+ * / `<body>` is intentionally NOT stripped — that's the DEFAULT
+ * language of the document, against which the rest of the content is
+ * already assumed to be aligned. Foreign-language runs are
+ * deviations from that default and must be wrapped in INNER
+ * `<span lang="…">` / `<section lang="…">` elements; only those
+ * inner wraps should suppress the heuristic.
+ *
+ * Missed nested wraps (a lang span inside another lang span) are
+ * tolerated — for a heuristic detector, the worst case is a false
+ * positive the operator dismisses.
+ */
+function stripLangBearingElements(html: string): string {
+  // Match INNER open tags that carry lang or xml:lang, then everything
+  // up to the corresponding close tag for the SAME tag name. The
+  // negative lookahead `(?!html|body)\b` rejects the document-level
+  // wrappers — without it, an outer `<html lang="en">` would scoop
+  // up the entire body content and silence every foreign-language
+  // run, defeating the validator.
+  return html.replace(
+    /<(?!html\b|body\b)([a-z][a-z0-9]*)\b[^>]*(?:^|\s)(?:lang|xml:lang)\s*=\s*["'][^"']*["'][^>]*>[\s\S]*?<\/\1>/gi,
+    ' ',
+  );
+}
+
+function stripHtmlMarkup(html: string): string {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z]+;/gi, ' ')
+    .replace(/&#x?[0-9a-f]+;/gi, ' ');
+}
+
+function buildIssue(location: string, runCount: number, samples: string[]): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES['PRH-LANG-INLINE-NOT-MARKED'];
+  const samplesPart = samples.length > 0 ? ` Examples: ${samples.map((s) => `"${s}"`).join(', ')}.` : '';
+  return {
+    code: 'PRH-LANG-INLINE-NOT-MARKED',
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location} contains ${runCount} unmarked non-Latin-script run(s).${samplesPart}`,
+    suggestion:
+      `Wrap each foreign-language run in <span lang="<ISO-639-1>">…</span> (e.g. <span lang="ru">…</span> for Russian). For long-form passages, set lang on the containing section instead. Latin-script foreign content (French, German, etc.) is not auto-detected — wrap manually.`,
+    location,
+  };
+}

--- a/src/services/epub/profiles/prh-uk/validators/text-utils.ts
+++ b/src/services/epub/profiles/prh-uk/validators/text-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared text-normalisation helpers used by P3/PR4's heuristic
+ * validators (inline-lang / hashtag / acronym). All three need the
+ * same "strip markup, return visible text" pass — extracting it here
+ * keeps the behaviour aligned across detectors so a fix in one is a
+ * fix in all.
+ */
+
+/**
+ * Strip XHTML markup down to its visible text. Removes:
+ *   - <script>…</script> + <style>…</style> blocks (their contents are
+ *     never visible text — leaving them in would surface spurious
+ *     matches against CSS class names, hashtag-looking selectors, etc.)
+ *   - all element tags (replaced with space so adjacent words stay
+ *     separate after collapse)
+ *   - named entities (&nbsp; etc.) — replaced with space
+ *   - numeric entities (&#160; / &#x00a0;) — replaced with space
+ *
+ * Output is NOT whitespace-collapsed — callers may need the
+ * positional information of the original text (e.g. for run-detection
+ * regex). Use a separate `.replace(/\s+/g, ' ').trim()` step if you
+ * need normalised whitespace.
+ */
+export function stripHtmlMarkup(html: string): string {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z]+;/gi, ' ')
+    .replace(/&#x?[0-9a-f]+;/gi, ' ');
+}

--- a/tests/unit/services/epub/profiles/prh-uk/validators/acronym-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/acronym-validator.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhAcronyms } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/acronym-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function file(body: string): PrhXhtmlFile {
+  return {
+    path: 'chapter1.xhtml',
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+describe('validatePrhAcronyms — flagged cases (3+ letters with separators)', () => {
+  it('flags "N.A.S.A."', () => {
+    const files = [file('<p>The N.A.S.A. mission launched.</p>')];
+    const issues = validatePrhAcronyms(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-ACRONYM-INSERTED-SEPARATORS');
+    expect(issues[0].message).toMatch(/N\.A\.S\.A/);
+  });
+
+  it('flags "F.B.I."', () => {
+    const files = [file('<p>An F.B.I. agent arrived.</p>')];
+    expect(validatePrhAcronyms(input(files))).toHaveLength(1);
+  });
+
+  it('flags space-separated 3-letter acronym ("U S A")', () => {
+    const files = [file('<p>Born in the U S A according to the song.</p>')];
+    const issues = validatePrhAcronyms(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/U S A/);
+  });
+
+  it('flags comma-separated 3-letter acronym ("F, B, I")', () => {
+    const files = [file('<p>Agency: F, B, I — the bureau.</p>')];
+    const issues = validatePrhAcronyms(input(files))[0];
+    expect(issues.message).toMatch(/F, B, I/);
+  });
+
+  it('flags 4+ letter acronyms ("R.S.V.P.")', () => {
+    const files = [file('<p>R.S.V.P. requested.</p>')];
+    expect(validatePrhAcronyms(input(files))).toHaveLength(1);
+  });
+});
+
+describe('validatePrhAcronyms — NOT flagged (intentional exclusions)', () => {
+  it('does NOT flag 2-letter abbreviations ("U.S.", "J.K.")', () => {
+    // Two-letter sequences are routine in body text and rarely cause
+    // TTS problems. Style Guide tolerates them.
+    const files = [file('<p>The U.S. economy. J.K. Rowling wrote it.</p>')];
+    expect(validatePrhAcronyms(input(files))).toEqual([]);
+  });
+
+  it('does NOT flag compact acronyms ("NASA", "FBI", "USA")', () => {
+    const files = [file('<p>NASA, the FBI, and the USA work together.</p>')];
+    expect(validatePrhAcronyms(input(files))).toEqual([]);
+  });
+
+  it('does NOT flag "e.g." or "i.e." (lowercase, not all-caps)', () => {
+    const files = [file('<p>The pattern, e.g., NASA, is compact. See also i.e.</p>')];
+    expect(validatePrhAcronyms(input(files))).toEqual([]);
+  });
+
+  it('does NOT flag mixed-case words like "PhD"', () => {
+    const files = [file('<p>She holds a PhD in mathematics.</p>')];
+    expect(validatePrhAcronyms(input(files))).toEqual([]);
+  });
+});
+
+describe('validatePrhAcronyms — message shape', () => {
+  it('lists multiple unique offenders', () => {
+    const files = [file('<p>N.A.S.A. and F.B.I. and U S A.</p>')];
+    const issues = validatePrhAcronyms(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/3 acronym/);
+  });
+
+  it('de-duplicates repeated offenders', () => {
+    const files = [file('<p>N.A.S.A. and N.A.S.A. again and once more N.A.S.A.</p>')];
+    const issues = validatePrhAcronyms(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/1 acronym/);
+  });
+
+  it('emits ONE issue per offending file', () => {
+    const files = [
+      file('<p>N.A.S.A.</p>'),
+      { path: 'b.xhtml', content: '<html><body><p>F.B.I.</p></body></html>' },
+      { path: 'c.xhtml', content: '<html><body><p>clean</p></body></html>' },
+    ];
+    const issues = validatePrhAcronyms(input(files));
+    expect(issues).toHaveLength(2);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/hashtag-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/hashtag-validator.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhHashtags } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/hashtag-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function file(body: string): PrhXhtmlFile {
+  return {
+    path: 'chapter1.xhtml',
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+describe('validatePrhHashtags — happy paths', () => {
+  it('emits zero issues for properly camelCased hashtags', () => {
+    const files = [file('<p>Follow #WomenInTech and #nytBestseller for updates.</p>')];
+    expect(validatePrhHashtags(input(files))).toEqual([]);
+  });
+
+  it('accepts PascalCase tokens', () => {
+    const files = [file('<p>#WomenInTech</p>')];
+    expect(validatePrhHashtags(input(files))).toEqual([]);
+  });
+
+  it('accepts camelCase tokens with internal capital', () => {
+    const files = [file('<p>#nytBestseller</p>')];
+    expect(validatePrhHashtags(input(files))).toEqual([]);
+  });
+
+  it('accepts mixed-case acronym-style tokens', () => {
+    const files = [file('<p>#PRHuk</p>')];
+    expect(validatePrhHashtags(input(files))).toEqual([]);
+  });
+
+  it('does NOT flag numeric tokens like "#42" or "#1"', () => {
+    const files = [file('<p>see #42 in the index</p>')];
+    expect(validatePrhHashtags(input(files))).toEqual([]);
+  });
+});
+
+describe('validatePrhHashtags — non-camel detection', () => {
+  it('flags all-lowercase hashtags', () => {
+    const files = [file('<p>Follow #womenintech for more.</p>')];
+    const issues = validatePrhHashtags(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-HASHTAG-NOT-CAMEL-CASE');
+    expect(issues[0].message).toMatch(/#womenintech/);
+  });
+
+  it('flags all-uppercase hashtags', () => {
+    const files = [file('<p>#NYTBESTSELLER</p>')];
+    const issues = validatePrhHashtags(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/#NYTBESTSELLER/);
+  });
+
+  it('de-duplicates repeated offenders in the message count', () => {
+    const files = [file('<p>#womenintech and again #womenintech and more #womenintech</p>')];
+    const issues = validatePrhHashtags(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/1 unique non-camelCase hashtag/);
+  });
+
+  it('lists multiple unique offenders', () => {
+    const files = [file('<p>#womenintech #nytbestseller #BOOKTOK</p>')];
+    const issues = validatePrhHashtags(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/3 unique non-camelCase/);
+  });
+
+  it('emits ONE issue per offending file', () => {
+    const files = [
+      file('<p>#allnouns</p>'),
+      { path: 'b.xhtml', content: '<html><body><p>#alsoalllowercase</p></body></html>' },
+      { path: 'c.xhtml', content: '<html><body><p>clean</p></body></html>' },
+    ];
+    const issues = validatePrhHashtags(input(files));
+    expect(issues).toHaveLength(2);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/inline-lang-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/inline-lang-validator.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhInlineLang } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/inline-lang-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function input(xhtmlFiles: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles,
+  };
+}
+
+function file(body: string): PrhXhtmlFile {
+  return {
+    path: 'chapter1.xhtml',
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops" lang="en">
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+describe('validatePrhInlineLang — happy paths', () => {
+  it('emits zero issues for plain English text', () => {
+    const files = [file('<p>Plain English content with normal punctuation.</p>')];
+    expect(validatePrhInlineLang(input(files))).toEqual([]);
+  });
+
+  it('does NOT fire on isolated non-Latin characters (<3 chars in a run)', () => {
+    // Single ñ, é, or smart quotes are technically Latin-script but
+    // even non-Latin singletons (one Cyrillic letter) shouldn't fire
+    // because of the 3-char minimum.
+    const files = [file('<p>Café résumé naïve — and one Я character.</p>')];
+    expect(validatePrhInlineLang(input(files))).toEqual([]);
+  });
+
+  it('emits ZERO issues when foreign text is correctly wrapped in <span lang>', () => {
+    // Russian phrase correctly marked → no issue.
+    const files = [file('<p>The Russian for hello is <span lang="ru">привет</span>.</p>')];
+    expect(validatePrhInlineLang(input(files))).toEqual([]);
+  });
+});
+
+describe('validatePrhInlineLang — non-Latin run detection', () => {
+  it('flags an unmarked Cyrillic run', () => {
+    const files = [file('<p>The Russian for hello is привет — said the spy.</p>')];
+    const issues = validatePrhInlineLang(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('PRH-LANG-INLINE-NOT-MARKED');
+    expect(issues[0].message).toMatch(/привет/);
+  });
+
+  it('flags Devanagari runs (Hindi)', () => {
+    const files = [file('<p>नमस्ते means hello.</p>')];
+    expect(validatePrhInlineLang(input(files))).toHaveLength(1);
+  });
+
+  it('flags Arabic runs', () => {
+    const files = [file('<p>The greeting مرحبا appears once.</p>')];
+    expect(validatePrhInlineLang(input(files))).toHaveLength(1);
+  });
+
+  it('flags Han (CJK) runs', () => {
+    const files = [file('<p>Beijing 北京 is the capital.</p>')];
+    expect(validatePrhInlineLang(input(files))).toHaveLength(1);
+  });
+
+  it('aggregates multiple runs into ONE issue per file', () => {
+    const files = [file('<p>привет and 北京 and नमस्ते all in one paragraph.</p>')];
+    const issues = validatePrhInlineLang(input(files));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/3 unmarked/);
+  });
+
+  it('reports up to 3 sample runs in the message', () => {
+    const files = [file('<p>привет здравствуйте добрый</p>')];
+    const issues = validatePrhInlineLang(input(files));
+    expect(issues[0].message).toMatch(/привет/);
+  });
+});
+
+describe('validatePrhInlineLang — defensive paths', () => {
+  it('handles files with no body content gracefully', () => {
+    const files: PrhXhtmlFile[] = [{ path: 'empty.xhtml', content: '<html><body/></html>' }];
+    expect(validatePrhInlineLang(input(files))).toEqual([]);
+  });
+
+  it('respects xml:lang too (a section with xml:lang="ru" is skipped)', () => {
+    const files = [file('<section xml:lang="ru"><p>привет здравствуйте</p></section>')];
+    expect(validatePrhInlineLang(input(files))).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/inline-lang-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/inline-lang-validator.test.ts
@@ -73,10 +73,19 @@ describe('validatePrhInlineLang — non-Latin run detection', () => {
     expect(issues[0].message).toMatch(/3 unmarked/);
   });
 
-  it('reports up to 3 sample runs in the message', () => {
-    const files = [file('<p>привет здравствуйте добрый</p>')];
+  it('reports up to 3 sample runs in the message — first three only, fourth excluded', () => {
+    // Four distinct Russian words. The validator caps the in-message
+    // sample list at 3 so the message stays readable on books with
+    // dozens of inline runs. Assert all three early samples appear
+    // AND that the fourth is excluded — otherwise the cap is silently
+    // off.
+    const files = [file('<p>привет здравствуйте добрый вечер</p>')];
     const issues = validatePrhInlineLang(input(files));
+    expect(issues).toHaveLength(1);
     expect(issues[0].message).toMatch(/привет/);
+    expect(issues[0].message).toMatch(/здравствуйте/);
+    expect(issues[0].message).toMatch(/добрый/);
+    expect(issues[0].message).not.toMatch(/вечер/);
   });
 });
 


### PR DESCRIPTION
## Summary

Final P3 PR — closes the markup-conventions priority. Three publisher-gated text-pattern detectors, 3 new codes. All explicitly heuristic.

## New validators

| Validator | Code | Severity | WCAG |
|---|---|---|---|
| `validatePrhInlineLang` | `PRH-LANG-INLINE-NOT-MARKED` | minor | 3.1.2 |
| `validatePrhHashtags` | `PRH-HASHTAG-NOT-CAMEL-CASE` | minor | — |
| `validatePrhAcronyms` | `PRH-ACRONYM-INSERTED-SEPARATORS` | minor | — |

## Heuristic design

These three rules carry higher false-positive risk than the rest of P3. Mitigations:
- All severity `minor`. Frontend Prompt 8 will surface a "review manually" info marker (planned).
- **inline-lang** uses a two-tier threshold: alphabetic scripts (Cyrillic/Devanagari/Arabic/Hebrew/Greek/Thai) at ≥3 chars, logographic/syllabic (Han/Hiragana/Katakana/Hangul) at ≥2 chars. CJK words carry meaning at 2 glyphs (`北京` = Beijing); alphabetic scripts need 3 to distinguish from noise.
- **inline-lang** intentionally excludes document-level `<html lang>` / `<body lang>` — foreign content is a deviation from that default, not a match for it.
- **inline-lang** does NOT detect Latin-script foreign content (French/German/Spanish) — that requires a language-detection model and is deferred to a future PR.
- **hashtag** skips all-digit tokens (`#42` is a page reference, not a hashtag).
- **acronym** requires ≥3 letters with separators between EACH pair. Two-letter abbreviations (`U.S.`, `J.K.`) are skipped — routine in body text and rarely cause TTS problems.
- High-volume codes group offenders into ONE issue per file (the FE grouping prompt will collapse multi-file).

## Test plan

- [x] 336/336 PRH unit tests passing (33 new across three validators)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean

## P3 completion

| PR | Validator | Codes | Tests |
|---|---|---|---|
| #369 | body epub:type + doc-* ARIA + body purity | 8 | 35 |
| #371 | forbidden tags + inline-style + layout-table | 3 | 24 |
| #372 | footnote ref↔id parity + page-break shape | 2 | 24 |
| **THIS** | inline-lang + hashtag + acronym | 3 | 33 |
| **Total P3** | — | **16** | **116 new** (336 total) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three text-pattern accessibility checks: unmarked inline non‑Latin language runs, non‑camelCase hashtags, and acronyms with inserted separators; each reports actionable suggestions.

* **Tests**
  * Added comprehensive unit tests covering detection, exclusions, deduplication, message formatting, and per-file aggregation for all three validators.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/375)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->