### PR TITLE
fix(workers): reduce calibration lockDuration from 3h to 5min

### DIFF
--- a/src/workers/calibration.worker.ts
+++ b/src/workers/calibration.worker.ts
@@ -65,6 +65,16 @@ export const startCalibrationWorker = () =>
     queueName: QUEUE_NAMES.CALIBRATION,
     processor: processCalibrationJob,
     concurrency: 2,
-    // Docling ML inference can take 1-2 hours for large PDFs (500+ pages) on CPU
-    lockDuration: 3 * 60 * 60 * 1000, // 3 hours
+    // lockDuration bounds **crash recovery**, not job duration. A live worker
+    // renews the lock every lockDuration/2; long jobs (Docling on a 672-page
+    // PDF took ~17min on GPU) are unaffected as long as no single synchronous
+    // block exceeds the renewal interval. The previous 3h value was sized for
+    // CPU-Docling but meant a crashed worker held a job for up to 3 hours
+    // before BullMQ's stalled-job sweeper could reassign it — exactly the
+    // failure mode of the 2026-05-11 OOM incident (Issue #366).
+    //
+    // 5 minutes gives the renewer (2.5min cadence) plenty of margin over the
+    // observed ~50s pdfjs extraction block on a 672-page PDF, while reducing
+    // post-crash recovery from hours to minutes.
+    lockDuration: 5 * 60 * 1000, // 5 minutes
   });


### PR DESCRIPTION
## Summary

Closes #366. Reduces \`lockDuration\` on the calibration worker from 3 hours to 5 minutes.

## Why

The 3h value was sized for CPU-Docling inference. Docling now runs on GPU (Tesla T4) and a 672-page PDF takes ~17 min end-to-end, with the longest single synchronous JS block (pdfjs extraction) at ~50s.

\`lockDuration\` bounds **crash recovery**, not job duration. A live worker renews the lock every \`lockDuration/2\`; long jobs are unaffected as long as no single synchronous block exceeds the renewal interval.

With the old value, a worker crash held the job locked for up to 3 hours — exactly the recovery delay we hit during the 2026-05-11 OOM incident. New value brings recovery down to ~5 min.

## Test plan

- [x] tsc --noEmit clean
- [x] No tests pin the constant (it's a tuning value)
- [ ] After merge + deploy: confirm normal calibration runs complete without "missing lock" errors. A 17-minute Docling run should show repeated lock-extension events at ~2.5min intervals in BullMQ telemetry (if logged).
- [ ] Optionally: simulate a worker crash mid-job (kill the ECS task during calibration) and confirm the job is reassigned within 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker recovery time following system failures or crashes, allowing jobs to be reclaimed more quickly and reducing potential downtime.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/379)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->