### PR TITLE
feat(prh): per-imprint copyright-page scaffolder (P5/PR2)

### DIFF
--- a/src/controllers/prh-remediation.controller.ts
+++ b/src/controllers/prh-remediation.controller.ts
@@ -30,10 +30,18 @@ import {
   buildBoilerplateDraft,
   applyBoilerplate,
 } from '../services/epub/profiles/prh-uk/remediators/boilerplate-injector.service';
+import {
+  buildCopyrightPageDraft,
+  applyCopyrightPage,
+} from '../services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.service';
 
 const applyBoilerplateSchema = z.object({
   approvedCodes: z.array(z.string().min(1)).min(1, 'At least one code must be approved'),
   overrides: z.record(z.string(), z.string()).optional(),
+}).strict();
+
+const applyCopyrightPageSchema = z.object({
+  xhtmlOverride: z.string().min(1).optional(),
 }).strict();
 
 class PrhRemediationController {
@@ -99,6 +107,54 @@ class PrhRemediationController {
       res.json({ success: true, data: result });
     } catch (error) {
       if (error instanceof Error && /only runs on PRH-UK|medium-or-high|No snippets approved|Copyright page not found|EPUB buffer not found/i.test(error.message)) {
+        return next(AppError.badRequest(error.message));
+      }
+      next(error);
+    }
+  }
+
+  /**
+   * GET draft for the copyright-page scaffolder. Read-only. Used
+   * when the EPUB has no copyright page at all — the injector PR1
+   * handles the partial-page case.
+   */
+  async getCopyrightPageDraft(req: Request, res: Response, next: NextFunction) {
+    try {
+      if (!req.user) throw AppError.unauthorized('Not authenticated');
+      const { jobId } = req.params;
+      await this.assertJobAccess(jobId, req.user.tenantId);
+
+      const draft = await buildCopyrightPageDraft(jobId);
+      res.json({ success: true, data: draft });
+    } catch (error) {
+      if (error instanceof Error && /only runs on PRH-UK|medium-or-high|no audit output/i.test(error.message)) {
+        return next(AppError.badRequest(error.message));
+      }
+      next(error);
+    }
+  }
+
+  /**
+   * POST apply: inserts the scaffolded copyright page into the
+   * EPUB's zip, manifest, spine, and nav landmarks. Atomic in
+   * memory before save — all four updates land or none do.
+   */
+  async applyCopyrightPage(req: Request, res: Response, next: NextFunction) {
+    try {
+      if (!req.user) throw AppError.unauthorized('Not authenticated');
+      const { jobId } = req.params;
+      await this.assertJobAccess(jobId, req.user.tenantId);
+
+      const validation = applyCopyrightPageSchema.safeParse(req.body);
+      if (!validation.success) {
+        throw AppError.badRequest('Invalid request body: ' + validation.error.message);
+      }
+
+      const result = await applyCopyrightPage(jobId, validation.data);
+      logger.info(`[PRH remediation] scaffolded copyright page for job ${jobId} → ${result.newFilePath}`);
+      res.json({ success: true, data: result });
+    } catch (error) {
+      if (error instanceof Error && /only runs on PRH-UK|medium-or-high|already exists|EPUB buffer not found|OPF not found/i.test(error.message)) {
         return next(AppError.badRequest(error.message));
       }
       next(error);

--- a/src/routes/prh-remediation.routes.ts
+++ b/src/routes/prh-remediation.routes.ts
@@ -36,4 +36,28 @@ router.post(
   prhRemediationController.applyBoilerplate.bind(prhRemediationController),
 );
 
+/**
+ * POST /api/v1/jobs/:jobId/prh-remediation/copyright-page/draft
+ * Composes a full <section epub:type="copyright-page"> XHTML from
+ * the imprint's template — for EPUBs that have no copyright page at
+ * all. Returns the XHTML for operator preview.
+ */
+router.post(
+  '/:jobId/prh-remediation/copyright-page/draft',
+  authenticate,
+  prhRemediationController.getCopyrightPageDraft.bind(prhRemediationController),
+);
+
+/**
+ * POST /api/v1/jobs/:jobId/prh-remediation/copyright-page/apply
+ * Body: { xhtmlOverride?: string }
+ * Inserts the (optionally edited) XHTML into the zip + manifest +
+ * spine + nav landmarks. Atomic in memory before save.
+ */
+router.post(
+  '/:jobId/prh-remediation/copyright-page/apply',
+  authenticate,
+  prhRemediationController.applyCopyrightPage.bind(prhRemediationController),
+);
+
 export default router;

--- a/src/services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.service.ts
+++ b/src/services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.service.ts
@@ -366,13 +366,47 @@ function hasCopyrightPage(zip: AdmZip): boolean {
  * to `<opf-dir>/copyright.xhtml`; if that already exists, appends
  * `_prh` to avoid clobbering. The "already exists" pre-check above
  * usually short-circuits before we reach this, but be defensive.
+ *
+ * When the OPF sits at the zip root (`opfInfo.dir === ''`), we
+ * deliberately use a bare filename — `${dir}/...` would yield a
+ * leading-slash path that doesn't match how AdmZip indexes entries.
  */
 function derivePathForNewCopyrightFile(zip: AdmZip): string {
   const opfInfo = readOpfPath(zip);
   const dir = opfInfo?.dir ?? 'EPUB';
-  const primary = `${dir}/copyright.xhtml`;
+  const primary = dir.length > 0 ? `${dir}/copyright.xhtml` : 'copyright.xhtml';
   if (!zip.getEntry(primary)) return primary;
-  return `${dir}/copyright_prh.xhtml`;
+  return dir.length > 0 ? `${dir}/copyright_prh.xhtml` : 'copyright_prh.xhtml';
+}
+
+/**
+ * Resolve a manifest href (which is relative to the OPF directory)
+ * into the zip-entry path the file actually lives at. Normalises
+ * `./` and `../` segments — without this, a manifest entry like
+ * `<item href="../text/chapter.xhtml"/>` would yield a lookup path
+ * of `EPUB/../text/chapter.xhtml` that AdmZip can't match.
+ *
+ * Mirrors the path-resolution logic in run-validators.ts so the
+ * scaffolder lines up exactly with the validator's view of the
+ * spine.
+ */
+function resolveOpfRelative(opfDir: string, href: string): string {
+  let cleanHref = href.trim();
+  // Strip leading "./" segments.
+  while (cleanHref.startsWith('./')) cleanHref = cleanHref.slice(2);
+
+  const combined = opfDir.length > 0 ? `${opfDir}/${cleanHref}` : cleanHref;
+  const segments = combined.split('/');
+  const out: string[] = [];
+  for (const seg of segments) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      out.pop();
+      continue;
+    }
+    out.push(seg);
+  }
+  return out.join('/');
 }
 
 function manifestIdForPath(path: string): string {
@@ -456,8 +490,10 @@ function buildManifestIdToPath(opf: string, opfDir: string): Map<string, string>
     const idMatch = attrs.match(/\bid\s*=\s*["']([^"']+)["']/i);
     const hrefMatch = attrs.match(/\bhref\s*=\s*["']([^"']+)["']/i);
     if (!idMatch || !hrefMatch) continue;
-    const fullPath = opfDir ? `${opfDir}/${hrefMatch[1]}` : hrefMatch[1];
-    map.set(idMatch[1], fullPath);
+    // Normalise `./` and `../` segments — see resolveOpfRelative.
+    // Without this, hrefs like "../text/chapter.xhtml" become
+    // unresolvable zip-entry lookups.
+    map.set(idMatch[1], resolveOpfRelative(opfDir, hrefMatch[1]));
   }
   return map;
 }
@@ -498,17 +534,44 @@ function updateNavLandmarks(
   return { path: navPath, content: nav };
 }
 
-function hrefRelativeToNav(navPath: string, copyrightPath: string, opfDir: string): string {
-  // Nav and copyright both inside the same opf-dir on most EPUBs —
-  // emit a basename href, which is correct relative to the nav.
-  const copyrightBasename = copyrightPath.includes('/') ? copyrightPath.slice(copyrightPath.lastIndexOf('/') + 1) : copyrightPath;
-  const navBasename = navPath.includes('/') ? navPath.slice(navPath.lastIndexOf('/') + 1) : navPath;
-  // Both in same dir → bare filename is fine.
-  if (opfDir && navPath.startsWith(opfDir + '/') && copyrightPath.startsWith(opfDir + '/')) {
-    return copyrightBasename;
+/**
+ * Compute a POSIX-style relative href from the nav doc to the new
+ * copyright XHTML. Real PRH EPUBs nest XHTML two ways:
+ *   - flat:    EPUB/nav.xhtml + EPUB/copyright.xhtml → "copyright.xhtml"
+ *   - nested:  EPUB/nav.xhtml + EPUB/xhtml/copyright.xhtml → "xhtml/copyright.xhtml"
+ *   - sibling: EPUB/nav/nav.xhtml + EPUB/text/copyright.xhtml → "../text/copyright.xhtml"
+ *
+ * The earlier "always basename" shortcut was wrong on the third
+ * shape — the resulting link would 404 in the reading system.
+ */
+function hrefRelativeToNav(navPath: string, copyrightPath: string, _opfDir: string): string {
+  const navDir = navPath.includes('/') ? navPath.slice(0, navPath.lastIndexOf('/')) : '';
+  if (navDir.length === 0) {
+    // Nav at zip root — emit the copyright path verbatim.
+    return copyrightPath;
   }
-  // Otherwise fall back to opf-relative href (rare in real EPUBs).
-  return copyrightBasename || navBasename;
+  if (copyrightPath.startsWith(navDir + '/')) {
+    // Copyright nested under the nav's directory — strip the
+    // shared prefix.
+    return copyrightPath.slice(navDir.length + 1);
+  }
+
+  // Walk up from navDir to a common ancestor, then descend into
+  // copyrightPath. Standard POSIX-relative-path algorithm.
+  const navParts = navDir.split('/');
+  const targetParts = copyrightPath.split('/');
+  let common = 0;
+  while (
+    common < navParts.length
+    && common < targetParts.length - 1
+    && navParts[common] === targetParts[common]
+  ) {
+    common += 1;
+  }
+  const upHops = navParts.length - common;
+  const ups = new Array(upHops).fill('..');
+  const downs = targetParts.slice(common);
+  return [...ups, ...downs].join('/');
 }
 
 /**
@@ -569,6 +632,11 @@ async function loadJobEpubBuffer(jobId: string, originalFileName: string | null)
   return null;
 }
 
-// Re-export the composer for unit testing — it's pure and worth
-// testing without the full draft pipeline.
-export const _internals = { composeCopyrightXhtml, bodyClassForTemplate };
+// Re-export composer + path helpers for unit testing. All pure
+// functions, worth covering without the full draft pipeline.
+export const _internals = {
+  composeCopyrightXhtml,
+  bodyClassForTemplate,
+  resolveOpfRelative,
+  hrefRelativeToNav,
+};

--- a/src/services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.service.ts
+++ b/src/services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.service.ts
@@ -1,0 +1,574 @@
+/**
+ * PRH UK copyright-page scaffolder (P5/PR2).
+ *
+ * For EPUBs that don't have a copyright page at all, this service
+ * composes a full `<section epub:type="copyright-page">` XHTML
+ * document from the imprint's template, inserts it into the zip,
+ * registers the new file in the manifest + spine, and adds a
+ * landmark entry to the nav doc.
+ *
+ * Two-phase API mirrors the boilerplate-injector:
+ *
+ *   1. `buildCopyrightPageDraft(jobId)` — composes the full XHTML
+ *      from the imprint's boilerplate snippets, returns it for
+ *      operator preview. No mutation.
+ *
+ *   2. `applyCopyrightPage(jobId, approval)` — writes the XHTML
+ *      file into the zip, updates manifest/spine/landmarks
+ *      atomically (all-or-nothing in memory before save), and
+ *      stores the remediated EPUB.
+ *
+ * Spine insertion: per PRH content-order rules, copyright comes
+ * AFTER the title page (or cover when no title page) and BEFORE
+ * the first bodymatter entry. We detect bodymatter by walking
+ * spine items and reading each XHTML's `<body epub:type="…">`.
+ *
+ * Imprint-gated like PR1 — PRH-UK at medium-or-high confidence;
+ * adult / children / vintage-bespoke template families.
+ */
+
+import prisma from '../../../../../lib/prisma';
+import AdmZip from 'adm-zip';
+import { logger } from '../../../../../lib/logger';
+import { fileStorageService } from '../../../../storage/file-storage.service';
+import { s3Service } from '../../../../s3.service';
+import {
+  buildBoilerplateSnippets,
+  imprintTemplate,
+  type BoilerplateMetadata,
+  type BoilerplateMissingField,
+  type ImprintTemplate,
+} from '../imprints/boilerplate-templates';
+import type { PrhImprint } from '../../types';
+
+export interface CopyrightPageDraft {
+  jobId: string;
+  imprint: PrhImprint | null | 'unknown';
+  template: ImprintTemplate;
+  metadata: BoilerplateMetadata;
+  /** Full XHTML document the operator previews and can override. */
+  xhtml: string;
+  /** Aggregate list of metadata fields with __MISSING_*__ placeholders. */
+  missingFields: BoilerplateMissingField[];
+  /** Path the new file will be written to (e.g. EPUB/copyright.xhtml). */
+  proposedPath: string;
+  /** True when the EPUB already has a copyright page — scaffolder is a no-op. */
+  copyrightPageAlreadyExists: boolean;
+}
+
+export interface CopyrightPageApproval {
+  /** Optional operator-edited XHTML override. Defaults to the draft xhtml. */
+  xhtmlOverride?: string;
+}
+
+export interface CopyrightPageApplyResult {
+  jobId: string;
+  insertedAtSpineIndex: number;
+  newFilePath: string;
+  remediatedFileName: string;
+}
+
+/**
+ * Body-class hint used in the wrapping XHTML — taken from the
+ * Branding Guide: adult template uses `copyright_page_left`,
+ * children's same, Vintage uses `copyright_page_center`.
+ */
+function bodyClassForTemplate(template: ImprintTemplate): string {
+  return template === 'vintage-bespoke' ? 'copyright_page_center' : 'copyright_page_left';
+}
+
+/**
+ * Build the full XHTML document. Wraps every boilerplate snippet
+ * inside a single `<section epub:type="copyright-page">` and a
+ * frontmatter body. Doctype + XML decl included so the file parses
+ * the same as other EPUB content.
+ */
+function composeCopyrightXhtml(
+  template: ImprintTemplate,
+  metadata: BoilerplateMetadata,
+): { xhtml: string; missingFields: BoilerplateMissingField[] } {
+  const snippets = buildBoilerplateSnippets(template, metadata);
+
+  // Aggregate missing-field list across all snippets (de-duped).
+  const missing: BoilerplateMissingField[] = [];
+  for (const s of snippets) {
+    for (const f of s.missingFields) {
+      if (!missing.includes(f)) missing.push(f);
+    }
+  }
+
+  const bodyClass = bodyClassForTemplate(template);
+  const innerHtml = snippets.map((s) => s.html).join('\n  ');
+
+  const xhtml = `<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:epub="http://www.idpf.org/2007/ops"
+      lang="en" xml:lang="en">
+<head>
+  <title>Copyright</title>
+</head>
+<body epub:type="frontmatter" class="${bodyClass}">
+  <section epub:type="copyright-page">
+  ${innerHtml}
+  </section>
+</body>
+</html>
+`;
+
+  return { xhtml, missingFields: missing };
+}
+
+/**
+ * Build the per-job draft. Same metadata-read path as the
+ * boilerplate-injector. Doesn't run when the EPUB already has a
+ * copyright page — the injector PR1 handles that case.
+ */
+export async function buildCopyrightPageDraft(jobId: string): Promise<CopyrightPageDraft> {
+  const job = await prisma.job.findUnique({
+    where: { id: jobId },
+    select: { id: true, output: true, input: true },
+  });
+  if (!job) throw new Error(`Job ${jobId} not found`);
+  if (!job.output) throw new Error(`Job ${jobId} has no audit output — run an audit first`);
+
+  const output = job.output as Record<string, unknown>;
+  const profile = (output.publisherProfile && typeof output.publisherProfile === 'object')
+    ? (output.publisherProfile as Record<string, unknown>)
+    : null;
+
+  if (!profile || profile.publisher !== 'PRH-UK') {
+    throw new Error('Copyright-page scaffolder only runs on PRH-UK jobs');
+  }
+  if (profile.confidence !== 'medium' && profile.confidence !== 'high') {
+    throw new Error('Copyright-page scaffolder requires medium-or-high publisher-profile confidence');
+  }
+
+  const imprint = (profile.imprint as PrhImprint | 'unknown' | null) ?? null;
+  const template = imprintTemplate(imprint);
+  const bookTitle = typeof output.bookTitle === 'string' ? output.bookTitle : null;
+
+  const metadata: BoilerplateMetadata = {
+    bookTitle,
+    authorName: null,
+    isbn: null,
+    year: null,
+    imprintDisplayName: deriveImprintDisplayName(imprint, template),
+    division: deriveDivisionLabel(imprint, template),
+  };
+
+  let copyrightPageAlreadyExists = false;
+  let proposedPath = 'EPUB/copyright.xhtml';
+
+  try {
+    const buffer = await loadJobEpubBuffer(jobId, jobInputFileName(job.input));
+    if (buffer) {
+      const opfMetadata = readOpfMetadata(buffer);
+      if (opfMetadata.authorName) metadata.authorName = opfMetadata.authorName;
+      if (opfMetadata.isbn) metadata.isbn = opfMetadata.isbn;
+      if (opfMetadata.year) metadata.year = opfMetadata.year;
+      if (!metadata.bookTitle && opfMetadata.bookTitle) {
+        metadata.bookTitle = opfMetadata.bookTitle;
+      }
+
+      const zip = new AdmZip(buffer);
+      copyrightPageAlreadyExists = hasCopyrightPage(zip);
+      proposedPath = derivePathForNewCopyrightFile(zip);
+    }
+  } catch (err) {
+    logger.warn(`[copyright-scaffolder] OPF read failed for job ${jobId}: ${err instanceof Error ? err.message : 'unknown'}`);
+  }
+
+  const { xhtml, missingFields } = composeCopyrightXhtml(template, metadata);
+
+  return {
+    jobId,
+    imprint,
+    template,
+    metadata,
+    xhtml,
+    missingFields,
+    proposedPath,
+    copyrightPageAlreadyExists,
+  };
+}
+
+/**
+ * Apply the scaffolded copyright page to the EPUB. Atomic in
+ * memory: builds the full updated zip (file + manifest + spine +
+ * landmarks) before writing back. Either all four pieces update or
+ * none do.
+ */
+export async function applyCopyrightPage(
+  jobId: string,
+  approval: CopyrightPageApproval,
+): Promise<CopyrightPageApplyResult> {
+  const job = await prisma.job.findUnique({
+    where: { id: jobId },
+    select: { id: true, input: true },
+  });
+  if (!job) throw new Error(`Job ${jobId} not found`);
+
+  const draft = await buildCopyrightPageDraft(jobId);
+  if (draft.copyrightPageAlreadyExists) {
+    throw new Error('Copyright page already exists — use the boilerplate injector (PR1) to update it');
+  }
+
+  const buffer = await loadJobEpubBuffer(jobId, jobInputFileName(job.input));
+  if (!buffer) throw new Error(`EPUB buffer not found for job ${jobId}`);
+
+  const zip = new AdmZip(buffer);
+
+  // Compose the final state in memory before mutating the zip —
+  // any failure short-circuits before we touch the file.
+  const xhtml = approval.xhtmlOverride ?? draft.xhtml;
+  const opfInfo = readOpfPath(zip);
+  if (!opfInfo) throw new Error('OPF not found in EPUB — cannot insert copyright page');
+
+  const newManifestItem = `<item id="${manifestIdForPath(draft.proposedPath)}" href="${hrefRelativeToOpf(opfInfo.dir, draft.proposedPath)}" media-type="application/xhtml+xml"/>`;
+  const newSpineItemref = `<itemref idref="${manifestIdForPath(draft.proposedPath)}"/>`;
+
+  const updatedOpf = insertCopyrightIntoOpf(
+    opfInfo.content,
+    newManifestItem,
+    newSpineItemref,
+    zip,
+    opfInfo.dir,
+  );
+  const updatedNavInfo = updateNavLandmarks(zip, opfInfo, draft.proposedPath);
+
+  const insertedAtSpineIndex = computeInsertedSpineIndex(opfInfo.content, updatedOpf);
+
+  // All planning done — mutate the zip.
+  zip.addFile(draft.proposedPath, Buffer.from(xhtml, 'utf-8'));
+  const opfEntry = zip.getEntry(opfInfo.path);
+  if (opfEntry) opfEntry.setData(Buffer.from(updatedOpf, 'utf-8'));
+  if (updatedNavInfo) {
+    const navEntry = zip.getEntry(updatedNavInfo.path);
+    if (navEntry) navEntry.setData(Buffer.from(updatedNavInfo.content, 'utf-8'));
+  }
+
+  const modifiedBuffer = zip.toBuffer();
+  const remediatedFileName = `${jobId}-prh-copyright-scaffolded.epub`;
+  await fileStorageService.saveRemediatedFile(jobId, remediatedFileName, modifiedBuffer);
+
+  logger.info(`[copyright-scaffolder] inserted copyright page for job ${jobId} at spine index ${insertedAtSpineIndex}`);
+
+  return {
+    jobId,
+    insertedAtSpineIndex,
+    newFilePath: draft.proposedPath,
+    remediatedFileName,
+  };
+}
+
+// ── shared helpers (mostly mirrors of boilerplate-injector's) ────────────
+
+function deriveImprintDisplayName(imprint: PrhImprint | null | 'unknown', template: ImprintTemplate): string {
+  if (imprint === 'penguin') return 'Penguin';
+  if (imprint === 'puffin') return 'Puffin';
+  if (imprint === 'vintage') return 'Vintage';
+  if (imprint === 'pelican') return 'Pelican';
+  if (imprint === 'ladybird') return 'Ladybird';
+  if (imprint === 'merky') return '#Merky Books';
+  if (imprint === 'cornerstone-saga') return 'Cornerstone Saga';
+  return template === 'children' ? 'Penguin Random House Children’s' : 'Penguin Random House';
+}
+
+function deriveDivisionLabel(imprint: PrhImprint | null | 'unknown', template: ImprintTemplate): string {
+  if (template === 'children') return 'Penguin Random House Children’s';
+  if (template === 'vintage-bespoke') return 'Vintage';
+  if (imprint === 'penguin') return 'Penguin Books';
+  if (imprint === 'pelican') return 'Pelican Books';
+  if (imprint === 'merky') return '#Merky Books';
+  if (imprint === 'cornerstone-saga') return 'Cornerstone Saga';
+  return 'Penguin Random House';
+}
+
+interface OpfInfo {
+  path: string;
+  /** Directory portion of opf path inside the zip (e.g. "EPUB"). */
+  dir: string;
+  content: string;
+}
+function readOpfPath(zip: AdmZip): OpfInfo | null {
+  const containerEntry = zip.getEntry('META-INF/container.xml');
+  if (!containerEntry) return null;
+  const containerXml = containerEntry.getData().toString('utf-8');
+  const m = containerXml.match(/rootfile[^>]+full-path\s*=\s*(?:"([^"]+)"|'([^']+)')/i);
+  const path = m?.[1] ?? m?.[2];
+  if (!path) return null;
+  const opfEntry = zip.getEntry(path);
+  if (!opfEntry) return null;
+  const content = opfEntry.getData().toString('utf-8');
+  const dir = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
+  return { path, dir, content };
+}
+
+interface OpfMetadata {
+  bookTitle: string | null;
+  authorName: string | null;
+  isbn: string | null;
+  year: string | null;
+}
+function readOpfMetadata(buffer: Buffer): OpfMetadata {
+  const result: OpfMetadata = { bookTitle: null, authorName: null, isbn: null, year: null };
+  try {
+    const zip = new AdmZip(buffer);
+    const opfInfo = readOpfPath(zip);
+    if (!opfInfo) return result;
+    const opf = opfInfo.content;
+    result.bookTitle = decoded(opf.match(/<dc:title\b[^>]*>([\s\S]*?)<\/dc:title>/i));
+    result.authorName = decoded(opf.match(/<dc:creator\b[^>]*>([\s\S]*?)<\/dc:creator>/i));
+    const idText = decoded(opf.match(/<dc:identifier\b[^>]*>([\s\S]*?)<\/dc:identifier>/i));
+    if (idText) {
+      const isbnMatch = idText.match(/97[89][\s-]?(?:\d[\s-]?){10}/);
+      if (isbnMatch) result.isbn = isbnMatch[0].replace(/\s/g, '');
+    }
+    const dateText = decoded(opf.match(/<dc:date\b[^>]*>([\s\S]*?)<\/dc:date>/i));
+    if (dateText) {
+      const yearMatch = dateText.match(/\b(19|20)\d{2}\b/);
+      if (yearMatch) result.year = yearMatch[0];
+    }
+  } catch {
+    /* fall through with nulls */
+  }
+  return result;
+}
+
+function decoded(m: RegExpMatchArray | null): string | null {
+  if (!m) return null;
+  const trimmed = m[1]
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#([0-9]+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function hasCopyrightPage(zip: AdmZip): boolean {
+  for (const entry of zip.getEntries()) {
+    if (entry.isDirectory) continue;
+    if (!/\.x?html?$/i.test(entry.entryName)) continue;
+    const content = entry.getData().toString('utf-8');
+    if (/epub:type\s*=\s*["'][^"']*\bcopyright-page\b/i.test(content)) return true;
+    if (/(?:^|\/)copyright[^/]*\.x?html?$/i.test(entry.entryName)) return true;
+  }
+  return false;
+}
+
+/**
+ * Pick a non-conflicting path for the new copyright file. Defaults
+ * to `<opf-dir>/copyright.xhtml`; if that already exists, appends
+ * `_prh` to avoid clobbering. The "already exists" pre-check above
+ * usually short-circuits before we reach this, but be defensive.
+ */
+function derivePathForNewCopyrightFile(zip: AdmZip): string {
+  const opfInfo = readOpfPath(zip);
+  const dir = opfInfo?.dir ?? 'EPUB';
+  const primary = `${dir}/copyright.xhtml`;
+  if (!zip.getEntry(primary)) return primary;
+  return `${dir}/copyright_prh.xhtml`;
+}
+
+function manifestIdForPath(path: string): string {
+  const basename = path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
+  return basename.replace(/\.x?html?$/i, '').replace(/[^a-zA-Z0-9_-]/g, '_') || 'copyright';
+}
+
+function hrefRelativeToOpf(opfDir: string, filePath: string): string {
+  if (!opfDir) return filePath;
+  if (filePath.startsWith(opfDir + '/')) {
+    return filePath.slice(opfDir.length + 1);
+  }
+  return filePath;
+}
+
+/**
+ * Insert manifest item + spine itemref into the OPF. Spine insertion
+ * position: just BEFORE the first bodymatter itemref. When no
+ * bodymatter is detected (rare on real EPUBs but possible on
+ * skeleton uploads) we append to the end of the spine — better than
+ * inserting at an arbitrary position.
+ */
+function insertCopyrightIntoOpf(
+  opf: string,
+  newManifestItem: string,
+  newSpineItemref: string,
+  zip: AdmZip,
+  opfDir: string,
+): string {
+  // Insert into manifest just before </manifest>.
+  let updated = opf.replace(
+    /<\/manifest>/i,
+    `  ${newManifestItem}\n</manifest>`,
+  );
+
+  // Insert into spine. Walk itemrefs, find the first whose target
+  // file's body epub:type === bodymatter; insert before it.
+  const spineMatch = updated.match(/<spine\b[^>]*>([\s\S]*?)<\/spine>/i);
+  if (!spineMatch) return updated; // malformed OPF — leave manifest update in place
+
+  const manifestMap = buildManifestIdToPath(updated, opfDir);
+  const refRe = /<itemref\b[^>]*\bidref\s*=\s*["']([^"']+)["'][^>]*\/?>/gi;
+  let m: RegExpExecArray | null;
+  let firstBodymatterMatch: RegExpExecArray | null = null;
+  while ((m = refRe.exec(spineMatch[1])) !== null) {
+    const idref = m[1];
+    const targetPath = manifestMap.get(idref);
+    if (!targetPath) continue;
+    const targetEntry = zip.getEntry(targetPath);
+    if (!targetEntry) continue;
+    const targetContent = targetEntry.getData().toString('utf-8');
+    if (/<body\b[^>]*\bepub:type\s*=\s*["'][^"']*\bbodymatter\b/i.test(targetContent)) {
+      firstBodymatterMatch = m;
+      break;
+    }
+  }
+
+  if (firstBodymatterMatch) {
+    // Replace the spine block with the same content but with the new
+    // itemref inserted just before the first bodymatter itemref.
+    const oldSpineInner = spineMatch[1];
+    const matchedRef = firstBodymatterMatch[0];
+    const idx = oldSpineInner.indexOf(matchedRef);
+    const newSpineInner = oldSpineInner.slice(0, idx) + `  ${newSpineItemref}\n` + oldSpineInner.slice(idx);
+    updated = updated.replace(spineMatch[0], spineMatch[0].replace(oldSpineInner, newSpineInner));
+  } else {
+    updated = updated.replace(/<\/spine>/i, `  ${newSpineItemref}\n</spine>`);
+  }
+
+  return updated;
+}
+
+function buildManifestIdToPath(opf: string, opfDir: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const manifestMatch = opf.match(/<manifest\b[^>]*>([\s\S]*?)<\/manifest>/i);
+  if (!manifestMatch) return map;
+  const itemRe = /<item\b([^>]*)\/?>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = itemRe.exec(manifestMatch[1])) !== null) {
+    const attrs = m[1];
+    const idMatch = attrs.match(/\bid\s*=\s*["']([^"']+)["']/i);
+    const hrefMatch = attrs.match(/\bhref\s*=\s*["']([^"']+)["']/i);
+    if (!idMatch || !hrefMatch) continue;
+    const fullPath = opfDir ? `${opfDir}/${hrefMatch[1]}` : hrefMatch[1];
+    map.set(idMatch[1], fullPath);
+  }
+  return map;
+}
+
+/**
+ * Locate and update the nav doc's landmarks block to include a
+ * copyright entry. Returns null when no nav doc is present (the
+ * spine update alone is enough; landmarks are nice-to-have).
+ */
+function updateNavLandmarks(
+  zip: AdmZip,
+  opfInfo: OpfInfo,
+  copyrightPath: string,
+): { path: string; content: string } | null {
+  const navMatch = opfInfo.content.match(/<item\b[^>]*\bproperties\s*=\s*["'][^"']*\bnav\b[^"']*["'][^>]*>/i);
+  if (!navMatch) return null;
+  const hrefMatch = navMatch[0].match(/\bhref\s*=\s*["']([^"']+)["']/i);
+  if (!hrefMatch) return null;
+  const navPath = opfInfo.dir ? `${opfInfo.dir}/${hrefMatch[1]}` : hrefMatch[1];
+  const navEntry = zip.getEntry(navPath);
+  if (!navEntry) return null;
+  let nav = navEntry.getData().toString('utf-8');
+
+  // Skip if landmarks already mentions a copyright entry.
+  if (/<nav\b[^>]*\bepub:type\s*=\s*["'][^"']*\blandmarks\b[\s\S]*?\bepub:type\s*=\s*["'][^"']*\bcopyright-page\b/i.test(nav)) {
+    return { path: navPath, content: nav };
+  }
+
+  const landmarksMatch = nav.match(/(<nav\b[^>]*\bepub:type\s*=\s*["'][^"']*\blandmarks\b[\s\S]*?<ol[^>]*>)([\s\S]*?)(<\/ol>[\s\S]*?<\/nav>)/i);
+  if (!landmarksMatch) return { path: navPath, content: nav };
+
+  const copyrightHref = hrefRelativeToNav(navPath, copyrightPath, opfInfo.dir);
+  const newLi = `<li><a epub:type="copyright-page" href="${copyrightHref}">Copyright</a></li>`;
+  nav = nav.replace(
+    landmarksMatch[0],
+    `${landmarksMatch[1]}${landmarksMatch[2]}\n  ${newLi}\n${landmarksMatch[3]}`,
+  );
+  return { path: navPath, content: nav };
+}
+
+function hrefRelativeToNav(navPath: string, copyrightPath: string, opfDir: string): string {
+  // Nav and copyright both inside the same opf-dir on most EPUBs —
+  // emit a basename href, which is correct relative to the nav.
+  const copyrightBasename = copyrightPath.includes('/') ? copyrightPath.slice(copyrightPath.lastIndexOf('/') + 1) : copyrightPath;
+  const navBasename = navPath.includes('/') ? navPath.slice(navPath.lastIndexOf('/') + 1) : navPath;
+  // Both in same dir → bare filename is fine.
+  if (opfDir && navPath.startsWith(opfDir + '/') && copyrightPath.startsWith(opfDir + '/')) {
+    return copyrightBasename;
+  }
+  // Otherwise fall back to opf-relative href (rare in real EPUBs).
+  return copyrightBasename || navBasename;
+}
+
+/**
+ * Re-derive the spine index where the new copyright itemref
+ * landed. Used by the apply result so the FE can highlight the
+ * new entry in the spine view.
+ */
+function computeInsertedSpineIndex(oldOpf: string, newOpf: string): number {
+  const oldRefs = countSpineItemrefs(oldOpf);
+  const newRefs = countSpineItemrefs(newOpf);
+  if (newRefs === oldRefs + 1) {
+    // Locate the position of the new copyright itemref by diffing
+    // walk — but simpler: find the index of the unique new
+    // idref in the new spine. The new idref always starts with
+    // "copyright" or contains "copyright" per manifestIdForPath.
+    const spineMatch = newOpf.match(/<spine\b[^>]*>([\s\S]*?)<\/spine>/i);
+    if (spineMatch) {
+      const refs = Array.from(spineMatch[1].matchAll(/<itemref\b[^>]*\bidref\s*=\s*["']([^"']+)["'][^>]*\/?>/gi));
+      for (let i = 0; i < refs.length; i += 1) {
+        if (refs[i][1].toLowerCase().startsWith('copyright')) return i;
+      }
+    }
+  }
+  return -1;
+}
+
+function countSpineItemrefs(opf: string): number {
+  const spineMatch = opf.match(/<spine\b[^>]*>([\s\S]*?)<\/spine>/i);
+  if (!spineMatch) return 0;
+  return (spineMatch[1].match(/<itemref\b/gi) || []).length;
+}
+
+function jobInputFileName(input: unknown): string | null {
+  if (!input || typeof input !== 'object') return null;
+  const inputObj = input as { originalName?: unknown; fileName?: unknown };
+  if (typeof inputObj.originalName === 'string') return inputObj.originalName;
+  if (typeof inputObj.fileName === 'string') return inputObj.fileName;
+  return null;
+}
+
+async function loadJobEpubBuffer(jobId: string, originalFileName: string | null): Promise<Buffer | null> {
+  if (originalFileName) {
+    try {
+      const remediated = await fileStorageService.getRemediatedFile(jobId, originalFileName);
+      if (remediated) return remediated;
+    } catch {
+      /* fall through */
+    }
+  }
+  try {
+    if (originalFileName) {
+      const fileKey = `jobs/${jobId}/${originalFileName}`;
+      return await s3Service.getFileBuffer(fileKey);
+    }
+  } catch (err) {
+    logger.warn(`[copyright-scaffolder] failed to load EPUB for job ${jobId}: ${err instanceof Error ? err.message : 'unknown'}`);
+  }
+  return null;
+}
+
+// Re-export the composer for unit testing — it's pure and worth
+// testing without the full draft pipeline.
+export const _internals = { composeCopyrightXhtml, bodyClassForTemplate };

--- a/tests/unit/services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { _internals } from '../../../../../../../src/services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.service';
+import type { BoilerplateMetadata } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints/boilerplate-templates';
+
+const { composeCopyrightXhtml, bodyClassForTemplate } = _internals;
+
+function metadata(overrides: Partial<BoilerplateMetadata> = {}): BoilerplateMetadata {
+  return {
+    bookTitle: 'Test Book',
+    authorName: 'Test Author',
+    isbn: '978-1-234-56789-0',
+    year: '2026',
+    imprintDisplayName: 'Penguin',
+    division: 'Penguin Books',
+    ...overrides,
+  };
+}
+
+describe('bodyClassForTemplate', () => {
+  it('uses copyright_page_left for adult', () => {
+    expect(bodyClassForTemplate('adult')).toBe('copyright_page_left');
+  });
+  it('uses copyright_page_left for children', () => {
+    expect(bodyClassForTemplate('children')).toBe('copyright_page_left');
+  });
+  it('uses copyright_page_center for vintage-bespoke', () => {
+    expect(bodyClassForTemplate('vintage-bespoke')).toBe('copyright_page_center');
+  });
+});
+
+describe('composeCopyrightXhtml — adult', () => {
+  it('produces a valid XHTML document with the canonical wrapper', () => {
+    const { xhtml } = composeCopyrightXhtml('adult', metadata());
+    expect(xhtml).toContain('<?xml version="1.0"');
+    expect(xhtml).toContain('<!DOCTYPE html>');
+    expect(xhtml).toMatch(/<html\b[^>]*xmlns:epub="http:\/\/www\.idpf\.org\/2007\/ops"/);
+    expect(xhtml).toContain('<title>Copyright</title>');
+    expect(xhtml).toContain('<body epub:type="frontmatter"');
+    expect(xhtml).toContain('class="copyright_page_left"');
+    expect(xhtml).toContain('<section epub:type="copyright-page">');
+  });
+
+  it('embeds the TDM-reservation paragraph on adult template', () => {
+    const { xhtml } = composeCopyrightXhtml('adult', metadata());
+    expect(xhtml).toMatch(/DSM Directive 2019\/790/);
+  });
+
+  it('embeds the EEA representative line on adult template', () => {
+    const { xhtml } = composeCopyrightXhtml('adult', metadata());
+    expect(xhtml).toMatch(/Morrison Chambers, 32 Nassau Street, Dublin D02 YH68/);
+  });
+
+  it('embeds the PRH UK logo figure', () => {
+    const { xhtml } = composeCopyrightXhtml('adult', metadata());
+    expect(xhtml).toMatch(/<figure class="copyright_logo">/);
+    expect(xhtml).toMatch(/alt="Penguin Random House UK"/);
+  });
+
+  it('reports no missing fields when all metadata is present', () => {
+    const { missingFields } = composeCopyrightXhtml('adult', metadata());
+    expect(missingFields).toEqual([]);
+  });
+
+  it('reports missing ISBN field when metadata.isbn is null', () => {
+    const { xhtml, missingFields } = composeCopyrightXhtml('adult', metadata({ isbn: null }));
+    expect(missingFields).toContain('isbn');
+    expect(xhtml).toContain('__MISSING_ISBN__');
+  });
+});
+
+describe('composeCopyrightXhtml — children', () => {
+  it('embeds all three children\'s URLs', () => {
+    const { xhtml } = composeCopyrightXhtml('children', metadata());
+    expect(xhtml).toMatch(/penguin\.co\.uk/);
+    expect(xhtml).toMatch(/puffin\.co\.uk/);
+    expect(xhtml).toMatch(/ladybird\.co\.uk/);
+  });
+
+  it('uses Children\'s correspondence address', () => {
+    const { xhtml } = composeCopyrightXhtml('children', metadata());
+    expect(xhtml).toMatch(/Penguin Random House Children/);
+  });
+
+  it('still includes TDM + EEA (same as adult)', () => {
+    const { xhtml } = composeCopyrightXhtml('children', metadata());
+    expect(xhtml).toMatch(/DSM Directive 2019\/790/);
+    expect(xhtml).toMatch(/Morrison Chambers/);
+  });
+});
+
+describe('composeCopyrightXhtml — vintage-bespoke', () => {
+  it('uses copyright_page_center body class', () => {
+    const { xhtml } = composeCopyrightXhtml('vintage-bespoke', metadata());
+    expect(xhtml).toContain('class="copyright_page_center"');
+  });
+
+  it('does NOT include TDM or EEA (per Branding Guide §5.3)', () => {
+    const { xhtml } = composeCopyrightXhtml('vintage-bespoke', metadata());
+    expect(xhtml).not.toMatch(/DSM Directive/);
+    expect(xhtml).not.toMatch(/Morrison Chambers/);
+  });
+
+  it('includes the Vintage bespoke anti-piracy opener', () => {
+    const { xhtml } = composeCopyrightXhtml('vintage-bespoke', metadata());
+    expect(xhtml).toMatch(/This ebook is copyright material/);
+  });
+
+  it('uses the Vintage address (20 Vauxhall Bridge Road)', () => {
+    const { xhtml } = composeCopyrightXhtml('vintage-bespoke', metadata());
+    expect(xhtml).toMatch(/20 Vauxhall Bridge Road, London SW1V 2SA/);
+  });
+
+  it('uses the Vintage URL', () => {
+    const { xhtml } = composeCopyrightXhtml('vintage-bespoke', metadata());
+    expect(xhtml).toMatch(/penguin\.co\.uk\/vintage/);
+  });
+});
+
+describe('composeCopyrightXhtml — placeholder de-duplication', () => {
+  it('de-duplicates the missing-field list across snippets', () => {
+    // ISBN appears in only one snippet in the adult template, so
+    // there's no opportunity for duplication YET — this test
+    // documents the invariant for future template changes that add
+    // the same token to multiple snippets.
+    const { missingFields } = composeCopyrightXhtml('adult', metadata({ isbn: null, year: null }));
+    const uniqueFields = new Set(missingFields);
+    expect(missingFields.length).toBe(uniqueFields.size);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { _internals } from '../../../../../../../src/services/epub/profiles/prh-uk/remediators/copyright-page-scaffolder.service';
 import type { BoilerplateMetadata } from '../../../../../../../src/services/epub/profiles/prh-uk/imprints/boilerplate-templates';
 
-const { composeCopyrightXhtml, bodyClassForTemplate } = _internals;
+const {
+  composeCopyrightXhtml,
+  bodyClassForTemplate,
+  resolveOpfRelative,
+  hrefRelativeToNav,
+} = _internals;
 
 function metadata(overrides: Partial<BoilerplateMetadata> = {}): BoilerplateMetadata {
   return {
@@ -125,5 +130,50 @@ describe('composeCopyrightXhtml — placeholder de-duplication', () => {
     const { missingFields } = composeCopyrightXhtml('adult', metadata({ isbn: null, year: null }));
     const uniqueFields = new Set(missingFields);
     expect(missingFields.length).toBe(uniqueFields.size);
+  });
+});
+
+describe('resolveOpfRelative — path normalisation (CR regression)', () => {
+  it('resolves bare filename when opfDir is empty', () => {
+    expect(resolveOpfRelative('', 'copyright.xhtml')).toBe('copyright.xhtml');
+  });
+
+  it('joins opfDir + href when both are present', () => {
+    expect(resolveOpfRelative('EPUB', 'copyright.xhtml')).toBe('EPUB/copyright.xhtml');
+  });
+
+  it('strips leading "./" segments', () => {
+    expect(resolveOpfRelative('EPUB', './copyright.xhtml')).toBe('EPUB/copyright.xhtml');
+  });
+
+  it('collapses ".." segments (regression — manifest hrefs like "../text/chapter.xhtml")', () => {
+    expect(resolveOpfRelative('EPUB/oebps', '../text/chapter.xhtml')).toBe('EPUB/text/chapter.xhtml');
+  });
+
+  it('handles consecutive ".." segments', () => {
+    expect(resolveOpfRelative('EPUB/oebps/content', '../../text/chapter.xhtml')).toBe('EPUB/text/chapter.xhtml');
+  });
+});
+
+describe('hrefRelativeToNav — POSIX relative path (CR regression)', () => {
+  it('emits bare basename when nav and target share a parent dir (flat layout)', () => {
+    expect(hrefRelativeToNav('EPUB/nav.xhtml', 'EPUB/copyright.xhtml', 'EPUB')).toBe('copyright.xhtml');
+  });
+
+  it('emits subdir/basename when target is nested under nav\'s dir', () => {
+    expect(hrefRelativeToNav('EPUB/nav.xhtml', 'EPUB/xhtml/copyright.xhtml', 'EPUB')).toBe('xhtml/copyright.xhtml');
+  });
+
+  it('emits ../ prefix when nav and target are in sibling dirs (regression)', () => {
+    // Previous "always basename" shortcut would 404 on this layout.
+    expect(hrefRelativeToNav('EPUB/nav/nav.xhtml', 'EPUB/text/copyright.xhtml', 'EPUB')).toBe('../text/copyright.xhtml');
+  });
+
+  it('emits multiple ../ when nav is deeply nested', () => {
+    expect(hrefRelativeToNav('EPUB/nav/sub/nav.xhtml', 'EPUB/copyright.xhtml', 'EPUB')).toBe('../../copyright.xhtml');
+  });
+
+  it('handles nav at zip root (no nav dir prefix)', () => {
+    expect(hrefRelativeToNav('nav.xhtml', 'copyright.xhtml', '')).toBe('copyright.xhtml');
   });
 });


### PR DESCRIPTION
## Summary

For EPUBs that don't have a copyright page at all, composes a full `<section epub:type="copyright-page">` XHTML from the imprint's boilerplate template, inserts it into the zip + manifest + spine + nav landmarks. Atomic in memory before save.

## Two-phase API

| Phase | Endpoint |
|---|---|
| Draft | `POST /api/v1/jobs/:jobId/prh-remediation/copyright-page/draft` |
| Apply | `POST /api/v1/jobs/:jobId/prh-remediation/copyright-page/apply` |

Apply body: `{ xhtmlOverride?: string }` — operator can edit before applying.

## Spine insertion strategy

Inserts the new itemref **just BEFORE the first bodymatter itemref** (per PRH content-order rules: copyright sits in frontmatter). Detection walks the spine and reads each XHTML's `<body epub:type="…">`. Falls back to spine-end when no bodymatter is detected (rare on real EPUBs, possible on skeleton uploads).

## Atomic mutation

All four updates (file content + manifest item + spine itemref + nav landmark `<li>`) compose in memory first, then write to the zip in one pass. Any failure short-circuits before mutation.

## Per-template differences

| Template | Body class | Includes |
|---|---|---|
| adult | `copyright_page_left` | TDM + EEA + full boilerplate |
| children | `copyright_page_left` | Same as adult + 3 URLs + `id="isbn"` |
| vintage-bespoke | `copyright_page_center` | Bespoke opener; NO TDM, NO EEA |

All three include the PRH UK logo figure.

## Test plan

- [x] 1468/1468 unit tests passing (18 new for the XHTML composer)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke: PRH job with no copyright page → draft returns proposed path + XHTML
- [ ] Staging smoke: apply with no override → remediated EPUB has the new file, manifest entry, spine itemref BEFORE bodymatter, landmark `<li>` in nav
- [ ] Staging smoke: draft on a job that already has a copyright page → returns `copyrightPageAlreadyExists: true`; apply rejects with 400

## P5 progress

| PR | Scope | Status |
|---|---|---|
| #382 | PR0: workflow-contracts enum reconciliation | merged |
| #383 | PR1: Boilerplate injector | merged |
| **THIS** | **PR2: Copyright-page scaffolder** | **open** |
| — | PR3: Auto-fix bundle (6 P3 markup codes) | next |
| — | PR4: Deliverable export + conformance report | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a copyright-page scaffolding workflow for EPUB remediation.
  * Users can preview draft copyright pages and apply them (with optional XHTML override).
  * Generated pages pull book metadata, update EPUB structure, and add navigation links when needed.

* **Tests**
  * Added comprehensive unit tests covering composition, templates, missing-field handling, and path/link resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/384)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->