### PR TITLE
feat(prh): AI alt-text policy gate per Style Guide Appendix 7 (P4/PR2)

### DIFF
--- a/src/controllers/alt-text.controller.ts
+++ b/src/controllers/alt-text.controller.ts
@@ -3,6 +3,7 @@ import { photoAltGenerator } from '../services/alt-text/photo-alt-generator.serv
 import { contextExtractor } from '../services/alt-text/context-extractor.service';
 import { chartDiagramGenerator } from '../services/alt-text/chart-diagram-generator.service';
 import { longDescriptionGenerator } from '../services/alt-text/long-description-generator.service';
+import { gateAiAltText } from '../utils/prh-ai-gate';
 import prisma from '../lib/prisma';
 import { Prisma } from '@prisma/client';
 import fs from 'fs/promises';
@@ -12,27 +13,33 @@ export const altTextController = {
   async generate(req: Request, res: Response) {
     try {
       const { imageId, jobId } = req.body;
-      
+
       if (!imageId || !jobId) {
-        return res.status(400).json({ 
-          success: false, 
-          error: 'imageId and jobId are required' 
+        return res.status(400).json({
+          success: false,
+          error: 'imageId and jobId are required'
         });
       }
-      
+
+      // PRH UK AI policy gate (Style Guide Appendix 7). When the
+      // job is PRH-UK AND the tenant has not flipped the
+      // aiAltTextEnabled flag, this returns true and sends a 403
+      // with the structured PRH_AI_DISABLED payload.
+      if (await gateAiAltText(req, res, jobId)) return;
+
       const file = await prisma.file.findFirst({
         where: { id: imageId }
       });
-      
+
       if (!file) {
-        return res.status(404).json({ 
-          success: false, 
-          error: 'Image not found' 
+        return res.status(404).json({
+          success: false,
+          error: 'Image not found'
         });
       }
-      
+
       const imageBuffer = await fs.readFile(file.path);
-      
+
       const result = await photoAltGenerator.generateAltText(
         imageBuffer,
         file.mimeType || 'image/jpeg'
@@ -78,6 +85,12 @@ export const altTextController = {
         });
       }
 
+      // No jobId on this endpoint — it accepts a raw buffer for
+      // ad-hoc testing. The PRH gate doesn't apply because we
+      // can't tell whether the image belongs to a PRH-UK book
+      // without job context. Production paths invoke `generate` /
+      // `generateForJob`, both of which DO go through the gate.
+
       const result = await photoAltGenerator.generateAltText(
         req.file.buffer,
         req.file.mimetype || 'image/jpeg'
@@ -103,20 +116,25 @@ export const altTextController = {
     try {
       const { jobId } = req.params;
       const userId = req.user?.id;
-      
+
       const job = await prisma.job.findFirst({
-        where: { 
+        where: {
           id: jobId,
           userId: userId,
         },
       });
-      
+
       if (!job) {
-        return res.status(404).json({ 
-          success: false, 
-          error: 'Job not found or access denied' 
+        return res.status(404).json({
+          success: false,
+          error: 'Job not found or access denied'
         });
       }
+
+      // PRH UK AI policy gate (Style Guide Appendix 7). Bulk-generate
+      // is the highest-volume Gemini caller — blocking it is the
+      // single most consequential gate point on the controller.
+      if (await gateAiAltText(req, res, jobId)) return;
       
       interface ExtractedImage { id?: string; path?: string; mimeType?: string }
       const jobOutput = job.output as { extractedImages?: ExtractedImage[] } | null;
@@ -276,14 +294,18 @@ export const altTextController = {
   async generateContextual(req: Request, res: Response) {
     try {
       const { imageId, jobId } = req.body;
-      
+
       if (!imageId || !jobId) {
-        return res.status(400).json({ 
-          success: false, 
-          error: 'imageId and jobId are required' 
+        return res.status(400).json({
+          success: false,
+          error: 'imageId and jobId are required'
         });
       }
-      
+
+      // PRH UK AI policy gate — context-aware generation is also a
+      // Gemini caller and must respect the same Appendix 7 rule.
+      if (await gateAiAltText(req, res, jobId)) return;
+
       const file = await prisma.file.findFirst({
         where: { id: imageId }
       });
@@ -585,18 +607,24 @@ export const altTextController = {
     try {
       const { id } = req.params;
       const { additionalContext, useContextAware } = req.body;
-      
+
       const existing = await prisma.generatedAltText.findUnique({
         where: { id },
       });
-      
+
       if (!existing) {
-        return res.status(404).json({ 
-          success: false, 
-          error: 'Alt text record not found' 
+        return res.status(404).json({
+          success: false,
+          error: 'Alt text record not found'
         });
       }
-      
+
+      // PRH UK AI policy gate — regenerate is just a re-invocation
+      // of the generators (with optional context), so the same
+      // Appendix 7 gate applies. The jobId comes from the existing
+      // alt-text record.
+      if (await gateAiAltText(req, res, existing.jobId)) return;
+
       const file = await prisma.file.findFirst({
         where: { id: existing.imageId }
       });
@@ -786,18 +814,23 @@ export const altTextController = {
     try {
       const { id } = req.params;
       const { trigger = 'MANUAL_REQUEST' } = req.body;
-      
+
       const altText = await prisma.generatedAltText.findUnique({
         where: { id },
       });
-      
+
       if (!altText) {
-        return res.status(404).json({ 
-          success: false, 
-          error: 'Alt text record not found' 
+        return res.status(404).json({
+          success: false,
+          error: 'Alt text record not found'
         });
       }
-      
+
+      // PRH UK AI policy gate — long-description generation is the
+      // OTHER Gemini caller (alongside the photo-alt generator) and
+      // shares the same Appendix 7 prohibition.
+      if (await gateAiAltText(req, res, altText.jobId)) return;
+
       const file = await prisma.file.findFirst({
         where: { id: altText.imageId }
       });

--- a/src/controllers/alt-text.controller.ts
+++ b/src/controllers/alt-text.controller.ts
@@ -21,12 +21,6 @@ export const altTextController = {
         });
       }
 
-      // PRH UK AI policy gate (Style Guide Appendix 7). When the
-      // job is PRH-UK AND the tenant has not flipped the
-      // aiAltTextEnabled flag, this returns true and sends a 403
-      // with the structured PRH_AI_DISABLED payload.
-      if (await gateAiAltText(req, res, jobId)) return;
-
       const file = await prisma.file.findFirst({
         where: { id: imageId }
       });
@@ -37,6 +31,15 @@ export const altTextController = {
           error: 'Image not found'
         });
       }
+
+      // PRH UK AI policy gate (Style Guide Appendix 7). Use the
+      // FILE'S authoritative jobId (file.latestJobId) for the gate
+      // check rather than trusting the body-supplied jobId — a
+      // client could otherwise pass an unrelated non-PRH jobId to
+      // bypass the gate while the actual image lives on a PRH job.
+      // Falls back to body jobId if the file hasn't been audited yet.
+      const gateJobId = file.latestJobId ?? jobId;
+      if (await gateAiAltText(req, res, gateJobId)) return;
 
       const imageBuffer = await fs.readFile(file.path);
 
@@ -302,21 +305,24 @@ export const altTextController = {
         });
       }
 
-      // PRH UK AI policy gate — context-aware generation is also a
-      // Gemini caller and must respect the same Appendix 7 rule.
-      if (await gateAiAltText(req, res, jobId)) return;
-
       const file = await prisma.file.findFirst({
         where: { id: imageId }
       });
-      
+
       if (!file) {
-        return res.status(404).json({ 
-          success: false, 
-          error: 'Image not found' 
+        return res.status(404).json({
+          success: false,
+          error: 'Image not found'
         });
       }
-      
+
+      // PRH UK AI policy gate — context-aware generation is also a
+      // Gemini caller and must respect the same Appendix 7 rule.
+      // Use file.latestJobId for the gate (authoritative source)
+      // rather than the body-supplied jobId.
+      const gateJobId = file.latestJobId ?? jobId;
+      if (await gateAiAltText(req, res, gateJobId)) return;
+
       const imageBuffer = await fs.readFile(file.path);
       
       const context = await contextExtractor.extractContext(jobId, imageId);

--- a/src/controllers/epub.controller.ts
+++ b/src/controllers/epub.controller.ts
@@ -19,6 +19,7 @@ import { AuthenticatedRequest } from '../types/authenticated-request';
 import { ComparisonService, mapFixTypeToChangeType, extractWcagCriteria, extractWcagLevel } from '../services/comparison';
 import { workflowService } from '../services/workflow/workflow.service';
 import { workflowConfigService } from '../services/workflow/workflow-config.service';
+import { gateAiAltText } from '../utils/prh-ai-gate';
 
 const comparisonService = new ComparisonService(prisma);
 
@@ -2511,6 +2512,12 @@ export const epubController = {
           error: 'imagePath is required. Send { imagePath: "OEBPS/images/file.png", imageType: "informative" }',
         });
       }
+
+      // PRH UK AI policy gate (Style Guide Appendix 7). When the
+      // job is PRH-UK AND the tenant has not flipped the
+      // aiAltTextEnabled flag, this returns a 403 with the
+      // structured PRH_AI_DISABLED payload and bails out.
+      if (await gateAiAltText(req, res, jobId)) return;
 
       logger.info(`[Alt Text] Generating for job ${jobId}, image: ${imagePath}`);
 

--- a/src/controllers/tenant-config.controller.ts
+++ b/src/controllers/tenant-config.controller.ts
@@ -6,6 +6,7 @@ import { AppError } from '../utils/app-error';
 import { logger } from '../lib/logger';
 import { z } from 'zod';
 import type { ExplanationSource } from '../services/acr/explanation-catalog.service';
+import { getPrhConfig, updatePrhConfig } from '../services/prh/prh-config.service';
 
 /**
  * Zod schema for workflow configuration updates.
@@ -34,6 +35,17 @@ const DEFAULT_TIME_METRICS_CONFIG = {
     ACR_SIGNOFF: 10,
   },
 };
+
+/**
+ * PRH UK config — currently a single feature flag for AI alt-text
+ * gating per Style Guide Appendix 7. Schema only accepts the flag
+ * field; the audit-trail fields (aiAltTextEnabledBy /
+ * aiAltTextEnabledAt) are stamped server-side from the calling
+ * user's id, not client-supplied.
+ */
+const prhConfigUpdateSchema = z.object({
+  aiAltTextEnabled: z.boolean(),
+}).strict();
 
 const aiRemediationConfigUpdateSchema = z.object({
   tableFixMode: z.enum(['apply-to-pdf', 'guidance-only', 'summaries-to-pdf-headers-as-guidance']).optional(),
@@ -520,6 +532,61 @@ export class TenantConfigController {
         success: true,
         data: effectiveConfig,
         message: 'AI remediation configuration updated successfully',
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * Get current PRH UK tenant config. Returns the flag + audit-trail
+   * fields (last-flipped userId and timestamp). When the tenant has
+   * never touched PRH settings, returns the default (flag off,
+   * audit fields null) — disabled-by-default per Style Guide
+   * Appendix 7.
+   */
+  async getPrhConfig(req: Request, res: Response, next: NextFunction) {
+    try {
+      if (!req.user) throw AppError.unauthorized('Not authenticated');
+      const config = await getPrhConfig(req.user.tenantId);
+      res.json({ success: true, data: config });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * Update PRH UK tenant config. Admin-only — flipping the AI gate
+   * is a policy attestation that the tenant has completed PRH UK
+   * vetting per Appendix 7. The route is wired with
+   * `authorize('ADMIN')` so non-admin requests 403 before reaching
+   * this method, but we defence-in-depth check the role again here.
+   *
+   * Server-stamped audit trail: `aiAltTextEnabledBy` = req.user.id,
+   * `aiAltTextEnabledAt` = now. Client cannot override these.
+   */
+  async updatePrhConfig(req: Request, res: Response, next: NextFunction) {
+    try {
+      if (!req.user) throw AppError.unauthorized('Not authenticated');
+      if (req.user.role !== 'ADMIN') {
+        throw AppError.forbidden('Only admins can update PRH UK configuration');
+      }
+
+      const validationResult = prhConfigUpdateSchema.safeParse(req.body);
+      if (!validationResult.success) {
+        throw AppError.badRequest('Invalid PRH configuration: ' + validationResult.error.message);
+      }
+
+      const config = await updatePrhConfig(
+        req.user.tenantId,
+        validationResult.data,
+        req.user.id,
+      );
+
+      res.json({
+        success: true,
+        data: config,
+        message: 'PRH UK configuration updated successfully',
       });
     } catch (error) {
       next(error);

--- a/src/routes/tenant-config.routes.ts
+++ b/src/routes/tenant-config.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { tenantConfigController } from '../controllers/tenant-config.controller';
-import { authenticate } from '../middleware/auth.middleware';
+import { authenticate, authorize } from '../middleware/auth.middleware';
 
 const router = Router();
 
@@ -91,6 +91,35 @@ router.patch(
   '/ai-remediation',
   authenticate,
   tenantConfigController.updateAiRemediationConfig.bind(tenantConfigController)
+);
+
+/**
+ * GET /api/v1/tenant/config/prh
+ * Get PRH UK tenant config (currently the AI-altext gate flag + audit
+ * trail of last-flipped userId / timestamp). Returns
+ * { aiAltTextEnabled: false, aiAltTextEnabledBy: null,
+ *   aiAltTextEnabledAt: null } when never touched — disabled-by-default
+ * per Style Guide Appendix 7.
+ */
+router.get(
+  '/prh',
+  authenticate,
+  tenantConfigController.getPrhConfig.bind(tenantConfigController)
+);
+
+/**
+ * PATCH /api/v1/tenant/config/prh
+ * Update PRH UK tenant config. ADMIN-ONLY — flipping the AI gate is
+ * a policy attestation that the tenant has completed PRH UK vetting
+ * per Appendix 7. Body: { aiAltTextEnabled: boolean }. Audit trail
+ * (aiAltTextEnabledBy / aiAltTextEnabledAt) is server-stamped from
+ * req.user.id and the current time.
+ */
+router.patch(
+  '/prh',
+  authenticate,
+  authorize('ADMIN'),
+  tenantConfigController.updatePrhConfig.bind(tenantConfigController)
 );
 
 export default router;

--- a/src/services/prh/prh-config.service.ts
+++ b/src/services/prh/prh-config.service.ts
@@ -1,0 +1,182 @@
+/**
+ * PRH UK tenant-config + AI-altext gate (P4/PR2).
+ *
+ * Per PRH Style Guide Appendix 7, "Use of AI-based tools and solutions
+ * is prohibited unless specifically vetted and approved by PRH UK".
+ * Ninja's photo-alt-generator and long-description-generator are
+ * Gemini-based, so they fall under that prohibition for PRH UK
+ * deliveries by default. This service implements the policy gate:
+ *
+ *   - `getPrhConfig(tenantId)` — reads `Tenant.settings.prh.*`,
+ *     merged with `DEFAULT_PRH_CONFIG` (disabled by default).
+ *   - `updatePrhConfig(tenantId, patch, userId)` — writes the flag
+ *     and stamps `aiAltTextEnabledBy` + `aiAltTextEnabledAt` for the
+ *     audit trail.
+ *   - `isJobPrhUk(jobId)` — looks at the persisted audit result
+ *     (`Job.output.publisherProfile`) and returns true when the
+ *     publisher resolved to PRH-UK at medium-or-high confidence.
+ *   - `assertAiAltTextAllowed(jobId, tenantId)` — throws
+ *     `PrhAiDisabledError` when the job is PRH-UK AND the tenant
+ *     hasn't enabled AI alt text. Throws nothing on non-PRH jobs
+ *     OR when the tenant has flipped the flag.
+ *
+ * Disabled-by-default is the safe policy posture — tenants who have
+ * completed PRH vetting flip the flag in admin settings.
+ */
+
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+import { logger } from '../../lib/logger';
+
+export interface PrhConfig {
+  /** True when AI alt-text generation is allowed on this tenant's PRH-UK jobs. */
+  aiAltTextEnabled: boolean;
+  /** UserId of the admin who last flipped the flag. Null when never flipped. */
+  aiAltTextEnabledBy: string | null;
+  /** ISO timestamp of the last flag change. Null when never flipped. */
+  aiAltTextEnabledAt: string | null;
+}
+
+export const DEFAULT_PRH_CONFIG: PrhConfig = {
+  aiAltTextEnabled: false,
+  aiAltTextEnabledBy: null,
+  aiAltTextEnabledAt: null,
+};
+
+/**
+ * Thrown when an AI alt-text generation attempt is blocked by the
+ * PRH gate. Carries a structured error payload the FE renders as a
+ * persistent banner (NOT a transient toast) so operators can act on
+ * the vetting requirement.
+ */
+export class PrhAiDisabledError extends Error {
+  static readonly CODE = 'PRH_AI_DISABLED';
+  constructor(message: string = 'PRH UK requires AI alt text to be vetted and approved per Style Guide Appendix 7. Contact your PRH production controller before enabling AI alt-text generation.') {
+    super(message);
+    this.name = 'PrhAiDisabledError';
+  }
+}
+
+/**
+ * Read the PRH-specific tenant config, merged with `DEFAULT_PRH_CONFIG`.
+ * Returns the default (all-false) when the tenant has never touched
+ * the settings — explicit disabled-by-default per Style Guide
+ * Appendix 7.
+ */
+export async function getPrhConfig(tenantId: string): Promise<PrhConfig> {
+  const tenant = await prisma.tenant.findUnique({
+    where: { id: tenantId },
+    select: { settings: true },
+  });
+  if (!tenant) return DEFAULT_PRH_CONFIG;
+
+  const settings = (tenant.settings && typeof tenant.settings === 'object')
+    ? (tenant.settings as Record<string, unknown>)
+    : {};
+  const stored = (settings.prh && typeof settings.prh === 'object')
+    ? (settings.prh as Record<string, unknown>)
+    : {};
+
+  return {
+    aiAltTextEnabled: typeof stored.aiAltTextEnabled === 'boolean' ? stored.aiAltTextEnabled : DEFAULT_PRH_CONFIG.aiAltTextEnabled,
+    aiAltTextEnabledBy: typeof stored.aiAltTextEnabledBy === 'string' ? stored.aiAltTextEnabledBy : DEFAULT_PRH_CONFIG.aiAltTextEnabledBy,
+    aiAltTextEnabledAt: typeof stored.aiAltTextEnabledAt === 'string' ? stored.aiAltTextEnabledAt : DEFAULT_PRH_CONFIG.aiAltTextEnabledAt,
+  };
+}
+
+/**
+ * Update the PRH tenant config. Currently only `aiAltTextEnabled` is
+ * operator-settable; `aiAltTextEnabledBy` + `aiAltTextEnabledAt` are
+ * stamped server-side from the calling user's id and the current
+ * time. This preserves the audit trail — operators can't backdate
+ * the flag flip or pin it to a different userId.
+ */
+export async function updatePrhConfig(
+  tenantId: string,
+  patch: { aiAltTextEnabled: boolean },
+  userId: string,
+): Promise<PrhConfig> {
+  const tenant = await prisma.tenant.findUnique({
+    where: { id: tenantId },
+    select: { settings: true },
+  });
+  if (!tenant) {
+    throw new Error(`Tenant ${tenantId} not found`);
+  }
+
+  const currentSettings = (tenant.settings && typeof tenant.settings === 'object')
+    ? (tenant.settings as Record<string, unknown>)
+    : {};
+  const currentPrh = (currentSettings.prh && typeof currentSettings.prh === 'object')
+    ? (currentSettings.prh as Record<string, unknown>)
+    : {};
+
+  const updatedPrh = {
+    ...currentPrh,
+    aiAltTextEnabled: patch.aiAltTextEnabled,
+    aiAltTextEnabledBy: userId,
+    aiAltTextEnabledAt: new Date().toISOString(),
+  };
+
+  await prisma.tenant.update({
+    where: { id: tenantId },
+    data: {
+      settings: {
+        ...currentSettings,
+        prh: updatedPrh,
+      } as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  logger.info(`[PRH config] tenant=${tenantId} aiAltTextEnabled=${patch.aiAltTextEnabled} by=${userId}`);
+
+  return getPrhConfig(tenantId);
+}
+
+/**
+ * Returns true when the job's persisted audit result identifies the
+ * EPUB as a PRH-UK build at medium-or-high confidence. False on
+ * everything else: non-PRH books, jobs without an audit result yet,
+ * profile-detection failures, low-confidence matches.
+ *
+ * Reads `Job.output` JSON — the audit pipeline stores `EpubAuditResult`
+ * there. We don't reach into the underlying `publisherProfile` field
+ * directly to avoid Prisma type coupling.
+ */
+export async function isJobPrhUk(jobId: string): Promise<boolean> {
+  const job = await prisma.job.findUnique({
+    where: { id: jobId },
+    select: { output: true },
+  });
+  if (!job || !job.output) return false;
+
+  const output = job.output as Record<string, unknown>;
+  const profile = (output.publisherProfile && typeof output.publisherProfile === 'object')
+    ? (output.publisherProfile as Record<string, unknown>)
+    : null;
+  if (!profile) return false;
+
+  return profile.publisher === 'PRH-UK' && profile.confidence !== 'low';
+}
+
+/**
+ * Throws `PrhAiDisabledError` when AI alt-text generation is blocked
+ * for this job. Returns silently when the request is allowed:
+ *   - non-PRH job → allowed (gate doesn't apply)
+ *   - PRH job + tenant.aiAltTextEnabled === true → allowed
+ *   - PRH job + tenant.aiAltTextEnabled === false → BLOCKED
+ *
+ * Callers should catch `PrhAiDisabledError` and translate it to a
+ * 403 response with the structured `PRH_AI_DISABLED` payload — the
+ * FE renders that as a persistent banner explaining the Appendix 7
+ * vetting requirement.
+ */
+export async function assertAiAltTextAllowed(jobId: string, tenantId: string): Promise<void> {
+  const isPrh = await isJobPrhUk(jobId);
+  if (!isPrh) return; // gate doesn't apply to non-PRH jobs
+
+  const config = await getPrhConfig(tenantId);
+  if (config.aiAltTextEnabled) return; // tenant has completed vetting
+
+  throw new PrhAiDisabledError();
+}

--- a/src/services/prh/prh-config.service.ts
+++ b/src/services/prh/prh-config.service.ts
@@ -111,11 +111,16 @@ export async function updatePrhConfig(
     ? (currentSettings.prh as Record<string, unknown>)
     : {};
 
+  // Only re-stamp the audit fields when the flag value actually
+  // changes. No-op PATCHes (admin re-confirms the existing state)
+  // shouldn't falsify "last flipped by / at" — the operator who
+  // genuinely made the policy decision stays on the record.
+  const flagChanged = currentPrh.aiAltTextEnabled !== patch.aiAltTextEnabled;
   const updatedPrh = {
     ...currentPrh,
     aiAltTextEnabled: patch.aiAltTextEnabled,
-    aiAltTextEnabledBy: userId,
-    aiAltTextEnabledAt: new Date().toISOString(),
+    aiAltTextEnabledBy: flagChanged ? userId : (currentPrh.aiAltTextEnabledBy ?? null),
+    aiAltTextEnabledAt: flagChanged ? new Date().toISOString() : (currentPrh.aiAltTextEnabledAt ?? null),
   };
 
   await prisma.tenant.update({
@@ -156,7 +161,12 @@ export async function isJobPrhUk(jobId: string): Promise<boolean> {
     : null;
   if (!profile) return false;
 
-  return profile.publisher === 'PRH-UK' && profile.confidence !== 'low';
+  // Whitelist explicit confidence values rather than blacklisting
+  // `'low'`. Anything malformed, missing, or unknown is treated as
+  // "not high enough to trigger the gate" — failsafe to NOT block
+  // when we can't determine confidence positively.
+  return profile.publisher === 'PRH-UK'
+    && (profile.confidence === 'medium' || profile.confidence === 'high');
 }
 
 /**

--- a/src/utils/prh-ai-gate.ts
+++ b/src/utils/prh-ai-gate.ts
@@ -1,0 +1,52 @@
+/**
+ * Controller-side helper for the PRH UK AI alt-text policy gate
+ * (P4/PR2). Wraps `assertAiAltTextAllowed` with the Express
+ * request/response plumbing so individual controller endpoints just
+ * call:
+ *
+ *   if (await gateAiAltText(req, res, jobId)) return;
+ *
+ * at the start of any Gemini-invoking path. The helper sends the
+ * structured 403 response itself when the gate fires — callers
+ * never need to handle PrhAiDisabledError directly.
+ */
+
+import type { Request, Response } from 'express';
+import { assertAiAltTextAllowed, PrhAiDisabledError } from '../services/prh/prh-config.service';
+
+/**
+ * Returns `true` when the gate fired (a 403 response has already
+ * been sent — caller should `return` immediately); returns `false`
+ * when the call may proceed.
+ *
+ * Skips the gate entirely when jobId or tenantId is missing — those
+ * are unusual edge cases (e.g. raw-buffer endpoints without job
+ * context) where PRH detection isn't possible anyway. Production
+ * Gemini-invoking paths always pass both.
+ */
+export async function gateAiAltText(
+  req: Request,
+  res: Response,
+  jobId: string | undefined | null,
+): Promise<boolean> {
+  if (!jobId) return false;
+  const tenantId = req.user?.tenantId;
+  if (!tenantId) return false;
+  try {
+    await assertAiAltTextAllowed(jobId, tenantId);
+    return false;
+  } catch (err) {
+    if (err instanceof PrhAiDisabledError) {
+      res.status(403).json({
+        success: false,
+        error: {
+          code: PrhAiDisabledError.CODE,
+          message: err.message,
+          banner: true,
+        },
+      });
+      return true;
+    }
+    throw err;
+  }
+}

--- a/src/utils/prh-ai-gate.ts
+++ b/src/utils/prh-ai-gate.ts
@@ -13,16 +13,23 @@
 
 import type { Request, Response } from 'express';
 import { assertAiAltTextAllowed, PrhAiDisabledError } from '../services/prh/prh-config.service';
+import { logger } from '../lib/logger';
 
 /**
  * Returns `true` when the gate fired (a 403 response has already
  * been sent — caller should `return` immediately); returns `false`
  * when the call may proceed.
  *
- * Skips the gate entirely when jobId or tenantId is missing — those
- * are unusual edge cases (e.g. raw-buffer endpoints without job
- * context) where PRH detection isn't possible anyway. Production
- * Gemini-invoking paths always pass both.
+ * Skips the gate ONLY when jobId is missing — that's the explicit
+ * raw-buffer test path (`generateFromBuffer`) which has no job
+ * context and is documented as outside the PRH-job flow.
+ *
+ * If jobId is supplied but tenantId is missing on req.user, we
+ * FAIL CLOSED — the `authenticate` middleware should always
+ * populate req.user.tenantId, so a missing value is a sign of
+ * either a misconfigured route (no auth middleware) or a malformed
+ * request slipping through. Failing closed prevents the gate from
+ * silently allowing AI generation when it can't verify the policy.
  */
 export async function gateAiAltText(
   req: Request,
@@ -31,7 +38,19 @@ export async function gateAiAltText(
 ): Promise<boolean> {
   if (!jobId) return false;
   const tenantId = req.user?.tenantId;
-  if (!tenantId) return false;
+  if (!tenantId) {
+    logger.warn(
+      `[gateAiAltText] missing req.user.tenantId on request that supplied jobId=${jobId} — failing closed`,
+    );
+    res.status(401).json({
+      success: false,
+      error: {
+        code: 'NOT_AUTHENTICATED',
+        message: 'Authentication required to invoke alt-text generation.',
+      },
+    });
+    return true;
+  }
   try {
     await assertAiAltTextAllowed(jobId, tenantId);
     return false;

--- a/tests/unit/services/prh/prh-config.service.test.ts
+++ b/tests/unit/services/prh/prh-config.service.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../../../src/lib/prisma', () => ({
+  default: {
+    tenant: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    job: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import prisma from '../../../../src/lib/prisma';
+import {
+  getPrhConfig,
+  updatePrhConfig,
+  isJobPrhUk,
+  assertAiAltTextAllowed,
+  PrhAiDisabledError,
+  DEFAULT_PRH_CONFIG,
+} from '../../../../src/services/prh/prh-config.service';
+
+const mTenantFindUnique = prisma.tenant.findUnique as ReturnType<typeof vi.fn>;
+const mTenantUpdate = prisma.tenant.update as ReturnType<typeof vi.fn>;
+const mJobFindUnique = prisma.job.findUnique as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mTenantFindUnique.mockReset();
+  mTenantUpdate.mockReset();
+  mJobFindUnique.mockReset();
+});
+
+describe('DEFAULT_PRH_CONFIG', () => {
+  it('disables AI alt text by default (Style Guide Appendix 7)', () => {
+    expect(DEFAULT_PRH_CONFIG.aiAltTextEnabled).toBe(false);
+    expect(DEFAULT_PRH_CONFIG.aiAltTextEnabledBy).toBeNull();
+    expect(DEFAULT_PRH_CONFIG.aiAltTextEnabledAt).toBeNull();
+  });
+});
+
+describe('getPrhConfig', () => {
+  it('returns DEFAULT_PRH_CONFIG when tenant has no settings', async () => {
+    mTenantFindUnique.mockResolvedValue({ settings: null });
+    const cfg = await getPrhConfig('tenant-1');
+    expect(cfg).toEqual(DEFAULT_PRH_CONFIG);
+  });
+
+  it('returns DEFAULT_PRH_CONFIG when tenant.settings has no `prh` key', async () => {
+    mTenantFindUnique.mockResolvedValue({ settings: { workflow: {} } });
+    const cfg = await getPrhConfig('tenant-1');
+    expect(cfg).toEqual(DEFAULT_PRH_CONFIG);
+  });
+
+  it('returns DEFAULT_PRH_CONFIG when tenant does not exist', async () => {
+    mTenantFindUnique.mockResolvedValue(null);
+    const cfg = await getPrhConfig('missing-tenant');
+    expect(cfg).toEqual(DEFAULT_PRH_CONFIG);
+  });
+
+  it('returns stored values when tenant has flipped the flag', async () => {
+    mTenantFindUnique.mockResolvedValue({
+      settings: {
+        prh: {
+          aiAltTextEnabled: true,
+          aiAltTextEnabledBy: 'admin-user-id',
+          aiAltTextEnabledAt: '2026-05-13T12:00:00.000Z',
+        },
+      },
+    });
+    const cfg = await getPrhConfig('tenant-1');
+    expect(cfg.aiAltTextEnabled).toBe(true);
+    expect(cfg.aiAltTextEnabledBy).toBe('admin-user-id');
+    expect(cfg.aiAltTextEnabledAt).toBe('2026-05-13T12:00:00.000Z');
+  });
+
+  it('coerces wrong types to defaults (defensive against malformed settings JSON)', async () => {
+    mTenantFindUnique.mockResolvedValue({
+      settings: {
+        prh: {
+          aiAltTextEnabled: 'yes', // string, not boolean
+          aiAltTextEnabledBy: 42, // number, not string
+        },
+      },
+    });
+    const cfg = await getPrhConfig('tenant-1');
+    expect(cfg.aiAltTextEnabled).toBe(false); // fell back to default
+    expect(cfg.aiAltTextEnabledBy).toBeNull(); // fell back to default
+  });
+});
+
+describe('updatePrhConfig', () => {
+  it('stamps aiAltTextEnabledBy from caller userId, not from patch', async () => {
+    mTenantFindUnique.mockResolvedValue({ settings: {} });
+    mTenantUpdate.mockResolvedValue({});
+    // After update, getPrhConfig is called again — mock the post-write state.
+    mTenantFindUnique.mockResolvedValueOnce({ settings: {} }).mockResolvedValueOnce({
+      settings: {
+        prh: {
+          aiAltTextEnabled: true,
+          aiAltTextEnabledBy: 'admin-1',
+          aiAltTextEnabledAt: '2026-05-13T12:00:00.000Z',
+        },
+      },
+    });
+
+    const cfg = await updatePrhConfig('tenant-1', { aiAltTextEnabled: true }, 'admin-1');
+    expect(cfg.aiAltTextEnabled).toBe(true);
+    expect(cfg.aiAltTextEnabledBy).toBe('admin-1');
+
+    // Verify the update call carried the userId stamp.
+    expect(mTenantUpdate).toHaveBeenCalledTimes(1);
+    const updateCall = mTenantUpdate.mock.calls[0][0];
+    const writtenPrh = (updateCall.data.settings as Record<string, Record<string, unknown>>).prh;
+    expect(writtenPrh.aiAltTextEnabledBy).toBe('admin-1');
+    expect(typeof writtenPrh.aiAltTextEnabledAt).toBe('string'); // ISO timestamp
+  });
+
+  it('preserves other tenant settings (workflow, reports, etc.) when writing prh config', async () => {
+    mTenantFindUnique
+      .mockResolvedValueOnce({
+        settings: {
+          workflow: { enabled: true },
+          reports: { explanationSource: 'gemini' },
+          prh: { aiAltTextEnabled: false },
+        },
+      })
+      .mockResolvedValueOnce({
+        settings: {
+          workflow: { enabled: true },
+          reports: { explanationSource: 'gemini' },
+          prh: {
+            aiAltTextEnabled: true,
+            aiAltTextEnabledBy: 'admin-1',
+            aiAltTextEnabledAt: '2026-05-13T12:00:00.000Z',
+          },
+        },
+      });
+    mTenantUpdate.mockResolvedValue({});
+
+    await updatePrhConfig('tenant-1', { aiAltTextEnabled: true }, 'admin-1');
+
+    const updateCall = mTenantUpdate.mock.calls[0][0];
+    const writtenSettings = updateCall.data.settings as Record<string, Record<string, unknown>>;
+    // Sibling keys must survive the merge — otherwise updating PRH
+    // config would silently wipe workflow / reports config.
+    expect(writtenSettings.workflow).toEqual({ enabled: true });
+    expect(writtenSettings.reports).toEqual({ explanationSource: 'gemini' });
+  });
+
+  it('throws when tenant does not exist', async () => {
+    mTenantFindUnique.mockResolvedValue(null);
+    await expect(
+      updatePrhConfig('missing-tenant', { aiAltTextEnabled: true }, 'admin-1'),
+    ).rejects.toThrow(/not found/i);
+    expect(mTenantUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('isJobPrhUk', () => {
+  it('returns false when job does not exist', async () => {
+    mJobFindUnique.mockResolvedValue(null);
+    expect(await isJobPrhUk('missing-job')).toBe(false);
+  });
+
+  it('returns false when job has no output yet (audit not run)', async () => {
+    mJobFindUnique.mockResolvedValue({ output: null });
+    expect(await isJobPrhUk('job-1')).toBe(false);
+  });
+
+  it('returns false when output has no publisherProfile', async () => {
+    mJobFindUnique.mockResolvedValue({ output: { score: 95 } });
+    expect(await isJobPrhUk('job-1')).toBe(false);
+  });
+
+  it('returns false for non-PRH publishers', async () => {
+    mJobFindUnique.mockResolvedValue({
+      output: { publisherProfile: { publisher: 'HACHETTE-UK', confidence: 'high' } },
+    });
+    expect(await isJobPrhUk('job-1')).toBe(false);
+  });
+
+  it('returns false for PRH-UK at LOW confidence (per spec — low matches are unreliable)', async () => {
+    mJobFindUnique.mockResolvedValue({
+      output: { publisherProfile: { publisher: 'PRH-UK', confidence: 'low' } },
+    });
+    expect(await isJobPrhUk('job-1')).toBe(false);
+  });
+
+  it('returns true for PRH-UK at medium confidence', async () => {
+    mJobFindUnique.mockResolvedValue({
+      output: { publisherProfile: { publisher: 'PRH-UK', confidence: 'medium' } },
+    });
+    expect(await isJobPrhUk('job-1')).toBe(true);
+  });
+
+  it('returns true for PRH-UK at high confidence', async () => {
+    mJobFindUnique.mockResolvedValue({
+      output: { publisherProfile: { publisher: 'PRH-UK', confidence: 'high' } },
+    });
+    expect(await isJobPrhUk('job-1')).toBe(true);
+  });
+});
+
+describe('assertAiAltTextAllowed', () => {
+  it('allows non-PRH jobs regardless of tenant flag', async () => {
+    mJobFindUnique.mockResolvedValue({
+      output: { publisherProfile: { publisher: null, confidence: 'low' } },
+    });
+    // tenant flag would be off (no findUnique call expected because
+    // isJobPrhUk short-circuits before checking config), but mock
+    // for defensiveness.
+    mTenantFindUnique.mockResolvedValue({ settings: {} });
+
+    await expect(assertAiAltTextAllowed('job-1', 'tenant-1')).resolves.toBeUndefined();
+  });
+
+  it('allows PRH-UK jobs when tenant has enabled the flag', async () => {
+    mJobFindUnique.mockResolvedValue({
+      output: { publisherProfile: { publisher: 'PRH-UK', confidence: 'high' } },
+    });
+    mTenantFindUnique.mockResolvedValue({
+      settings: { prh: { aiAltTextEnabled: true, aiAltTextEnabledBy: 'admin', aiAltTextEnabledAt: '2026-05-13T00:00:00.000Z' } },
+    });
+
+    await expect(assertAiAltTextAllowed('job-1', 'tenant-1')).resolves.toBeUndefined();
+  });
+
+  it('throws PrhAiDisabledError on PRH-UK jobs when tenant has NOT enabled the flag (default state)', async () => {
+    mJobFindUnique.mockResolvedValue({
+      output: { publisherProfile: { publisher: 'PRH-UK', confidence: 'high' } },
+    });
+    mTenantFindUnique.mockResolvedValue({ settings: {} }); // default = disabled
+
+    await expect(assertAiAltTextAllowed('job-1', 'tenant-1')).rejects.toThrow(PrhAiDisabledError);
+  });
+
+  it('PrhAiDisabledError carries the CODE constant for FE banner detection', async () => {
+    expect(PrhAiDisabledError.CODE).toBe('PRH_AI_DISABLED');
+    const err = new PrhAiDisabledError();
+    expect(err.name).toBe('PrhAiDisabledError');
+    expect(err.message).toMatch(/Appendix 7/);
+  });
+});

--- a/tests/unit/services/prh/prh-config.service.test.ts
+++ b/tests/unit/services/prh/prh-config.service.test.ts
@@ -156,6 +156,49 @@ describe('updatePrhConfig', () => {
     ).rejects.toThrow(/not found/i);
     expect(mTenantUpdate).not.toHaveBeenCalled();
   });
+
+  it('preserves existing aiAltTextEnabledBy on no-op PATCH (audit-trail integrity)', async () => {
+    // Admin1 originally flipped the flag on; admin2 now PATCHes the
+    // same value (no actual change). The original flipper's
+    // attribution must NOT be overwritten by admin2 — they didn't
+    // make the policy decision, they just re-confirmed it.
+    const originalState = {
+      aiAltTextEnabled: true,
+      aiAltTextEnabledBy: 'admin-1',
+      aiAltTextEnabledAt: '2026-05-01T00:00:00.000Z',
+    };
+    mTenantFindUnique
+      .mockResolvedValueOnce({ settings: { prh: originalState } })
+      .mockResolvedValueOnce({ settings: { prh: originalState } });
+    mTenantUpdate.mockResolvedValue({});
+
+    await updatePrhConfig('tenant-1', { aiAltTextEnabled: true }, 'admin-2');
+
+    const updateCall = mTenantUpdate.mock.calls[0][0];
+    const writtenPrh = (updateCall.data.settings as Record<string, Record<string, unknown>>).prh;
+    expect(writtenPrh.aiAltTextEnabledBy).toBe('admin-1');
+    expect(writtenPrh.aiAltTextEnabledAt).toBe('2026-05-01T00:00:00.000Z');
+  });
+
+  it('re-stamps audit fields when the flag value actually flips', async () => {
+    const originalState = {
+      aiAltTextEnabled: true,
+      aiAltTextEnabledBy: 'admin-1',
+      aiAltTextEnabledAt: '2026-05-01T00:00:00.000Z',
+    };
+    mTenantFindUnique
+      .mockResolvedValueOnce({ settings: { prh: originalState } })
+      .mockResolvedValueOnce({ settings: { prh: { ...originalState, aiAltTextEnabled: false } } });
+    mTenantUpdate.mockResolvedValue({});
+
+    // Flip from true → false; admin-2 is the new flipper.
+    await updatePrhConfig('tenant-1', { aiAltTextEnabled: false }, 'admin-2');
+
+    const updateCall = mTenantUpdate.mock.calls[0][0];
+    const writtenPrh = (updateCall.data.settings as Record<string, Record<string, unknown>>).prh;
+    expect(writtenPrh.aiAltTextEnabledBy).toBe('admin-2');
+    expect(writtenPrh.aiAltTextEnabledAt).not.toBe(originalState.aiAltTextEnabledAt);
+  });
 });
 
 describe('isJobPrhUk', () => {
@@ -200,6 +243,23 @@ describe('isJobPrhUk', () => {
       output: { publisherProfile: { publisher: 'PRH-UK', confidence: 'high' } },
     });
     expect(await isJobPrhUk('job-1')).toBe(true);
+  });
+
+  it('returns false for PRH-UK with malformed / unknown confidence value (regression)', async () => {
+    // The predicate whitelists explicit 'medium' or 'high'. A
+    // garbage / missing confidence value used to slip through under
+    // the old `confidence !== 'low'` check.
+    mJobFindUnique.mockResolvedValue({
+      output: { publisherProfile: { publisher: 'PRH-UK', confidence: 'unknown' } },
+    });
+    expect(await isJobPrhUk('job-1')).toBe(false);
+  });
+
+  it('returns false for PRH-UK with missing confidence field', async () => {
+    mJobFindUnique.mockResolvedValue({
+      output: { publisherProfile: { publisher: 'PRH-UK' } },
+    });
+    expect(await isJobPrhUk('job-1')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Second P4 PR — resolves the policy conflict between PRH UK Style Guide Appendix 7 ("AI tools prohibited unless vetted") and Ninja's Gemini-based alt-text generators. Adds a tenant-level feature flag that gates AI alt-text generation for PRH-UK jobs, disabled by default.

## What ships

### New service: `src/services/prh/prh-config.service.ts`
- `getPrhConfig` / `updatePrhConfig` — read/write `Tenant.settings.prh`
- `isJobPrhUk(jobId)` — checks `Job.output.publisherProfile` for PRH-UK at medium+ confidence
- `assertAiAltTextAllowed(jobId, tenantId)` — throws `PrhAiDisabledError` when blocked
- `PrhAiDisabledError` — custom error with `CODE = 'PRH_AI_DISABLED'` constant for FE banner discrimination

### New util: `src/utils/prh-ai-gate.ts`
- `gateAiAltText(req, res, jobId)` — Express helper; returns `true` if the gate fired (403 sent) so callers `return` immediately

### New endpoints
- `GET /api/v1/tenant/config/prh` — authenticated read
- `PATCH /api/v1/tenant/config/prh` — **ADMIN-only** flip; audit trail (`aiAltTextEnabledBy` + `aiAltTextEnabledAt`) stamped server-side from `req.user.id`

### Gate applied at all 6 Gemini-invoking endpoints
- `alt-text.controller.ts`: `generate`, `generateForJob`, `generateContextual`, `regenerate`, `generateLongDescription`
- `epub.controller.ts`: `generateImageAltText`
- `generateFromBuffer` intentionally NOT gated — no jobId context (raw-buffer test endpoint outside the PRH-job flow)

## Disabled-state response

```
HTTP 403
{
  "success": false,
  "error": {
    "code": "PRH_AI_DISABLED",
    "message": "PRH UK requires AI alt text to be vetted...",
    "banner": true
  }
}
```

FE matches on `error.code === 'PRH_AI_DISABLED'` (not message content) → renders a persistent banner, not a transient toast.

## Scoping decisions baked in

| Decision | Choice | Rationale |
|---|---|---|
| Default state | Disabled | Style Guide Appendix 7 — AI prohibited unless vetted |
| Permission to flip | Admin-only | Policy attestation, not casual operator action |
| Audit trail | Server-stamps `enabledBy` + `enabledAt` from `req.user.id` | Client cannot forge userId or timestamp |
| Confidence threshold | Medium+ only | Low-confidence PRH matches don't trigger the gate (consistent with P2/P3 imprint gating) |
| Error response shape | Structured `{ code, message, banner }` | FE banner detection needs typed code; deliberate deviation from the file's usual string-error convention |

## Test plan

- [x] 1423/1423 unit tests passing (20 new for prh-config.service covering all 3 branches of `assertAiAltTextAllowed` + server-stamping + sibling-settings preservation)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke: PRH job → POST alt-text generate → expect 403 with `PRH_AI_DISABLED` payload
- [ ] Staging smoke: PATCH `/tenant/config/prh` as admin with `{ aiAltTextEnabled: true }` → re-POST alt-text → succeeds
- [ ] Staging smoke: PATCH as non-admin → expect 403 with "Insufficient permissions"
- [ ] Staging smoke: non-PRH job → alt-text generation works regardless of flag

## P4 completion status

| PR | Codes | Tests new | Status |
|---|---|---|---|
| #380 | — | 12 | merged (PRH-mode prompt + cover template + bookTitle) |
| **THIS** | — | 20 | open (AI-content gating) |
| P4/PR3 | 1 (decorative-group) | — | deferred per scoping |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PRH‑UK tenant configuration endpoints to view and update AI alt-text settings (admin-restricted).
  * Enforced PRH‑UK AI alt-text policy on image alt-text generation flows; generation will return a structured 403 when disallowed.

* **Tests**
  * Added unit tests covering PRH config behavior, gate logic, and job/tenant cases.

* **Notes**
  * Ad-hoc buffer/testing generation remains unaffected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/381)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->