### PR TITLE
feat(prh): PRH-COVER-ALT-EMPTY quick-fix wiring (Prompt 3 BE)

### DIFF
--- a/src/constants/fix-classification.ts
+++ b/src/constants/fix-classification.ts
@@ -63,10 +63,13 @@ export const QUICK_FIXABLE_CODES = new Set([
   'EPUB-SEM-003',
   'LANDMARK-UNIQUE',
   'EPUB-TYPE-HAS-MATCHING-ROLE',
-  // PRH-COVER-ALT-EMPTY is NOT in this set yet: it falls back to
-  // manual classification (severity=serious so it still stands out in
-  // the UI). Wiring the quick-fix controller route to call addAltText
-  // for the cover image is a small follow-up — out of scope for PR4.
+  // PRH UK cover alt — operator supplies alt text via the existing
+  // quick-fix dialog ("Cover for [Book Title]" template). Routed
+  // through the same addAltText handler as EPUB-IMG-001, with a
+  // dedicated controller arm that rejects missing imageAlts (cover
+  // MUST have alt; falling back to decorative is wrong for the cover
+  // image specifically).
+  'PRH-COVER-ALT-EMPTY',
 ]);
 
 // Map ACE codes to equivalent JS Auditor codes to prevent duplicate processing

--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -153,10 +153,13 @@ export const PRH_ISSUE_CODES = {
     severity: 'serious',
     wcag: ['1.1.1'],
     // Quick-fix: operator supplies alt text via the existing
-    // EPUB-IMG-001-style dialog, controller arm in epub.controller.ts
-    // routes the payload through epubModifier.addAltText. Falls back
-    // to manual if imageAlts is missing — we don't fabricate cover
-    // alt text or mark the cover decorative.
+    // EPUB-IMG-001-style dialog. The controller arm in
+    // epub.controller.ts validates the payload — missing/empty
+    // imageAlts, missing imageSrc, or whitespace-only altText all
+    // produce a 400 with a clear error message rather than silently
+    // writing empty alt to the cover image. addAltText is only
+    // invoked when the payload is well-formed; we never fabricate
+    // cover alt text or fall back to marking the cover decorative.
     fixType: 'quickfix',
     summary: 'Cover image alt must be non-empty (e.g. "Cover for [Book Title]")',
   },

--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -150,13 +150,14 @@ export const PRH_ISSUE_CODES = {
   // ── Image (PR4) ────────────────────────────────────────────────────────
   'PRH-COVER-ALT-EMPTY': {
     code: 'PRH-COVER-ALT-EMPTY',
-    // Marked `manual` for now: the existing applyBatchQuickFix
-    // controller switch has no case for this code (would 400 on
-    // "unknown fix code"). Operator fixes the cover alt manually until
-    // a follow-up wires the quick-fix route to addAltText for the cover.
     severity: 'serious',
     wcag: ['1.1.1'],
-    fixType: 'manual',
+    // Quick-fix: operator supplies alt text via the existing
+    // EPUB-IMG-001-style dialog, controller arm in epub.controller.ts
+    // routes the payload through epubModifier.addAltText. Falls back
+    // to manual if imageAlts is missing — we don't fabricate cover
+    // alt text or mark the cover decorative.
+    fixType: 'quickfix',
     summary: 'Cover image alt must be non-empty (e.g. "Cover for [Book Title]")',
   },
   'PRH-DECORATIVE-MISSING-PRESENTATION-ROLE': {

--- a/src/controllers/epub.controller.ts
+++ b/src/controllers/epub.controller.ts
@@ -22,6 +22,38 @@ import { workflowConfigService } from '../services/workflow/workflow-config.serv
 
 const comparisonService = new ComparisonService(prisma);
 
+/**
+ * Validate the imageAlts payload supplied for PRH-COVER-ALT-EMPTY
+ * quick-fix requests. Returns null when the payload is well-formed
+ * (non-empty array, every entry has a non-empty imageSrc and a
+ * non-whitespace altText). Returns a human-readable error string
+ * when the payload is malformed — the caller renders that as a 400.
+ *
+ * PRH's rule is that the cover image MUST have explicit alt text;
+ * an empty / whitespace-only altText is the precise failure mode
+ * the validator is designed to catch, so accepting it here would
+ * defeat the rule. Same applies to imageAlts entries whose imageSrc
+ * is missing — without a target there's nothing for addAltText to
+ * write into.
+ */
+function validateCoverAltPayload(
+  imageAlts: Array<{ imageSrc?: string; altText?: string }> | undefined,
+): string | null {
+  if (!imageAlts || imageAlts.length === 0) {
+    return 'PRH-COVER-ALT-EMPTY requires options.imageAlts with at least one { imageSrc, altText } entry — cover image must have explicit alt text, never decorative.';
+  }
+  for (let i = 0; i < imageAlts.length; i += 1) {
+    const entry = imageAlts[i];
+    if (!entry.imageSrc || entry.imageSrc.trim().length === 0) {
+      return `PRH-COVER-ALT-EMPTY: options.imageAlts[${i}].imageSrc must be a non-empty string identifying the cover image.`;
+    }
+    if (!entry.altText || entry.altText.trim().length === 0) {
+      return `PRH-COVER-ALT-EMPTY: options.imageAlts[${i}].altText must be non-empty (e.g. "Cover for [Book Title]"). PRH forbids empty or whitespace-only cover alt.`;
+    }
+  }
+  return null;
+}
+
 export const epubController = {
   async getJob(req: AuthenticatedRequest, res: Response) {
     try {
@@ -1166,21 +1198,25 @@ export const epubController = {
             results = await epubModifier.addDecorativeAltAttributes(zip);
           }
           break;
-        case 'PRH-COVER-ALT-EMPTY':
+        case 'PRH-COVER-ALT-EMPTY': {
           // Cover-image alt is REQUIRED by PRH — never marked decorative.
           // The FE quick-fix dialog must supply `options.imageAlts`
-          // with at least one { imageSrc, altText } entry (template:
-          // "Cover for [Book Title]"). Reject the request rather than
-          // falling back to addDecorativeAltAttributes — that would
-          // silently mark the cover as decorative.
-          if (!options?.imageAlts || options.imageAlts.length === 0) {
-            return res.status(400).json({
-              success: false,
-              error: 'PRH-COVER-ALT-EMPTY requires options.imageAlts with at least one { imageSrc, altText } entry — cover image must have explicit alt text, never decorative.',
-            });
+          // with at least one { imageSrc, altText } entry, where
+          // altText is non-empty after trim. Reject the request
+          // rather than falling back to addDecorativeAltAttributes —
+          // that would silently mark the cover as decorative. Also
+          // reject per-entry empty altText / imageSrc, otherwise a
+          // payload like [{ imageSrc: '...', altText: '   ' }] would
+          // produce empty alt and defeat the very rule we enforce.
+          const validation = validateCoverAltPayload(options?.imageAlts);
+          if (validation) {
+            return res.status(400).json({ success: false, error: validation });
           }
-          results = await epubModifier.addAltText(zip, options.imageAlts);
+          // Non-null assertion is safe — validateCoverAltPayload
+          // returns null only when imageAlts is a non-empty array.
+          results = await epubModifier.addAltText(zip, options!.imageAlts!);
           break;
+        }
         case 'EPUB-STRUCT-002':
           results = await epubModifier.addTableHeaders(zip);
           break;
@@ -2187,17 +2223,18 @@ export const epubController = {
             allResults = await epubModifier.addDecorativeAltAttributes(zip);
           }
           break;
-        case 'PRH-COVER-ALT-EMPTY':
+        case 'PRH-COVER-ALT-EMPTY': {
           // Same contract as the applyQuickFix arm — cover image alt
-          // is REQUIRED; reject if imageAlts is missing/empty.
-          if (!options?.imageAlts || options.imageAlts.length === 0) {
-            return res.status(400).json({
-              success: false,
-              error: 'PRH-COVER-ALT-EMPTY requires options.imageAlts with at least one { imageSrc, altText } entry — cover image must have explicit alt text, never decorative.',
-            });
+          // is REQUIRED, every entry must carry a non-empty imageSrc
+          // and a non-whitespace altText (empty alt would silently
+          // defeat the rule).
+          const validation = validateCoverAltPayload(options?.imageAlts);
+          if (validation) {
+            return res.status(400).json({ success: false, error: validation });
           }
-          allResults = await epubModifier.addAltText(zip, options.imageAlts);
+          allResults = await epubModifier.addAltText(zip, options!.imageAlts!);
           break;
+        }
         case 'EPUB-STRUCT-002':
           allResults = await epubModifier.addTableHeaders(zip);
           break;

--- a/src/controllers/epub.controller.ts
+++ b/src/controllers/epub.controller.ts
@@ -972,6 +972,7 @@ export const epubController = {
             'EPUB-NAV-001': 'Add skip navigation links',
             'EPUB-NAV-002': 'Add unique aria-labels to navigation landmarks',
             'EPUB-FIG-001': 'Add figure/figcaption structure',
+            'PRH-COVER-ALT-EMPTY': 'Add cover image alt text (e.g. "Cover for [Book Title]")',
           },
         },
       });
@@ -1164,6 +1165,21 @@ export const epubController = {
           } else {
             results = await epubModifier.addDecorativeAltAttributes(zip);
           }
+          break;
+        case 'PRH-COVER-ALT-EMPTY':
+          // Cover-image alt is REQUIRED by PRH — never marked decorative.
+          // The FE quick-fix dialog must supply `options.imageAlts`
+          // with at least one { imageSrc, altText } entry (template:
+          // "Cover for [Book Title]"). Reject the request rather than
+          // falling back to addDecorativeAltAttributes — that would
+          // silently mark the cover as decorative.
+          if (!options?.imageAlts || options.imageAlts.length === 0) {
+            return res.status(400).json({
+              success: false,
+              error: 'PRH-COVER-ALT-EMPTY requires options.imageAlts with at least one { imageSrc, altText } entry — cover image must have explicit alt text, never decorative.',
+            });
+          }
+          results = await epubModifier.addAltText(zip, options.imageAlts);
           break;
         case 'EPUB-STRUCT-002':
           results = await epubModifier.addTableHeaders(zip);
@@ -2170,6 +2186,17 @@ export const epubController = {
           } else {
             allResults = await epubModifier.addDecorativeAltAttributes(zip);
           }
+          break;
+        case 'PRH-COVER-ALT-EMPTY':
+          // Same contract as the applyQuickFix arm — cover image alt
+          // is REQUIRED; reject if imageAlts is missing/empty.
+          if (!options?.imageAlts || options.imageAlts.length === 0) {
+            return res.status(400).json({
+              success: false,
+              error: 'PRH-COVER-ALT-EMPTY requires options.imageAlts with at least one { imageSrc, altText } entry — cover image must have explicit alt text, never decorative.',
+            });
+          }
+          allResults = await epubModifier.addAltText(zip, options.imageAlts);
           break;
         case 'EPUB-STRUCT-002':
           allResults = await epubModifier.addTableHeaders(zip);

--- a/tests/unit/constants/fix-classification.test.ts
+++ b/tests/unit/constants/fix-classification.test.ts
@@ -35,3 +35,31 @@ describe('QUICK_FIXABLE_CODES set membership', () => {
     expect(AUTO_FIXABLE_CODES.has('PRH-COVER-ALT-EMPTY')).toBe(false);
   });
 });
+
+describe('PRH-COVER-ALT-EMPTY payload-validation invariants', () => {
+  // These tests assert the contract documented on the controller's
+  // validateCoverAltPayload helper. The helper itself isn't exported
+  // (it's a controller-scoped utility), so we lock the contract in
+  // via the documentation here and via the integration paths in
+  // controller spec coverage when that's added. The shape rules:
+  //
+  //   - imageAlts is required and must be non-empty.
+  //   - Every entry must have a non-empty imageSrc.
+  //   - Every entry must have a non-whitespace altText.
+  //
+  // A whitespace-only altText (`"   "`) explicitly fails because
+  // accepting it would write empty cover alt and silently break the
+  // rule we're enforcing. Tests here are sentinel-style — they
+  // document the expected behaviour; the runtime enforcement lives
+  // in src/controllers/epub.controller.ts validateCoverAltPayload.
+  it('documents required shape: { imageSrc, altText } entries, both non-empty', () => {
+    // Compile-time contract assertion: this test exists to flag any
+    // future change to the contract during code review. If the shape
+    // moves to a different field set, update both the controller
+    // helper and this sentinel.
+    type ExpectedShape = { imageSrc: string; altText: string };
+    const sample: ExpectedShape = { imageSrc: 'cover.jpg', altText: 'Cover for The Book' };
+    expect(sample.imageSrc.length).toBeGreaterThan(0);
+    expect(sample.altText.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/constants/fix-classification.test.ts
+++ b/tests/unit/constants/fix-classification.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getFixType,
+  AUTO_FIXABLE_CODES,
+  QUICK_FIXABLE_CODES,
+} from '../../../src/constants/fix-classification';
+
+describe('getFixType — quick-fix routing', () => {
+  it('routes EPUB-IMG-001 to quickfix (sanity baseline)', () => {
+    expect(getFixType('EPUB-IMG-001')).toBe('quickfix');
+  });
+
+  it('routes PRH-COVER-ALT-EMPTY to quickfix (P2-P3 FE Prompt 3)', () => {
+    // PRH cover-alt is operator-supplied; the FE quick-fix dialog
+    // collects the alt text and POSTs it through the same payload
+    // shape as EPUB-IMG-001. Wired up in epub.controller.ts arms in
+    // applyQuickFix + applyBatchQuickFix.
+    expect(getFixType('PRH-COVER-ALT-EMPTY')).toBe('quickfix');
+  });
+
+  it('routes an unknown PRH code to manual (default fallback)', () => {
+    expect(getFixType('PRH-UNKNOWN-CODE-XYZ')).toBe('manual');
+  });
+});
+
+describe('QUICK_FIXABLE_CODES set membership', () => {
+  it('includes PRH-COVER-ALT-EMPTY', () => {
+    expect(QUICK_FIXABLE_CODES.has('PRH-COVER-ALT-EMPTY')).toBe(true);
+  });
+
+  it('does NOT promote PRH-COVER-ALT-EMPTY to auto-fixable (operator must supply alt)', () => {
+    // PRH explicitly requires operator-supplied alt for the cover
+    // image; never auto-fabricated. Guards against accidental
+    // promotion to AUTO_FIXABLE_CODES.
+    expect(AUTO_FIXABLE_CODES.has('PRH-COVER-ALT-EMPTY')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Small additive change that wires `PRH-COVER-ALT-EMPTY` into the existing alt-text quick-fix flow. Unblocks staging end-to-end testing of the FE-side Prompt 3 work that already shipped (per the P2-P3 frontend follow-up plan).

## Changes

| File | Change |
|---|---|
| `fix-classification.ts` | Add `PRH-COVER-ALT-EMPTY` to `QUICK_FIXABLE_CODES` so `getFixType()` resolves it to `'quickfix'` |
| `prh-issue-codes.ts` | Update the `PrhIssueDefinition.fixType` field from `'manual'` to `'quickfix'` (was a placeholder) |
| `epub.controller.ts` | Add case arms to BOTH `applyQuickFix` (~L1167) and `applyBatchQuickFix` (~L2173). Routes through `epubModifier.addAltText` with `options.imageAlts`. **Rejects with 400 if `imageAlts` is missing or empty** — the cover image must NEVER be marked decorative; falling back to `addDecorativeAltAttributes` (the EPUB-IMG-001 behaviour) would silently break PRH conformance for the cover. |
| `getSupportedFixes` descriptions | Add `'Add cover image alt text (e.g. "Cover for [Book Title]")'` |
| `tests/unit/constants/fix-classification.test.ts` | NEW — 5 tests locking the routing |

## Payload contract

Unchanged from `EPUB-IMG-001`:
```
{ fixCode: 'PRH-COVER-ALT-EMPTY',
  options: { imageAlts: [{ imageSrc: '<cover image src>', altText: '<user input>' }] } }
```

## Test plan

- [x] 1390/1390 unit tests passing (5 new for routing assertions)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke: FE submits the new payload → cover alt is set on the remediated EPUB → re-audit shows `PRH-COVER-ALT-EMPTY` resolved
- [ ] Staging smoke: FE submits the new payload WITHOUT `imageAlts` → 400 with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cover-image alt-text issues can be resolved via quick-fix with explicit alt-text input (no auto-generated or decorative fallback).

* **Behavior Changes**
  * Quick-fix endpoints now validate alt-text payloads and return errors for missing/empty values instead of auto-filling.

* **Tests**
  * Added unit tests for fix-code routing, fix-type categorization, and cover-alt payload shape.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/377)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->