### PR TITLE
chore(prh): add VPAT2.5-PRH-UK to workflow-contracts edition enum (P5/PR0)

### DIFF
--- a/src/types/workflow-contracts.ts
+++ b/src/types/workflow-contracts.ts
@@ -484,7 +484,7 @@ export const batchAutoApprovalPolicySchema = z.object({
 export const acrBatchConfigSchema = z.object({
   vendor: z.string().min(1, 'Vendor name is required'),
   contactEmail: z.string().email('Valid email required'),
-  edition: z.enum(['VPAT2.5-WCAG', 'VPAT2.5-508', 'VPAT2.5-EU', 'VPAT2.5-INT']).default('VPAT2.5-WCAG'),
+  edition: z.enum(['VPAT2.5-WCAG', 'VPAT2.5-508', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']).default('VPAT2.5-WCAG'),
   mode: z.enum(['individual', 'aggregate']).default('individual'),
   aggregationStrategy: z.enum(['conservative', 'optimistic']).default('conservative'),
 });

--- a/src/types/workflow-contracts.ts
+++ b/src/types/workflow-contracts.ts
@@ -204,7 +204,7 @@ export interface GateStatus {
 /** POST /api/v1/workflows */
 export interface StartWorkflowRequest {
   fileId: string;
-  vpatEditions?: string[];             // 'VPAT2.5-508' | 'VPAT2.5-WCAG' | 'VPAT2.5-EU' | 'VPAT2.5-INT'
+  vpatEditions?: string[];             // 'VPAT2.5-508' | 'VPAT2.5-WCAG' | 'VPAT2.5-EU' | 'VPAT2.5-INT' | 'VPAT2.5-PRH-UK'
 }
 
 /** POST /api/v1/workflows/:id/pause|resume|cancel|retry */


### PR DESCRIPTION
## Summary

Single one-line fix that was deferred during Sprint 9's READ-ONLY freeze on `src/types/workflow-contracts.ts`. Carry-over from the P1 frontend follow-ups (Prompt 5).

## Why now

The freeze has effectively lifted — Sprint 10 commits (`8080cd2`, `091ed94`, `c7256a7`) have edited the file since, so the coordination guardrail is no longer in force.

## What changed

Line 487:
```diff
-  edition: z.enum(['VPAT2.5-WCAG', 'VPAT2.5-508', 'VPAT2.5-EU', 'VPAT2.5-INT']).default('VPAT2.5-WCAG'),
+  edition: z.enum(['VPAT2.5-WCAG', 'VPAT2.5-508', 'VPAT2.5-EU', 'VPAT2.5-INT', 'VPAT2.5-PRH-UK']).default('VPAT2.5-WCAG'),
```

## Context

P1/PR5 added `'VPAT2.5-PRH-UK'` to every other edition whitelist (the `ACR_EDITIONS` const + controller Zod schemas), but the workflow-driven ACR path's independent enum copy was deliberately left untouched out of respect for the READ-ONLY rule. This closes that gap so workflow-path ACR generation accepts the PRH UK edition.

## Prereq for

P5/PR4 (PRH-deliverable export + VPAT URL embedding) — that PR wires the conformance VPAT through the workflow path.

## Test plan

- [x] 1427/1427 unit tests passing
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the "VPAT2.5-PRH-UK" accessibility reporting edition option across batch configuration and workflow inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/382)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->