### PR TITLE
feat(prh): PRH-mode alt-text generator + cover template + bookTitle (P4/PR1)

### DIFF
--- a/src/services/alt-text/long-description-generator.service.ts
+++ b/src/services/alt-text/long-description-generator.service.ts
@@ -1,6 +1,18 @@
 import { GoogleGenerativeAI, GenerativeModel } from '@google/generative-ai';
 import DOMPurify from 'isomorphic-dompurify';
 import { logger } from '../../lib/logger';
+import type { AltTextProfile } from './photo-alt-generator.service';
+
+/**
+ * Optional generation tweaks. Callers from PRH-UK audited jobs should
+ * set `profile: 'prh-uk'` so the prose follows Style Guide Appendix 7
+ * rules (literal/objective wording, neutral pronouns, full-stop
+ * endings, etc.) — same shape as photo-alt-generator's options so
+ * the two services align.
+ */
+export interface LongDescriptionOptions {
+  profile?: AltTextProfile;
+}
 
 interface LongDescription {
   id: string;
@@ -87,7 +99,8 @@ class LongDescriptionGeneratorService {
     imageBuffer: Buffer,
     mimeType: string,
     trigger: LongDescriptionTrigger,
-    existingShortAlt?: string
+    existingShortAlt?: string,
+    options: LongDescriptionOptions = {},
   ): Promise<LongDescription> {
     if (!this.model) {
       return {
@@ -100,36 +113,8 @@ class LongDescriptionGeneratorService {
         aiModel: 'gemini-1.5-pro',
       };
     }
-    const prompt = `
-Generate a comprehensive long description for this image to be used with aria-describedby for accessibility.
-
-${existingShortAlt ? `Short alt text: "${existingShortAlt}"` : ''}
-
-Trigger: ${trigger}
-
-Requirements:
-- Write a detailed prose description (300-500 words)
-- Structure with clear sections if the image has distinct parts
-- For charts/graphs: describe all data points, trends, and axes
-- For flowcharts: describe each step and decision in sequence
-- For diagrams: explain all components and their relationships
-- For tables: describe all rows and columns of data
-- Use clear, plain language
-- Do NOT use "Image shows" or similar phrases
-- Present tense
-
-Return JSON only (no markdown):
-{
-  "plainText": "Full prose description...",
-  "markdown": "# Title\\n\\nDescription with **emphasis** and structure...",
-  "html": "<h2>Title</h2><p>Description...</p>",
-  "sections": [
-    { "heading": "Overview", "content": "..." },
-    { "heading": "Data Details", "content": "..." }
-  ],
-  "wordCount": 350
-}
-`;
+    const profile: AltTextProfile = options.profile ?? 'default';
+    const prompt = buildLongDescriptionPrompt(profile, trigger, existingShortAlt);
 
     const imagePart = {
       inlineData: {
@@ -230,3 +215,91 @@ Return JSON only (no markdown):
 
 export const longDescriptionGenerator = new LongDescriptionGeneratorService();
 export type { LongDescription, LongDescriptionTrigger, DescriptionSection };
+
+/**
+ * Build the long-description prompt. Two variants:
+ *   - default: existing detailed-prose rules
+ *   - prh-uk: PRH UK Style Guide Appendix 7 rules layered on top
+ *
+ * Both return JSON with plainText / markdown / html / sections /
+ * wordCount. PRH variant adds literal/objective wording, full-stop
+ * sentence endings, neutral pronouns, colour-only-when-significant.
+ */
+function buildLongDescriptionPrompt(
+  profile: AltTextProfile,
+  trigger: LongDescriptionTrigger,
+  existingShortAlt: string | undefined,
+): string {
+  const shortAltLine = existingShortAlt ? `Short alt text: "${existingShortAlt}"` : '';
+
+  if (profile === 'prh-uk') {
+    return `
+Generate a comprehensive long description for this image to be used with aria-describedby for accessibility.
+
+${shortAltLine}
+
+Trigger: ${trigger}
+
+PRH UK Style Guide Appendix 7 requirements (STRICT — follow exactly):
+- Write a detailed prose description (300-500 words).
+- Structure with clear sections if the image has distinct parts.
+- For charts/graphs: describe all data points, trends, and axes.
+- For flowcharts: describe each step and decision in sequence.
+- For diagrams: explain all components and their relationships.
+- For tables: describe all rows and columns of data.
+- Use clear, plain language.
+- Use LITERAL, OBJECTIVE wording. Do NOT speculate ("appears to be",
+  "perhaps", "seems to") or interpret emotion / motive.
+- END every sentence with a full stop.
+- Use NEUTRAL / non-gendered language by default ("person", "they")
+  unless context confirms identification.
+- Mention COLOUR only when significant to identification or meaning.
+- Do NOT use "Image shows", "This image depicts", "Picture of",
+  "Photo of", or similar opener phrases.
+- Present tense throughout.
+
+Return JSON only (no markdown):
+{
+  "plainText": "Full prose description with every sentence ending in a full stop...",
+  "markdown": "# Title\\n\\nDescription with **emphasis** and structure...",
+  "html": "<h2>Title</h2><p>Description...</p>",
+  "sections": [
+    { "heading": "Overview", "content": "..." },
+    { "heading": "Data Details", "content": "..." }
+  ],
+  "wordCount": 350
+}
+`;
+  }
+
+  return `
+Generate a comprehensive long description for this image to be used with aria-describedby for accessibility.
+
+${shortAltLine}
+
+Trigger: ${trigger}
+
+Requirements:
+- Write a detailed prose description (300-500 words)
+- Structure with clear sections if the image has distinct parts
+- For charts/graphs: describe all data points, trends, and axes
+- For flowcharts: describe each step and decision in sequence
+- For diagrams: explain all components and their relationships
+- For tables: describe all rows and columns of data
+- Use clear, plain language
+- Do NOT use "Image shows" or similar phrases
+- Present tense
+
+Return JSON only (no markdown):
+{
+  "plainText": "Full prose description...",
+  "markdown": "# Title\\n\\nDescription with **emphasis** and structure...",
+  "html": "<h2>Title</h2><p>Description...</p>",
+  "sections": [
+    { "heading": "Overview", "content": "..." },
+    { "heading": "Data Details", "content": "..." }
+  ],
+  "wordCount": 350
+}
+`;
+}

--- a/src/services/alt-text/photo-alt-generator.service.ts
+++ b/src/services/alt-text/photo-alt-generator.service.ts
@@ -5,6 +5,33 @@ import { aiConfig } from '../../config/ai.config';
 
 const ACTIVE_MODEL = aiConfig.gemini.model;
 
+/**
+ * Generator output profile. The default profile produces standard
+ * accessibility alt text. The `prh-uk` profile applies PRH UK
+ * Style Guide Appendix 7 rules:
+ *   - Literal / objective wording (no "appears to be", "perhaps").
+ *   - End every description with a full stop.
+ *   - Use neutral / non-gendered language unless context confirms.
+ *   - Mention colour only when significant to identification or meaning.
+ *   - No forbidden prefixes ("Image of", "Photo of", etc.) — enforced
+ *     in the prompt AND post-hoc via stripForbiddenPrefixes.
+ */
+export type AltTextProfile = 'default' | 'prh-uk';
+
+/**
+ * Optional generation tweaks. Callers from PRH-UK audited jobs should
+ * set `profile: 'prh-uk'`; for the cover image specifically, also
+ * set `isCover: true` and pass the book's `dc:title` as `bookTitle`.
+ * When isCover + prh-uk are both set, the generator short-circuits
+ * to the PRH-documented template ("Cover for [Book Title].") and
+ * skips the Gemini call entirely.
+ */
+export interface AltTextOptions {
+  profile?: AltTextProfile;
+  isCover?: boolean;
+  bookTitle?: string | null;
+}
+
 interface AltTextGenerationResult {
   imageId: string;
   shortAlt: string;
@@ -15,7 +42,7 @@ interface AltTextGenerationResult {
   generatedAt: Date;
 }
 
-type AltTextFlag = 
+type AltTextFlag =
   | 'FACE_DETECTED'
   | 'TEXT_IN_IMAGE'
   | 'LOW_CONFIDENCE'
@@ -24,7 +51,8 @@ type AltTextFlag =
   | 'AUTO_CORRECTED'
   | 'NEEDS_MANUAL_REVIEW'
   | 'REGENERATED'
-  | 'PARSE_ERROR';
+  | 'PARSE_ERROR'
+  | 'COVER_TEMPLATE';
 
 const FORBIDDEN_PREFIXES = [
   /^image of\s+/i,
@@ -39,30 +67,85 @@ const FORBIDDEN_PREFIXES = [
 const MAX_SHORT_ALT_LENGTH = 125;
 const MAX_EXTENDED_ALT_LENGTH = 250;
 
-class PhotoAltGeneratorService {
-  private genAI: GoogleGenerativeAI | null = null;
-  private model: GenerativeModel | null = null;
+/**
+ * Build the cover-image alt text per PRH Style Guide Appendix 7.
+ * `"Cover for [Book Title]."` when title is present; falls back to
+ * `"Cover image."` when `dc:title` is missing. Both forms end with
+ * the mandatory full stop. This is exported so callers (the
+ * controllers wiring PRH-COVER-ALT-EMPTY quick-fix dialogs) can use
+ * the same template logic without re-implementing it.
+ */
+export function buildPrhCoverAlt(bookTitle: string | null | undefined): string {
+  const trimmed = (bookTitle ?? '').trim();
+  return trimmed.length > 0 ? `Cover for ${trimmed}.` : 'Cover image.';
+}
 
-  /**
-   * Lazily initialize the Gemini client.
-   * This allows the module to be imported without requiring GEMINI_API_KEY,
-   * which is needed for CI/CD test runs that don't use this service.
-   */
-  private ensureInitialized(): void {
-    if (this.model) return;
+/**
+ * Ensure a PRH-mode alt-text string ends with sentence-terminating
+ * punctuation. PRH Style Guide Appendix 7 requires every description
+ * to end with a full stop; the Gemini model usually complies but can
+ * drop it, especially on short outputs. We accept `.`, `!`, `?`, and
+ * `…` (the truncation ellipsis) as valid endings; anything else gets
+ * a period appended.
+ *
+ * Empty / whitespace-only strings are returned untouched — callers
+ * surface those as NEEDS_MANUAL_REVIEW via a separate code path.
+ */
+function ensurePrhSentenceEnding(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return text;
+  // Treat ASCII `...` (3-char ellipsis), Unicode `…`, and standard
+  // sentence terminators as already-ended. Don't append after them.
+  if (/(?:\.\.\.|[.!?…])$/.test(trimmed)) return trimmed;
+  return `${trimmed}.`;
+}
 
-    if (!process.env.GEMINI_API_KEY) {
-      throw new Error('GEMINI_API_KEY environment variable is required');
-    }
-    this.genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    this.model = this.genAI.getGenerativeModel({ model: ACTIVE_MODEL });
+/**
+ * Build the standalone alt-text prompt. Two variants:
+ *   - default: existing concise-description rules
+ *   - prh-uk: PRH UK Style Guide Appendix 7 rules layered on top
+ *
+ * Both return JSON with shortAlt / extendedAlt / confidence / flags.
+ */
+function buildAltTextPrompt(profile: AltTextProfile): string {
+  if (profile === 'prh-uk') {
+    return `
+Describe this image for someone who cannot see it.
+
+PRH UK Style Guide Appendix 7 requirements (STRICT — follow exactly):
+- Be concise (under 125 characters preferred for short version).
+- Use LITERAL, OBJECTIVE wording — describe what's visible. Do NOT
+  speculate ("appears to be", "perhaps", "seems to") or interpret
+  emotion / motive.
+- END every description with a full stop.
+- Use NEUTRAL / non-gendered language by default ("person", "they")
+  unless visible context (uniform, caption text, etc.) confirms a
+  specific identification.
+- Mention COLOUR only when it is significant to identification or
+  meaning — not as decoration.
+- Use ACTION VERBS when motion is depicted ("a hummingbird in flight",
+  not just "a hummingbird").
+- For images of TEXT, mirror the text content in the description.
+- Do NOT start with "Image of", "Photo of", "Picture of", "Photograph
+  of", "An image of", "A picture of", "A photo of".
+- Present tense.
+
+Return JSON only (no markdown):
+{
+  "shortAlt": "concise description under 125 chars, ending with a full stop",
+  "extendedAlt": "detailed description up to 250 chars, ending with a full stop",
+  "confidence": 85,
+  "flags": []
+}
+
+Flags to include if applicable:
+- "FACE_DETECTED" if human faces are visible
+- "TEXT_IN_IMAGE" if text appears in the image
+- "COMPLEX_SCENE" if multiple distinct elements
+- "SENSITIVE_CONTENT" if potentially sensitive
+`;
   }
-
-  async generateAltText(
-    imageBuffer: Buffer,
-    mimeType: string = 'image/jpeg'
-  ): Promise<AltTextGenerationResult> {
-    const prompt = `
+  return `
 Describe this image for someone who cannot see it.
 Requirements:
 - Be concise (under 125 characters preferred for short version)
@@ -85,6 +168,126 @@ Flags to include if applicable:
 - "COMPLEX_SCENE" if multiple distinct elements
 - "SENSITIVE_CONTENT" if potentially sensitive
 `;
+}
+
+/**
+ * Build the context-aware prompt. Same default vs prh-uk split as
+ * buildAltTextPrompt, plus the surrounding-text context block. PRH
+ * mode layers Style Guide Appendix 7 rules over the context-aware
+ * directives.
+ */
+function buildContextAwarePrompt(profile: AltTextProfile, context: DocumentContext): string {
+  const contextBlock = `
+DOCUMENT CONTEXT:
+- Document: ${context.documentTitle}
+${context.chapterTitle ? `- Chapter: ${context.chapterTitle}` : ''}
+- Section: ${context.nearestHeading}
+${context.caption ? `- Caption: ${context.caption}` : ''}
+${context.pageNumber ? `- Page: ${context.pageNumber}` : ''}
+
+TEXT BEFORE IMAGE:
+${context.textBefore || '(none available)'}
+
+TEXT AFTER IMAGE:
+${context.textAfter || '(none available)'}
+`;
+
+  if (profile === 'prh-uk') {
+    return `
+Describe this image for someone who cannot see it.
+${contextBlock}
+PRH UK Style Guide Appendix 7 requirements (STRICT — follow exactly):
+- Be concise (under 125 characters preferred for short version).
+- Use LITERAL, OBJECTIVE wording — describe what's visible. Do NOT
+  speculate ("appears to be", "perhaps", "seems to") or interpret
+  emotion / motive.
+- END every description with a full stop.
+- Use NEUTRAL / non-gendered language by default unless context
+  (uniform, caption text, document context) confirms identification.
+- Mention COLOUR only when significant.
+- Reference document context when it sharpens identification.
+- Do NOT repeat the caption verbatim — provide complementary
+  information.
+- Do NOT start with "Image of", "Photo of", "Picture of", "Photograph
+  of", "An image of", "A picture of", "A photo of".
+- Present tense.
+
+Return JSON only (no markdown):
+{
+  "shortAlt": "context-aware description under 125 chars, ending with a full stop",
+  "extendedAlt": "detailed context-aware description up to 250 chars, ending with a full stop",
+  "confidence": 85,
+  "flags": [],
+  "usedContext": ["nearestHeading", "caption"]
+}
+`;
+  }
+  return `
+Describe this image for someone who cannot see it.
+${contextBlock}
+Requirements:
+- Be concise (under 125 characters for short version)
+- Use context to make description more specific and relevant
+- Reference document context when it helps understanding
+- Do NOT start with "Image of", "Photo of", or "Picture of"
+- Do NOT repeat the caption verbatim - provide complementary information
+- Use present tense
+
+Return JSON only (no markdown):
+{
+  "shortAlt": "context-aware description under 125 chars",
+  "extendedAlt": "detailed context-aware description up to 250 chars",
+  "confidence": 85,
+  "flags": [],
+  "usedContext": ["nearestHeading", "caption"]
+}
+`;
+}
+
+class PhotoAltGeneratorService {
+  private genAI: GoogleGenerativeAI | null = null;
+  private model: GenerativeModel | null = null;
+
+  /**
+   * Lazily initialize the Gemini client.
+   * This allows the module to be imported without requiring GEMINI_API_KEY,
+   * which is needed for CI/CD test runs that don't use this service.
+   */
+  private ensureInitialized(): void {
+    if (this.model) return;
+
+    if (!process.env.GEMINI_API_KEY) {
+      throw new Error('GEMINI_API_KEY environment variable is required');
+    }
+    this.genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+    this.model = this.genAI.getGenerativeModel({ model: ACTIVE_MODEL });
+  }
+
+  async generateAltText(
+    imageBuffer: Buffer,
+    mimeType: string = 'image/jpeg',
+    options: AltTextOptions = {},
+  ): Promise<AltTextGenerationResult> {
+    const profile: AltTextProfile = options.profile ?? 'default';
+
+    // Cover short-circuit: when the caller flags this as the cover
+    // image AND we're in PRH-UK mode, return the documented template
+    // ("Cover for [Book Title].") without invoking Gemini. Saves a
+    // model call and guarantees the alt text matches PRH spec exactly.
+    if (options.isCover && profile === 'prh-uk') {
+      const alt = buildPrhCoverAlt(options.bookTitle);
+      return {
+        imageId: '',
+        shortAlt: alt,
+        extendedAlt: alt,
+        confidence: 100,
+        flags: ['COVER_TEMPLATE'],
+        aiModel: 'prh-cover-template',
+        generatedAt: new Date(),
+      };
+    }
+
+    const prompt = buildAltTextPrompt(profile);
 
     const imagePart = {
       inlineData: {
@@ -140,7 +343,8 @@ Flags to include if applicable:
     const sanitized = this.sanitizeAndValidate(
       parsed.shortAlt || '',
       parsed.extendedAlt || '',
-      parsed.flags || []
+      parsed.flags || [],
+      profile,
     );
 
     return {
@@ -157,7 +361,8 @@ Flags to include if applicable:
   private sanitizeAndValidate(
     shortAlt: string,
     extendedAlt: string,
-    flags: AltTextFlag[]
+    flags: AltTextFlag[],
+    profile: AltTextProfile = 'default',
   ): { shortAlt: string; extendedAlt: string; flags: AltTextFlag[] } {
     const resultFlags: AltTextFlag[] = [...flags];
     let corrected = false;
@@ -172,7 +377,7 @@ Flags to include if applicable:
     if (sanitizedShort.length > MAX_SHORT_ALT_LENGTH) {
       const truncated = sanitizedShort.substring(0, MAX_SHORT_ALT_LENGTH - 3).trim();
       const lastSpace = truncated.lastIndexOf(' ');
-      sanitizedShort = lastSpace > MAX_SHORT_ALT_LENGTH * 0.5 
+      sanitizedShort = lastSpace > MAX_SHORT_ALT_LENGTH * 0.5
         ? truncated.substring(0, lastSpace) + '...'
         : truncated + '...';
       corrected = true;
@@ -185,6 +390,21 @@ Flags to include if applicable:
         ? truncated.substring(0, lastSpace) + '...'
         : truncated + '...';
       corrected = true;
+    }
+
+    // PRH mode: enforce the trailing-full-stop rule on both lengths.
+    // The model may drop it (especially after truncation reshapes the
+    // tail to "...") so we re-enforce here. Truncated text ending in
+    // ellipsis ("...") keeps the ellipsis — adding a period after it
+    // produces "....", which is uglier than just the ellipsis.
+    if (profile === 'prh-uk') {
+      const shortFixed = ensurePrhSentenceEnding(sanitizedShort);
+      const extendedFixed = ensurePrhSentenceEnding(sanitizedExtended);
+      if (shortFixed !== sanitizedShort || extendedFixed !== sanitizedExtended) {
+        sanitizedShort = shortFixed;
+        sanitizedExtended = extendedFixed;
+        corrected = true;
+      }
     }
 
     if (corrected && !resultFlags.includes('AUTO_CORRECTED')) {
@@ -216,13 +436,20 @@ Flags to include if applicable:
   }
 
   async generateBatch(
-    images: Array<{ id: string; buffer: Buffer; mimeType: string }>
+    images: Array<{ id: string; buffer: Buffer; mimeType: string; isCover?: boolean }>,
+    options: AltTextOptions = {},
   ): Promise<AltTextGenerationResult[]> {
     const results: AltTextGenerationResult[] = [];
-    
+
     for (const image of images) {
       try {
-        const result = await this.generateAltText(image.buffer, image.mimeType);
+        // Per-image isCover overrides any batch-level setting — useful
+        // when the batch contains exactly one cover plus N body images.
+        const perImageOptions: AltTextOptions = {
+          ...options,
+          isCover: image.isCover ?? options.isCover,
+        };
+        const result = await this.generateAltText(image.buffer, image.mimeType, perImageOptions);
         result.imageId = image.id;
         results.push(result);
       } catch (error) {
@@ -257,46 +484,23 @@ Flags to include if applicable:
   async generateContextAwareAltText(
     imageBuffer: Buffer,
     mimeType: string,
-    context: DocumentContext
+    context: DocumentContext,
+    options: AltTextOptions = {},
   ): Promise<{
     contextAware: AltTextGenerationResult;
     standalone: AltTextGenerationResult;
   }> {
-    const standalone = await this.generateAltText(imageBuffer, mimeType);
+    const profile: AltTextProfile = options.profile ?? 'default';
+    const standalone = await this.generateAltText(imageBuffer, mimeType, options);
 
-    const contextPrompt = `
-Describe this image for someone who cannot see it.
+    // Cover short-circuit: when this is the cover image AND we're in
+    // PRH mode, the standalone path already returned the template;
+    // context-aware adds nothing useful (the template is fixed).
+    if (options.isCover && profile === 'prh-uk') {
+      return { contextAware: standalone, standalone };
+    }
 
-DOCUMENT CONTEXT:
-- Document: ${context.documentTitle}
-${context.chapterTitle ? `- Chapter: ${context.chapterTitle}` : ''}
-- Section: ${context.nearestHeading}
-${context.caption ? `- Caption: ${context.caption}` : ''}
-${context.pageNumber ? `- Page: ${context.pageNumber}` : ''}
-
-TEXT BEFORE IMAGE:
-${context.textBefore || '(none available)'}
-
-TEXT AFTER IMAGE:
-${context.textAfter || '(none available)'}
-
-Requirements:
-- Be concise (under 125 characters for short version)
-- Use context to make description more specific and relevant
-- Reference document context when it helps understanding
-- Do NOT start with "Image of", "Photo of", or "Picture of"
-- Do NOT repeat the caption verbatim - provide complementary information
-- Use present tense
-
-Return JSON only (no markdown):
-{
-  "shortAlt": "context-aware description under 125 chars",
-  "extendedAlt": "detailed context-aware description up to 250 chars",
-  "confidence": 85,
-  "flags": [],
-  "usedContext": ["nearestHeading", "caption"]
-}
-`;
+    const contextPrompt = buildContextAwarePrompt(profile, context);
 
     const imagePart = {
       inlineData: {
@@ -312,7 +516,7 @@ Return JSON only (no markdown):
       const result = await this.model!.generateContent([contextPrompt, imagePart]);
       const response = await result.response;
       const text = response.text();
-      
+
       let parsed;
       try {
         parsed = JSON.parse(text.replace(/```json\n?|\n?```/g, ''));
@@ -324,7 +528,8 @@ Return JSON only (no markdown):
       const sanitized = this.sanitizeAndValidate(
         parsed.shortAlt || '',
         parsed.extendedAlt || '',
-        parsed.flags || []
+        parsed.flags || [],
+        profile,
       );
 
       if (parsed.confidence < 70 && !sanitized.flags.includes('LOW_CONFIDENCE')) {

--- a/src/services/epub/epub-audit.service.ts
+++ b/src/services/epub/epub-audit.service.ts
@@ -826,6 +826,27 @@ class EpubAuditService {
    * audit service is upstream of profile detection, and a circular
    * import would be worse than a few lines of duplicated regex.
    */
+  /**
+   * Decode the named + numeric XML entities that legitimately appear
+   * in `<dc:title>` values: `&amp;`, `&lt;`, `&gt;`, `&quot;`,
+   * `&apos;`, and decimal/hex numeric refs (`&#8217;`, `&#x2019;`).
+   * Doesn't handle the long tail of HTML named entities — those
+   * aren't valid in OPF XML anyway. Idempotent; safe to call on
+   * already-decoded strings.
+   */
+  private decodeXmlEntities(text: string): string {
+    return text
+      .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+      .replace(/&#([0-9]+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+      .replace(/&apos;/g, "'")
+      .replace(/&quot;/g, '"')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      // `&amp;` must be last so a string like `&amp;amp;` decodes
+      // to `&amp;` (one round-trip), not `&` (two).
+      .replace(/&amp;/g, '&');
+  }
+
   private readBookTitle(buffer: Buffer): string | null {
     try {
       const zip = new AdmZip(buffer);
@@ -840,8 +861,14 @@ class EpubAuditService {
       const opfContent = opfEntry.getData().toString('utf-8');
       const titleMatch = opfContent.match(/<dc:title\b[^>]*>([\s\S]*?)<\/dc:title>/i);
       if (!titleMatch) return null;
-      const trimmed = titleMatch[1].trim();
-      return trimmed.length === 0 ? null : trimmed;
+      // Decode XML entities BEFORE trimming so titles containing
+      // `&amp;`, `&apos;`, `&#8217;` etc. surface as human-readable
+      // text on the audit response. The FE templates the title into
+      // alt strings like "Cover for [Book Title]." — entity-encoded
+      // output ("Cover for A &amp; B.") would silently break the
+      // intended cover-alt format.
+      const decoded = this.decodeXmlEntities(titleMatch[1]).trim();
+      return decoded.length === 0 ? null : decoded;
     } catch (err) {
       logger.warn(`[readBookTitle] failed: ${err instanceof Error ? err.message : 'unknown'}`);
       return null;

--- a/src/services/epub/epub-audit.service.ts
+++ b/src/services/epub/epub-audit.service.ts
@@ -127,6 +127,14 @@ interface EpubAuditResult {
    * (PR2+) should be skipped in that case.
    */
   publisherProfile: PublisherProfile;
+  /**
+   * Book title parsed from the OPF's `<dc:title>` element. Null when
+   * the OPF can't be located or the element is missing/empty. The FE
+   * uses this to pre-fill cover-alt quick-fix dialogs with the PRH
+   * template `"Cover for [Book Title]."` — see the photo-alt-generator
+   * service's `buildPrhCoverAlt` helper.
+   */
+  bookTitle: string | null;
   coverage: {
     totalFiles: number;
     filesScanned: number;
@@ -421,6 +429,11 @@ class EpubAuditService {
       logger.info(`📊 Audit Coverage: ${coverage.filesScanned}/${coverage.totalFiles} files (${coverage.percentage}%)`);
       logger.info(`   Front Matter: ${coverage.fileCategories.frontMatter}, Chapters: ${coverage.fileCategories.chapters}, Back Matter: ${coverage.fileCategories.backMatter}`);
 
+      // Read dc:title for downstream consumers (FE cover-alt template,
+      // ACR generation). Best-effort — never block the audit on a
+      // missing or malformed OPF.
+      const bookTitle = this.readBookTitle(buffer);
+
       const result: EpubAuditResult = {
         jobId,
         fileName,
@@ -443,6 +456,7 @@ class EpubAuditService {
         classificationStats,
         accessibilityMetadata: aceResult?.metadata || null,
         publisherProfile,
+        bookTitle,
         coverage,
         auditedAt: new Date(),
       };
@@ -793,6 +807,44 @@ class EpubAuditService {
         percentage: 0,
         fileCategories: { frontMatter: 0, chapters: 0, backMatter: 0 }
       };
+    }
+  }
+
+  /**
+   * Read the book's title (`<dc:title>`) from the EPUB's OPF.
+   * Best-effort — returns `null` on any structural problem rather
+   * than throwing, so a malformed OPF never breaks the audit flow.
+   *
+   * Resolution order:
+   *   1. Read `META-INF/container.xml` to find the OPF rootfile path.
+   *   2. Read that OPF; extract the first `<dc:title>…</dc:title>`.
+   *   3. Trim whitespace; return null if empty after trim.
+   *
+   * The PRH-UK validator orchestrator does the same parsing inside
+   * `run-validators.ts`; we deliberately duplicate the lightweight
+   * regex parse here rather than depending on that module — the
+   * audit service is upstream of profile detection, and a circular
+   * import would be worse than a few lines of duplicated regex.
+   */
+  private readBookTitle(buffer: Buffer): string | null {
+    try {
+      const zip = new AdmZip(buffer);
+      const containerEntry = zip.getEntry('META-INF/container.xml');
+      if (!containerEntry) return null;
+      const containerXml = containerEntry.getData().toString('utf-8');
+      const m = containerXml.match(/rootfile[^>]+full-path\s*=\s*(?:"([^"]+)"|'([^']+)')/i);
+      const opfPath = m?.[1] ?? m?.[2];
+      if (!opfPath) return null;
+      const opfEntry = zip.getEntry(opfPath);
+      if (!opfEntry) return null;
+      const opfContent = opfEntry.getData().toString('utf-8');
+      const titleMatch = opfContent.match(/<dc:title\b[^>]*>([\s\S]*?)<\/dc:title>/i);
+      if (!titleMatch) return null;
+      const trimmed = titleMatch[1].trim();
+      return trimmed.length === 0 ? null : trimmed;
+    } catch (err) {
+      logger.warn(`[readBookTitle] failed: ${err instanceof Error ? err.message : 'unknown'}`);
+      return null;
     }
   }
 

--- a/tests/unit/services/alt-text/photo-alt-generator.test.ts
+++ b/tests/unit/services/alt-text/photo-alt-generator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   photoAltGenerator,
   buildPrhCoverAlt,
@@ -43,6 +43,10 @@ describe('generateAltText — PRH cover short-circuit', () => {
   // we don't need to mock GEMINI_API_KEY or the model.
   const dummyBuffer = Buffer.from('dummy');
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('returns the PRH template without invoking Gemini when isCover + prh-uk profile', async () => {
     const result = await photoAltGenerator.generateAltText(
       dummyBuffer,
@@ -66,37 +70,57 @@ describe('generateAltText — PRH cover short-circuit', () => {
   });
 
   it('does NOT short-circuit when isCover is true but profile is default', async () => {
-    // The cover template is PRH-specific. Default-profile cover
-    // images go through the normal Gemini path. We don't run that
-    // path here (would need API mocking) — assert via behaviour: the
-    // short-circuit returns confidence 100 + aiModel 'prh-cover-template',
-    // so if those aren't present we know we'd have entered the
-    // Gemini path. We use a try/catch to handle the inevitable
-    // ensureInitialized() failure on missing GEMINI_API_KEY.
-    try {
-      const result = await photoAltGenerator.generateAltText(
+    // Stub the lazy Gemini initializer to throw a known marker error.
+    // If the test enters the model path (i.e. short-circuit DIDN'T
+    // fire), the stub trips and we catch a marker error. If the
+    // short-circuit DID fire, the stub is never invoked.
+    const initSpy = vi
+      .spyOn(photoAltGenerator as unknown as { ensureInitialized: () => void }, 'ensureInitialized')
+      .mockImplementation(() => {
+        throw new Error('STUB_ENSURED_INIT_CALLED');
+      });
+
+    await expect(
+      photoAltGenerator.generateAltText(
         dummyBuffer,
         'image/jpeg',
         { isCover: true }, // no profile → defaults to 'default'
-      );
-      expect(result.aiModel).not.toBe('prh-cover-template');
-    } catch (err) {
-      // Expected when GEMINI_API_KEY is absent — proves we entered
-      // the model path, not the short-circuit.
-      expect((err as Error).message).toMatch(/GEMINI_API_KEY/);
-    }
+      ),
+    ).rejects.toThrow('STUB_ENSURED_INIT_CALLED');
+
+    expect(initSpy).toHaveBeenCalled();
   });
 
   it('does NOT short-circuit when profile is prh-uk but isCover is false', async () => {
-    try {
-      const result = await photoAltGenerator.generateAltText(
+    const initSpy = vi
+      .spyOn(photoAltGenerator as unknown as { ensureInitialized: () => void }, 'ensureInitialized')
+      .mockImplementation(() => {
+        throw new Error('STUB_ENSURED_INIT_CALLED');
+      });
+
+    await expect(
+      photoAltGenerator.generateAltText(
         dummyBuffer,
         'image/jpeg',
         { profile: 'prh-uk' }, // no isCover
-      );
-      expect(result.aiModel).not.toBe('prh-cover-template');
-    } catch (err) {
-      expect((err as Error).message).toMatch(/GEMINI_API_KEY/);
-    }
+      ),
+    ).rejects.toThrow('STUB_ENSURED_INIT_CALLED');
+
+    expect(initSpy).toHaveBeenCalled();
+  });
+
+  it('short-circuit does NOT invoke ensureInitialized (no Gemini call)', async () => {
+    const initSpy = vi.spyOn(
+      photoAltGenerator as unknown as { ensureInitialized: () => void },
+      'ensureInitialized',
+    );
+
+    await photoAltGenerator.generateAltText(
+      dummyBuffer,
+      'image/jpeg',
+      { profile: 'prh-uk', isCover: true, bookTitle: 'Test' },
+    );
+
+    expect(initSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/alt-text/photo-alt-generator.test.ts
+++ b/tests/unit/services/alt-text/photo-alt-generator.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  photoAltGenerator,
+  buildPrhCoverAlt,
+} from '../../../../src/services/alt-text/photo-alt-generator.service';
+
+describe('buildPrhCoverAlt', () => {
+  it('returns "Cover for [Title]." when title is present', () => {
+    expect(buildPrhCoverAlt('The Book')).toBe('Cover for The Book.');
+  });
+
+  it('trims whitespace from the title before formatting', () => {
+    expect(buildPrhCoverAlt('   The Book   ')).toBe('Cover for The Book.');
+  });
+
+  it('falls back to "Cover image." when title is null', () => {
+    expect(buildPrhCoverAlt(null)).toBe('Cover image.');
+  });
+
+  it('falls back to "Cover image." when title is undefined', () => {
+    expect(buildPrhCoverAlt(undefined)).toBe('Cover image.');
+  });
+
+  it('falls back to "Cover image." when title is empty string', () => {
+    expect(buildPrhCoverAlt('')).toBe('Cover image.');
+  });
+
+  it('falls back to "Cover image." when title is whitespace-only', () => {
+    expect(buildPrhCoverAlt('   ')).toBe('Cover image.');
+  });
+
+  it('always ends with a full stop (PRH Style Guide Appendix 7)', () => {
+    // Whatever the input, the output must end in `.` — PRH requires
+    // every description to end with a full stop.
+    expect(buildPrhCoverAlt('Book')).toMatch(/\.$/);
+    expect(buildPrhCoverAlt(null)).toMatch(/\.$/);
+  });
+});
+
+describe('generateAltText — PRH cover short-circuit', () => {
+  // These tests exercise the path that bypasses Gemini entirely. The
+  // generator returns the documented template without an API call, so
+  // we don't need to mock GEMINI_API_KEY or the model.
+  const dummyBuffer = Buffer.from('dummy');
+
+  it('returns the PRH template without invoking Gemini when isCover + prh-uk profile', async () => {
+    const result = await photoAltGenerator.generateAltText(
+      dummyBuffer,
+      'image/jpeg',
+      { profile: 'prh-uk', isCover: true, bookTitle: 'Test Book' },
+    );
+    expect(result.shortAlt).toBe('Cover for Test Book.');
+    expect(result.extendedAlt).toBe('Cover for Test Book.');
+    expect(result.confidence).toBe(100);
+    expect(result.flags).toEqual(['COVER_TEMPLATE']);
+    expect(result.aiModel).toBe('prh-cover-template');
+  });
+
+  it('falls back to "Cover image." when bookTitle is missing', async () => {
+    const result = await photoAltGenerator.generateAltText(
+      dummyBuffer,
+      'image/jpeg',
+      { profile: 'prh-uk', isCover: true },
+    );
+    expect(result.shortAlt).toBe('Cover image.');
+  });
+
+  it('does NOT short-circuit when isCover is true but profile is default', async () => {
+    // The cover template is PRH-specific. Default-profile cover
+    // images go through the normal Gemini path. We don't run that
+    // path here (would need API mocking) — assert via behaviour: the
+    // short-circuit returns confidence 100 + aiModel 'prh-cover-template',
+    // so if those aren't present we know we'd have entered the
+    // Gemini path. We use a try/catch to handle the inevitable
+    // ensureInitialized() failure on missing GEMINI_API_KEY.
+    try {
+      const result = await photoAltGenerator.generateAltText(
+        dummyBuffer,
+        'image/jpeg',
+        { isCover: true }, // no profile → defaults to 'default'
+      );
+      expect(result.aiModel).not.toBe('prh-cover-template');
+    } catch (err) {
+      // Expected when GEMINI_API_KEY is absent — proves we entered
+      // the model path, not the short-circuit.
+      expect((err as Error).message).toMatch(/GEMINI_API_KEY/);
+    }
+  });
+
+  it('does NOT short-circuit when profile is prh-uk but isCover is false', async () => {
+    try {
+      const result = await photoAltGenerator.generateAltText(
+        dummyBuffer,
+        'image/jpeg',
+        { profile: 'prh-uk' }, // no isCover
+      );
+      expect(result.aiModel).not.toBe('prh-cover-template');
+    } catch (err) {
+      expect((err as Error).message).toMatch(/GEMINI_API_KEY/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

First P4 PR — branches Ninja's AI alt-text generators on a `'prh-uk'` profile so PRH publishers get output that complies with Style Guide Appendix 7. Adds the cover-alt template helper and surfaces `bookTitle` on the audit response so the FE quick-fix dialog can pre-fill `"Cover for [Book Title]."` automatically.

## Three small changes

### 1. `photo-alt-generator.service.ts`

New types `AltTextProfile` (`'default' | 'prh-uk'`) and `AltTextOptions` (`{ profile?, isCover?, bookTitle? }`).

| Change | Detail |
|---|---|
| `generateAltText()` | New `options` param. **Cover short-circuit**: when `isCover && profile === 'prh-uk'`, returns the documented template (`"Cover for [Book Title]."` or `"Cover image."` fallback) WITHOUT a Gemini call. |
| `buildAltTextPrompt(profile)` | Default vs PRH-mode prompts. PRH adds Appendix 7 rules: literal/objective wording, full-stop endings, neutral pronouns, colour-only-when-significant, action verbs for motion. |
| `sanitizeAndValidate()` | PRH mode appends a trailing full stop when the model drops it. |
| `generateContextAwareAltText()` | Same profile branching; same cover short-circuit. |
| `generateBatch()` | Threads options + per-image `isCover` override. |
| `buildPrhCoverAlt()` | New exported helper — controllers wiring the FE quick-fix can use the same template. |

### 2. `long-description-generator.service.ts`

Same `profile?: 'default' | 'prh-uk'` branching for prose long-descriptions. PRH variant applies Appendix 7 to longer-form descriptions.

### 3. `epub-audit.service.ts`

`EpubAuditResult.bookTitle: string | null` — populated from `<dc:title>`. Best-effort read; returns null on malformed OPF rather than throwing.

## Test plan

- [x] 1402/1402 unit tests passing (11 new for photo-alt-generator covering `buildPrhCoverAlt` edge cases + cover short-circuit paths that don't need Gemini)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke: PRH audit response now includes `bookTitle`
- [ ] Staging smoke: trigger alt-text generation on a PRH job — verify outputs end in full stops, no forbidden prefixes, neutral pronouns

## Out of scope (deferred to P4/PR2)

- AI-content gating per Style Guide Appendix 7 ("AI prohibited unless vetted"). PR1 branches *behavior* when AI runs; PR2 adds the *policy gate* that controls whether AI runs at all for PRH jobs.

## Out of scope (deferred to backlog)

- P4/PR3 (decorative grouped-images heuristic) — explicitly deferred per scoping decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PRH-UK alt-text profile added with stricter, objective constraints (neutral pronouns, required full-stop punctuation).
  * Cover images can use a templated alt-text path that bypasses AI calls.
  * Alt-text generation accepts per-call options (profile, cover, book title) and batch calls support per-image overrides.
  * EPUB processing now extracts book titles into audit results.

* **Tests**
  * Added unit tests covering PRH cover template behavior and PRH-specific formatting rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/380)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->