### PR TITLE
feat(prh): auto-fix bundle for 6 P3 markup codes (P5/PR3)

### DIFF
--- a/src/constants/fix-classification.ts
+++ b/src/constants/fix-classification.ts
@@ -33,6 +33,20 @@ const BASE_AUTO_FIXABLE_CODES = new Set([
   // PRH UK profile image — adds role="presentation" to decorative
   // images (alt="") that are missing the role attribute.
   'PRH-DECORATIVE-MISSING-PRESENTATION-ROLE',
+  // PRH UK markup auto-fixes (P5/PR3) — promoted from detect-only
+  // because each is a mechanical text/markup transformation that
+  // doesn't change semantic meaning. The remediator caps inline-
+  // style auto-strip at 50 attributes per file (defers above).
+  'PRH-MARKUP-DEPRECATED-TAG',
+  'PRH-MARKUP-INLINE-STYLE',
+  'PRH-MARKUP-EPUB-TYPE-MISPLACED',
+  'PRH-ARIA-CHAPTER-ROLE-MISSING',
+  'PRH-ARIA-PART-ROLE-MISSING',
+  'PRH-ARIA-DEDICATION-ROLE-MISSING',
+  'PRH-ARIA-EPIGRAPH-ROLE-MISSING',
+  'PRH-ARIA-APPENDIX-ROLE-MISSING',
+  'PRH-BODY-HAS-ARIA',
+  'PRH-PAGEBREAK-MALFORMED',
   // PRH-SPINE-* codes are detect-only in PR2 — spine reordering is risky
   // enough that we want operator review before mutating spine entries.
   // PRH-NAV-* codes are detect-only in PR3 — nav-doc structure changes

--- a/src/services/epub/auto-remediation.service.ts
+++ b/src/services/epub/auto-remediation.service.ts
@@ -14,6 +14,12 @@ import {
   fixA11ySummaryUrl,
   fixXmlLang,
   fixDecorativeRole,
+  fixDeprecatedTags,
+  fixInlineStyles,
+  fixEpubTypePlacement,
+  addDocAriaRoles,
+  fixBodyPurity,
+  fixPagebreakMalformed,
 } from './profiles/prh-uk';
 
 const comparisonService = new ComparisonService(prisma);
@@ -165,6 +171,20 @@ class AutoRemediationService {
     // Complements addDecorativeAltAttributes which only emits the role
     // when also adding a missing alt.
     'PRH-DECORATIVE-MISSING-PRESENTATION-ROLE': async (zip) => fixDecorativeRole(zip),
+    // ── PRH UK markup auto-fixes (P5/PR3) ────────────────────────────────
+    // Mechanical text/markup transformations for P3 detect-only codes.
+    // Idempotent; safe to re-run; conservative thresholds for the
+    // FP-prone cases (inline-style auto-strip caps at 50 per file).
+    'PRH-MARKUP-DEPRECATED-TAG': async (zip) => fixDeprecatedTags(zip),
+    'PRH-MARKUP-INLINE-STYLE': async (zip) => fixInlineStyles(zip),
+    'PRH-MARKUP-EPUB-TYPE-MISPLACED': async (zip) => fixEpubTypePlacement(zip),
+    'PRH-ARIA-CHAPTER-ROLE-MISSING': async (zip) => addDocAriaRoles(zip),
+    'PRH-ARIA-PART-ROLE-MISSING': async (zip) => addDocAriaRoles(zip),
+    'PRH-ARIA-DEDICATION-ROLE-MISSING': async (zip) => addDocAriaRoles(zip),
+    'PRH-ARIA-EPIGRAPH-ROLE-MISSING': async (zip) => addDocAriaRoles(zip),
+    'PRH-ARIA-APPENDIX-ROLE-MISSING': async (zip) => addDocAriaRoles(zip),
+    'PRH-BODY-HAS-ARIA': async (zip) => fixBodyPurity(zip),
+    'PRH-PAGEBREAK-MALFORMED': async (zip) => fixPagebreakMalformed(zip),
   };
 
   async runAutoRemediation(

--- a/src/services/epub/profiles/prh-uk/index.ts
+++ b/src/services/epub/profiles/prh-uk/index.ts
@@ -21,3 +21,11 @@ export {
 } from './remediators/metadata-remediator';
 export { fixXmlLang } from './remediators/xhtml-remediator';
 export { fixDecorativeRole } from './remediators/image-remediator';
+export {
+  fixDeprecatedTags,
+  fixInlineStyles,
+  fixEpubTypePlacement,
+  addDocAriaRoles,
+  fixBodyPurity,
+  fixPagebreakMalformed,
+} from './remediators/markup-remediator';

--- a/src/services/epub/profiles/prh-uk/remediators/markup-remediator.ts
+++ b/src/services/epub/profiles/prh-uk/remediators/markup-remediator.ts
@@ -161,7 +161,14 @@ export async function fixDeprecatedTags(zip: JSZip): Promise<ChangeResult[]> {
  */
 export async function fixInlineStyles(zip: JSZip): Promise<ChangeResult[]> {
   const results: ChangeResult[] = [];
-  const inlineStyleRe = /(\s)style\s*=\s*["'][^"']*["']/gi;
+  // Backreference (\2) ensures the closing quote matches the opening
+  // quote. Without it, an attribute like style="font-family: 'Times
+  // New Roman'" would have its value truncated at the inner single
+  // quote (the regex would see `style="font-family: '` as a full
+  // match), leaving `Times New Roman'"` orphaned in the markup.
+  // The (\s) capture preserves leading whitespace so the strip
+  // doesn't collapse adjacent attributes.
+  const inlineStyleRe = /(\s)style\s*=\s*(["'])([\s\S]*?)\2/gi;
 
   for (const filePath of Object.keys(zip.files)) {
     if (!/\.x?html?$/i.test(filePath)) continue;
@@ -174,8 +181,12 @@ export async function fixInlineStyles(zip: JSZip): Promise<ChangeResult[]> {
     if (!matches || matches.length === 0) continue;
 
     if (matches.length > INLINE_STYLE_AUTO_THRESHOLD) {
+      // Deferred ≠ fixed. Return success: false so the auto-
+      // remediation pipeline counts this file as outstanding rather
+      // than counting it toward the "resolved" tally. The operator
+      // sees the file in the still-needs-review bucket.
       results.push({
-        success: true,
+        success: false,
         description: `${filePath} has ${matches.length} inline styles — deferred to operator review (auto threshold is ${INLINE_STYLE_AUTO_THRESHOLD})`,
       });
       continue;
@@ -344,7 +355,10 @@ export async function fixBodyPurity(zip: JSZip): Promise<ChangeResult[]> {
     let attrs = bodyOpenMatch[1];
     const offenders: string[] = [];
     for (const attr of BANNED) {
-      const re = new RegExp(`(\\s)${attr}\\s*=\\s*["'][^"']*["']`, 'i');
+      // Backreference pattern handles `aria-label="Chapter's start"`
+      // and similar attributes that contain inner quotes. Without it
+      // the strip would truncate at the inner apostrophe.
+      const re = new RegExp(`(\\s)${attr}\\s*=\\s*(["'])[\\s\\S]*?\\2`, 'i');
       if (re.test(attrs)) {
         offenders.push(attr);
         attrs = attrs.replace(re, '');

--- a/src/services/epub/profiles/prh-uk/remediators/markup-remediator.ts
+++ b/src/services/epub/profiles/prh-uk/remediators/markup-remediator.ts
@@ -1,0 +1,450 @@
+/**
+ * PRH UK markup remediators (P5/PR3).
+ *
+ * Each fix wires a P3 detect-only code into auto-remediation.
+ * Idempotent — running twice on the same EPUB is a no-op once the
+ * file is conformant. Returns a `ChangeResult[]` (one entry per
+ * mutated file) so the auto-remediation pipeline can attribute
+ * changes back to specific files for the comparison report.
+ *
+ * Fixes shipped:
+ *   - fixDeprecatedTags         → PRH-MARKUP-DEPRECATED-TAG
+ *   - fixInlineStyles           → PRH-MARKUP-INLINE-STYLE
+ *   - fixEpubTypePlacement      → PRH-MARKUP-EPUB-TYPE-MISPLACED
+ *   - addDocAriaRoles           → PRH-ARIA-*-ROLE-MISSING (5 codes)
+ *   - fixBodyPurity             → PRH-BODY-HAS-ARIA
+ *   - fixPagebreakMalformed     → PRH-PAGEBREAK-MALFORMED
+ *
+ * All operate on XHTML files. None mutate the OPF, manifest, or
+ * spine — they're content-only transformations.
+ */
+
+import JSZip from 'jszip';
+import { logger } from '../../../../../lib/logger';
+
+interface ChangeResult {
+  success: boolean;
+  description: string;
+  before?: string;
+  after?: string;
+}
+
+/**
+ * Inline-style files with more than this many style attributes
+ * trigger an operator-defer rather than auto-strip. Hits the
+ * sweet spot per the P5 plan (Q3): catches accidental template
+ * bugs (one or two stripped) without auto-erasing legitimate
+ * heavy inline-styling (more often a P6 CSS-extraction concern).
+ */
+const INLINE_STYLE_AUTO_THRESHOLD = 50;
+
+/** Deprecated-tag swap map. `null` means strip the wrapper, keep inner text. */
+const DEPRECATED_TAG_REWRITES: Record<string, string | null> = {
+  b: 'strong',
+  i: 'em',
+  big: null,
+  small: null,
+  font: null,
+  center: null,
+  strike: 'del',
+  // `<u>` is intentionally absent — could be a real semantic
+  // underline ("the *not* in 'not allowed' is underlined"). Skip
+  // and let the operator decide.
+};
+
+/**
+ * <section epub:type="X"> values that PRH forbids. Each maps to
+ * the canonical doc-* role replacement. Per Technical Guide §6.1.
+ */
+const SECTION_EPUB_TYPE_TO_ROLE: Record<string, string> = {
+  chapter: 'doc-chapter',
+  part: 'doc-part',
+  dedication: 'doc-dedication',
+  epigraph: 'doc-epigraph',
+  appendix: 'doc-appendix',
+  prologue: 'doc-prologue',
+  preface: 'doc-preface',
+  acknowledgements: 'doc-acknowledgments',
+  acknowledgments: 'doc-acknowledgments',
+};
+
+// ── fixDeprecatedTags ────────────────────────────────────────────────────
+
+/**
+ * Walk every XHTML file. For each deprecated tag with a known
+ * replacement, swap the opening + closing tag in-place; for tags
+ * marked `null` (strip), remove the wrapper but keep the inner
+ * text content. Self-closing variants are normalised to opening
+ * tags first.
+ *
+ * Idempotent — a file with no deprecated tags is left untouched.
+ */
+export async function fixDeprecatedTags(zip: JSZip): Promise<ChangeResult[]> {
+  const results: ChangeResult[] = [];
+
+  for (const filePath of Object.keys(zip.files)) {
+    if (!/\.x?html?$/i.test(filePath)) continue;
+    const entry = zip.file(filePath);
+    if (!entry) continue;
+    const original = await entry.async('text');
+
+    // Don't mutate <head>; scope to <body>…</body>.
+    const bodyMatch = original.match(/(<body\b[^>]*>)([\s\S]*?)(<\/body>)/i);
+    if (!bodyMatch) continue;
+    const [, bodyOpen, bodyInner, bodyClose] = bodyMatch;
+
+    let mutatedInner = bodyInner;
+    let changeCount = 0;
+
+    for (const [tag, replacement] of Object.entries(DEPRECATED_TAG_REWRITES)) {
+      // Tag-boundary regex — `<b ...>` / `<b>` / `<b/>` but NOT
+      // `<body>` / `<br>` / `<blockquote>`. The lookahead requires
+      // whitespace, `/`, or `>` immediately after the tag name.
+      const openRe = new RegExp(`<${tag}(?=[\\s/>])([^>]*)>`, 'gi');
+      const selfCloseRe = new RegExp(`<${tag}(?=[\\s/])([^>]*)\\/>`, 'gi');
+      const closeRe = new RegExp(`</${tag}\\s*>`, 'gi');
+
+      if (replacement === null) {
+        // Strip path: remove wrappers (open + close), preserve inner.
+        const openCount = (mutatedInner.match(openRe) || []).length;
+        const closeCount = (mutatedInner.match(closeRe) || []).length;
+        const selfClose = (mutatedInner.match(selfCloseRe) || []).length;
+        if (openCount + closeCount + selfClose === 0) continue;
+        mutatedInner = mutatedInner
+          .replace(selfCloseRe, '')
+          .replace(openRe, '')
+          .replace(closeRe, '');
+        changeCount += openCount + selfClose;
+      } else {
+        // Swap path: rewrite tag name on open + close.
+        const openCount = (mutatedInner.match(openRe) || []).length;
+        const closeCount = (mutatedInner.match(closeRe) || []).length;
+        const selfClose = (mutatedInner.match(selfCloseRe) || []).length;
+        if (openCount + closeCount + selfClose === 0) continue;
+        mutatedInner = mutatedInner
+          .replace(selfCloseRe, `<${replacement}$1/>`)
+          .replace(openRe, `<${replacement}$1>`)
+          .replace(closeRe, `</${replacement}>`);
+        changeCount += openCount + selfClose;
+      }
+    }
+
+    if (changeCount === 0) continue;
+
+    const mutatedFull = original.replace(bodyMatch[0], bodyOpen + mutatedInner + bodyClose);
+    zip.file(filePath, mutatedFull);
+    results.push({
+      success: true,
+      description: `Rewrote ${changeCount} deprecated tag(s) in ${filePath}`,
+      before: bodyInner.slice(0, 200),
+      after: mutatedInner.slice(0, 200),
+    });
+  }
+
+  if (results.length === 0) {
+    return [{ success: true, description: 'No deprecated tags found — no changes needed' }];
+  }
+  return results;
+}
+
+// ── fixInlineStyles ──────────────────────────────────────────────────────
+
+/**
+ * Strip `style="…"` attributes from body elements. Files with
+ * more than INLINE_STYLE_AUTO_THRESHOLD inline styles are
+ * deferred to operator review (returned as `success: true` with
+ * a `skipped` description so the operator sees the deferral).
+ *
+ * Anchored on whitespace (not `\b`) per the attribute-regex rule
+ * in feedback_attribute_regex_anchor — prevents false-matching
+ * inside `data-style=` etc.
+ */
+export async function fixInlineStyles(zip: JSZip): Promise<ChangeResult[]> {
+  const results: ChangeResult[] = [];
+  const inlineStyleRe = /(\s)style\s*=\s*["'][^"']*["']/gi;
+
+  for (const filePath of Object.keys(zip.files)) {
+    if (!/\.x?html?$/i.test(filePath)) continue;
+    const entry = zip.file(filePath);
+    if (!entry) continue;
+    const original = await entry.async('text');
+
+    inlineStyleRe.lastIndex = 0;
+    const matches = original.match(inlineStyleRe);
+    if (!matches || matches.length === 0) continue;
+
+    if (matches.length > INLINE_STYLE_AUTO_THRESHOLD) {
+      results.push({
+        success: true,
+        description: `${filePath} has ${matches.length} inline styles — deferred to operator review (auto threshold is ${INLINE_STYLE_AUTO_THRESHOLD})`,
+      });
+      continue;
+    }
+
+    inlineStyleRe.lastIndex = 0;
+    const mutated = original.replace(inlineStyleRe, '');
+    zip.file(filePath, mutated);
+    results.push({
+      success: true,
+      description: `Stripped ${matches.length} inline style attribute(s) from ${filePath}`,
+    });
+  }
+
+  if (results.length === 0) {
+    return [{ success: true, description: 'No inline styles found — no changes needed' }];
+  }
+  return results;
+}
+
+// ── fixEpubTypePlacement ────────────────────────────────────────────────
+
+/**
+ * Swap forbidden `<section epub:type="chapter">` style markup
+ * to `<section role="doc-chapter">`, dropping the epub:type
+ * attribute. Idempotent — sections already carrying the role get
+ * the duplicate `epub:type` stripped but `role` is preserved.
+ *
+ * Only handles the forbidden `<section>` values per PRH spec.
+ * `<body epub:type="…">` is left alone (PRH allows the 4
+ * transition types there).
+ */
+export async function fixEpubTypePlacement(zip: JSZip): Promise<ChangeResult[]> {
+  const results: ChangeResult[] = [];
+
+  for (const filePath of Object.keys(zip.files)) {
+    if (!/\.x?html?$/i.test(filePath)) continue;
+    const entry = zip.file(filePath);
+    if (!entry) continue;
+    const original = await entry.async('text');
+
+    let mutated = original;
+    let swapCount = 0;
+
+    // Match every <section …epub:type="X" …> opening tag. Iterate
+    // the matches; for each forbidden X, rewrite the attributes
+    // (strip epub:type, add role if absent).
+    const sectionRe = /<section\b([^>]*?)>/gi;
+    mutated = mutated.replace(sectionRe, (match, attrs) => {
+      const epubTypeMatch = attrs.match(/(\s)epub:type\s*=\s*["']([^"']+)["']/i);
+      if (!epubTypeMatch) return match;
+      const tokens = epubTypeMatch[2].split(/\s+/).map((t: string) => t.toLowerCase());
+      const forbidden = tokens.find((t: string) => SECTION_EPUB_TYPE_TO_ROLE[t]);
+      if (!forbidden) return match;
+
+      const docRole = SECTION_EPUB_TYPE_TO_ROLE[forbidden];
+
+      // Strip the epub:type attribute entirely. We don't try to
+      // preserve other tokens — PRH's rule is "no epub:type on
+      // these sections", full stop.
+      let newAttrs = attrs.replace(/(\s)epub:type\s*=\s*["'][^"']*["']/i, '');
+
+      // Add role="doc-*" when no role attribute is present;
+      // otherwise leave the existing role alone (operator may
+      // have already set the correct value).
+      if (!/(?:^|\s)role\s*=/i.test(newAttrs)) {
+        newAttrs = `${newAttrs.trimEnd()} role="${docRole}"`;
+      }
+      swapCount += 1;
+      return `<section${newAttrs}>`;
+    });
+
+    if (swapCount === 0) continue;
+
+    zip.file(filePath, mutated);
+    results.push({
+      success: true,
+      description: `Swapped ${swapCount} forbidden section epub:type value(s) to role attribute(s) in ${filePath}`,
+    });
+  }
+
+  if (results.length === 0) {
+    return [{ success: true, description: 'No misplaced epub:type values found — no changes needed' }];
+  }
+  return results;
+}
+
+// ── addDocAriaRoles ──────────────────────────────────────────────────────
+
+/**
+ * Insert `role="doc-*"` on the first matching section per
+ * filename-driven heuristic. Same logic as the validator but
+ * mutating instead of detecting. Adds the role; leaves any
+ * existing attributes alone.
+ */
+export async function addDocAriaRoles(zip: JSZip): Promise<ChangeResult[]> {
+  const results: ChangeResult[] = [];
+
+  const SECTION_RULES: Array<{
+    pathPattern: RegExp;
+    docRole: string;
+    element: 'section' | 'blockquote';
+  }> = [
+    { pathPattern: /(?:^|\/)(?:chapter|chap)[_-]?\d*\.x?html?$/i, docRole: 'doc-chapter', element: 'section' },
+    { pathPattern: /(?:^|\/)part[_-]?\d*\.x?html?$/i, docRole: 'doc-part', element: 'section' },
+    { pathPattern: /(?:^|\/)dedication\.x?html?$/i, docRole: 'doc-dedication', element: 'section' },
+    { pathPattern: /(?:^|\/)epigraph\.x?html?$/i, docRole: 'doc-epigraph', element: 'blockquote' },
+    { pathPattern: /(?:^|\/)appendix[_-]?\d*\.x?html?$/i, docRole: 'doc-appendix', element: 'section' },
+  ];
+
+  for (const rule of SECTION_RULES) {
+    // First-only per the validator's FIRST-ONLY rule.
+    const candidatePath = Object.keys(zip.files).find((p) => rule.pathPattern.test(p));
+    if (!candidatePath) continue;
+    const entry = zip.file(candidatePath);
+    if (!entry) continue;
+    const original = await entry.async('text');
+
+    // Locate the first matching element opening tag.
+    const openRe = new RegExp(`<${rule.element}\\b([^>]*)>`, 'i');
+    const m = original.match(openRe);
+    if (!m) continue;
+
+    const existingRole = m[1].match(/(?:^|\s)role\s*=\s*["']([^"']+)["']/i);
+    if (existingRole) {
+      // Role already set — leave it alone, even if it isn't doc-*.
+      // Operator may have a reason; validator will re-flag if so.
+      continue;
+    }
+
+    const updatedTag = `<${rule.element}${m[1].trimEnd()} role="${rule.docRole}">`;
+    const mutated = original.replace(m[0], updatedTag);
+    zip.file(candidatePath, mutated);
+    results.push({
+      success: true,
+      description: `Added role="${rule.docRole}" to first <${rule.element}> in ${candidatePath}`,
+    });
+  }
+
+  if (results.length === 0) {
+    return [{ success: true, description: 'No matching first-of-type sections needed doc-* roles — no changes needed' }];
+  }
+  return results;
+}
+
+// ── fixBodyPurity ────────────────────────────────────────────────────────
+
+/**
+ * Strip `role`, `aria-label`, and `aria-labelledby` from every
+ * `<body>` element. PRH explicitly prohibits ARIA on body. Same
+ * whitespace-anchor regex as the validator.
+ */
+export async function fixBodyPurity(zip: JSZip): Promise<ChangeResult[]> {
+  const results: ChangeResult[] = [];
+  const BANNED = ['role', 'aria-label', 'aria-labelledby'] as const;
+
+  for (const filePath of Object.keys(zip.files)) {
+    if (!/\.x?html?$/i.test(filePath)) continue;
+    const entry = zip.file(filePath);
+    if (!entry) continue;
+    const original = await entry.async('text');
+
+    const bodyOpenMatch = original.match(/<body\b([^>]*)>/i);
+    if (!bodyOpenMatch) continue;
+
+    let attrs = bodyOpenMatch[1];
+    const offenders: string[] = [];
+    for (const attr of BANNED) {
+      const re = new RegExp(`(\\s)${attr}\\s*=\\s*["'][^"']*["']`, 'i');
+      if (re.test(attrs)) {
+        offenders.push(attr);
+        attrs = attrs.replace(re, '');
+      }
+    }
+    if (offenders.length === 0) continue;
+
+    const mutated = original.replace(bodyOpenMatch[0], `<body${attrs}>`);
+    zip.file(filePath, mutated);
+    results.push({
+      success: true,
+      description: `Stripped ${offenders.join(' / ')} from <body> in ${filePath}`,
+    });
+  }
+
+  if (results.length === 0) {
+    return [{ success: true, description: 'No <body> ARIA attributes found — no changes needed' }];
+  }
+  return results;
+}
+
+// ── fixPagebreakMalformed ────────────────────────────────────────────────
+
+/**
+ * Repair `<span epub:type="pagebreak">` elements:
+ *   - Ensure `role="doc-pagebreak"` is set (add when absent or
+ *     when role doesn't include the doc-pagebreak token).
+ *   - Rewrite `aria-label` to a bare digit string when it currently
+ *     carries "page 12" / "pg 12" / "page12" prefixes. Leave bare
+ *     digit / roman-numeral text aria-labels alone; the validator
+ *     surfaces those separately for operator review.
+ */
+export async function fixPagebreakMalformed(zip: JSZip): Promise<ChangeResult[]> {
+  const results: ChangeResult[] = [];
+
+  for (const filePath of Object.keys(zip.files)) {
+    if (!/\.x?html?$/i.test(filePath)) continue;
+    const entry = zip.file(filePath);
+    if (!entry) continue;
+    const original = await entry.async('text');
+
+    let mutated = original;
+    let repairCount = 0;
+
+    const tagRe = /<span\b([^>]*(?:^|\s)epub:type\s*=\s*["'][^"']*\bpagebreak\b[^"']*["'][^>]*)(\s*\/?\s*)>/gi;
+    mutated = mutated.replace(tagRe, (match, attrs, trailing) => {
+      let newAttrs = attrs;
+      let mutatedHere = false;
+
+      // 1. role attribute
+      const roleMatch = newAttrs.match(/(?:^|\s)role\s*=\s*["']([^"']+)["']/i);
+      const hasDocPagebreakRole =
+        !!roleMatch && roleMatch[1].split(/\s+/).map((t: string) => t.toLowerCase()).includes('doc-pagebreak');
+      if (!hasDocPagebreakRole) {
+        if (roleMatch) {
+          // Append doc-pagebreak to the existing role tokens.
+          newAttrs = newAttrs.replace(
+            /((?:^|\s)role\s*=\s*["'])([^"']+)(["'])/i,
+            (_m: string, prefix: string, tokens: string, suffix: string) => `${prefix}${tokens} doc-pagebreak${suffix}`,
+          );
+        } else {
+          newAttrs = `${newAttrs.trimEnd()} role="doc-pagebreak"`;
+        }
+        mutatedHere = true;
+      }
+
+      // 2. aria-label — rewrite "page 12" → "12", "pg 12" → "12".
+      const labelMatch = newAttrs.match(/(\s)aria-label\s*=\s*["']([^"']*)["']/i);
+      if (labelMatch) {
+        const labelValue = labelMatch[2];
+        const digitsOnly = labelValue.match(/\b(\d+)\b/);
+        if (digitsOnly && /^(?:page|pg)\s*\d+/i.test(labelValue.trim())) {
+          newAttrs = newAttrs.replace(
+            /(\s)aria-label\s*=\s*["'][^"']*["']/i,
+            `$1aria-label="${digitsOnly[1]}"`,
+          );
+          mutatedHere = true;
+        }
+      }
+
+      if (!mutatedHere) return match;
+      repairCount += 1;
+      return `<span${newAttrs}${trailing}>`;
+    });
+
+    if (repairCount === 0) continue;
+
+    zip.file(filePath, mutated);
+    results.push({
+      success: true,
+      description: `Repaired ${repairCount} pagebreak span(s) in ${filePath}`,
+    });
+  }
+
+  if (results.length === 0) {
+    return [{ success: true, description: 'No malformed pagebreaks found — no changes needed' }];
+  }
+  return results;
+}
+
+// ── Logger wrapper (intentionally unused export — for future debug hook) ──
+
+void logger;

--- a/tests/unit/services/epub/profiles/prh-uk/remediators/markup-remediator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/remediators/markup-remediator.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import JSZip from 'jszip';
+import {
+  fixDeprecatedTags,
+  fixInlineStyles,
+  fixEpubTypePlacement,
+  addDocAriaRoles,
+  fixBodyPurity,
+  fixPagebreakMalformed,
+} from '../../../../../../../src/services/epub/profiles/prh-uk/remediators/markup-remediator';
+
+async function getFile(zip: JSZip, path: string): Promise<string> {
+  const c = await zip.file(path)?.async('text');
+  if (!c) throw new Error(`File not in zip: ${path}`);
+  return c;
+}
+
+function buildXhtml(bodyInner: string, bodyAttrs: string = ''): string {
+  return `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title></head>
+<body ${bodyAttrs}>${bodyInner}</body>
+</html>`;
+}
+
+describe('fixDeprecatedTags', () => {
+  let zip: JSZip;
+  beforeEach(() => { zip = new JSZip(); });
+
+  it('swaps <b> → <strong>', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p><b>bold text</b></p>'));
+    const result = await fixDeprecatedTags(zip);
+    expect(result[0].success).toBe(true);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toContain('<strong>bold text</strong>');
+    expect(updated).not.toContain('<b>');
+  });
+
+  it('swaps <i> → <em>', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p><i>italic</i></p>'));
+    await fixDeprecatedTags(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toContain('<em>italic</em>');
+  });
+
+  it('strips <big>/<small>/<font>/<center> wrappers keeping inner text', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p><big>X</big> <small>Y</small> <font>Z</font> <center>W</center></p>'));
+    await fixDeprecatedTags(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toContain('X');
+    expect(updated).toContain('Y');
+    expect(updated).toContain('Z');
+    expect(updated).toContain('W');
+    expect(updated).not.toMatch(/<big|<small|<font|<center/);
+  });
+
+  it('does NOT swap <u> (could be a real semantic underline)', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p><u>underlined</u></p>'));
+    const result = await fixDeprecatedTags(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toContain('<u>underlined</u>');
+    expect(result[0].description).toMatch(/no deprecated|No changes needed/i);
+  });
+
+  it('does NOT false-match <body>/<br>/<blockquote> (tag-boundary regression)', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<blockquote>x</blockquote><br/>'));
+    const result = await fixDeprecatedTags(zip);
+    expect(result[0].description).toMatch(/no deprecated/i);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toContain('<blockquote>');
+    expect(updated).toContain('<br/>');
+  });
+
+  it('is idempotent — re-running on clean output produces no further changes', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p><b>x</b></p>'));
+    await fixDeprecatedTags(zip);
+    const result = await fixDeprecatedTags(zip);
+    expect(result[0].description).toMatch(/no deprecated/i);
+  });
+});
+
+describe('fixInlineStyles', () => {
+  let zip: JSZip;
+  beforeEach(() => { zip = new JSZip(); });
+
+  it('strips style="…" attributes from body elements', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p style="color: red">red</p>'));
+    await fixInlineStyles(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).not.toMatch(/style="/);
+    expect(updated).toContain('<p>red</p>');
+  });
+
+  it('defers files with >50 inline styles (auto threshold)', async () => {
+    const bigContent = Array(51).fill('<p style="margin: 1em">x</p>').join('');
+    zip.file('big.xhtml', buildXhtml(bigContent));
+    const result = await fixInlineStyles(zip);
+    expect(result[0].description).toMatch(/deferred to operator review/i);
+    // File NOT mutated — the 51 styles are still there.
+    const after = await getFile(zip, 'big.xhtml');
+    expect((after.match(/style="/g) || []).length).toBe(51);
+  });
+
+  it('does NOT false-match data-style attributes (regex-anchor regression)', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p data-style="x">text</p>'));
+    const result = await fixInlineStyles(zip);
+    expect(result[0].description).toMatch(/no inline styles/i);
+  });
+
+  it('is idempotent', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p style="color: red">x</p>'));
+    await fixInlineStyles(zip);
+    const result = await fixInlineStyles(zip);
+    expect(result[0].description).toMatch(/no inline styles/i);
+  });
+});
+
+describe('fixEpubTypePlacement', () => {
+  let zip: JSZip;
+  beforeEach(() => { zip = new JSZip(); });
+
+  it('swaps <section epub:type="chapter"> to <section role="doc-chapter">', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<section epub:type="chapter"><h1>Ch 1</h1></section>'));
+    await fixEpubTypePlacement(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).not.toMatch(/epub:type\s*=\s*["']chapter/);
+    expect(updated).toMatch(/role="doc-chapter"/);
+  });
+
+  it('swaps all forbidden values (part, dedication, epigraph, appendix)', async () => {
+    zip.file('part.xhtml', buildXhtml('<section epub:type="part">Part 1</section>'));
+    zip.file('dedication.xhtml', buildXhtml('<section epub:type="dedication">To X</section>'));
+    zip.file('epigraph.xhtml', buildXhtml('<section epub:type="epigraph">Q</section>'));
+    zip.file('appendix.xhtml', buildXhtml('<section epub:type="appendix">A1</section>'));
+    await fixEpubTypePlacement(zip);
+    expect(await getFile(zip, 'part.xhtml')).toMatch(/role="doc-part"/);
+    expect(await getFile(zip, 'dedication.xhtml')).toMatch(/role="doc-dedication"/);
+    expect(await getFile(zip, 'epigraph.xhtml')).toMatch(/role="doc-epigraph"/);
+    expect(await getFile(zip, 'appendix.xhtml')).toMatch(/role="doc-appendix"/);
+  });
+
+  it('preserves an existing role attribute (doesn\'t double-set)', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<section role="doc-chapter region" epub:type="chapter">x</section>'));
+    await fixEpubTypePlacement(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    // Existing role preserved; epub:type stripped.
+    expect(updated).toMatch(/role="doc-chapter region"/);
+    expect(updated).not.toMatch(/epub:type/);
+  });
+
+  it('leaves <body epub:type="…"> alone (PRH allows it on body)', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p>x</p>', 'epub:type="bodymatter"'));
+    const result = await fixEpubTypePlacement(zip);
+    expect(result[0].description).toMatch(/no misplaced/i);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toMatch(/<body[^>]*epub:type="bodymatter"/);
+  });
+
+  it('is idempotent', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<section epub:type="chapter">x</section>'));
+    await fixEpubTypePlacement(zip);
+    const result = await fixEpubTypePlacement(zip);
+    expect(result[0].description).toMatch(/no misplaced/i);
+  });
+});
+
+describe('addDocAriaRoles', () => {
+  let zip: JSZip;
+  beforeEach(() => { zip = new JSZip(); });
+
+  it('adds role="doc-chapter" to first chapter section when missing', async () => {
+    zip.file('chapter1.xhtml', buildXhtml('<section><h1>C1</h1></section>'));
+    await addDocAriaRoles(zip);
+    const updated = await getFile(zip, 'chapter1.xhtml');
+    expect(updated).toMatch(/<section[^>]*role="doc-chapter"/);
+  });
+
+  it('adds role="doc-epigraph" to first <blockquote> in epigraph.xhtml', async () => {
+    zip.file('epigraph.xhtml', buildXhtml('<blockquote>"Quote"</blockquote>'));
+    await addDocAriaRoles(zip);
+    const updated = await getFile(zip, 'epigraph.xhtml');
+    expect(updated).toMatch(/<blockquote[^>]*role="doc-epigraph"/);
+  });
+
+  it('does NOT touch a section that already has a role attribute', async () => {
+    zip.file('chapter1.xhtml', buildXhtml('<section role="doc-chapter region"><h1>C1</h1></section>'));
+    await addDocAriaRoles(zip);
+    const updated = await getFile(zip, 'chapter1.xhtml');
+    // Existing role preserved verbatim.
+    expect(updated).toMatch(/role="doc-chapter region"/);
+    expect((updated.match(/role=/g) || []).length).toBe(1);
+  });
+
+  it('is idempotent — second run on patched output is a no-op', async () => {
+    zip.file('chapter1.xhtml', buildXhtml('<section><h1>C1</h1></section>'));
+    await addDocAriaRoles(zip);
+    const result = await addDocAriaRoles(zip);
+    expect(result[0].description).toMatch(/no matching|no changes needed/i);
+  });
+});
+
+describe('fixBodyPurity', () => {
+  let zip: JSZip;
+  beforeEach(() => { zip = new JSZip(); });
+
+  it('strips role from <body>', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p>x</p>', 'role="main"'));
+    await fixBodyPurity(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).not.toMatch(/<body[^>]*\srole=/);
+  });
+
+  it('strips multiple banned attributes at once', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p>x</p>', 'role="main" aria-label="Chapter" aria-labelledby="title"'));
+    await fixBodyPurity(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).not.toMatch(/<body[^>]*role=/);
+    expect(updated).not.toMatch(/<body[^>]*aria-label=/);
+    expect(updated).not.toMatch(/<body[^>]*aria-labelledby=/);
+  });
+
+  it('preserves non-banned attributes (epub:type stays)', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p>x</p>', 'epub:type="bodymatter" role="main"'));
+    await fixBodyPurity(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toMatch(/<body[^>]*epub:type="bodymatter"/);
+    expect(updated).not.toMatch(/<body[^>]*role=/);
+  });
+
+  it('does NOT false-match data-role on body (anchor regression)', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p>x</p>', 'data-role="container" epub:type="bodymatter"'));
+    const result = await fixBodyPurity(zip);
+    expect(result[0].description).toMatch(/no <body> ARIA/i);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toMatch(/data-role="container"/);
+  });
+
+  it('is idempotent', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<p>x</p>', 'role="main"'));
+    await fixBodyPurity(zip);
+    const result = await fixBodyPurity(zip);
+    expect(result[0].description).toMatch(/no <body> ARIA/i);
+  });
+});
+
+describe('fixPagebreakMalformed', () => {
+  let zip: JSZip;
+  beforeEach(() => { zip = new JSZip(); });
+
+  it('adds role="doc-pagebreak" when missing', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<span epub:type="pagebreak" aria-label="12"/>'));
+    await fixPagebreakMalformed(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toMatch(/role="doc-pagebreak"/);
+  });
+
+  it('appends doc-pagebreak to existing role attribute', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<span epub:type="pagebreak" role="region" aria-label="12"/>'));
+    await fixPagebreakMalformed(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toMatch(/role="region doc-pagebreak"/);
+  });
+
+  it('rewrites aria-label="page 12" → aria-label="12"', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<span epub:type="pagebreak" role="doc-pagebreak" aria-label="page 12"/>'));
+    await fixPagebreakMalformed(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toMatch(/aria-label="12"/);
+    expect(updated).not.toMatch(/aria-label="page 12"/);
+  });
+
+  it('leaves a correctly-shaped pagebreak alone', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<span epub:type="pagebreak" role="doc-pagebreak" aria-label="42"/>'));
+    const result = await fixPagebreakMalformed(zip);
+    expect(result[0].description).toMatch(/no malformed/i);
+  });
+
+  it('is idempotent on patched output', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<span epub:type="pagebreak" aria-label="page 1"/>'));
+    await fixPagebreakMalformed(zip);
+    const result = await fixPagebreakMalformed(zip);
+    expect(result[0].description).toMatch(/no malformed/i);
+  });
+
+  it('does NOT touch spans without epub:type="pagebreak"', async () => {
+    zip.file('ch1.xhtml', buildXhtml('<span>plain text</span>'));
+    const result = await fixPagebreakMalformed(zip);
+    expect(result[0].description).toMatch(/no malformed/i);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/remediators/markup-remediator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/remediators/markup-remediator.test.ts
@@ -113,6 +113,35 @@ describe('fixInlineStyles', () => {
     const result = await fixInlineStyles(zip);
     expect(result[0].description).toMatch(/no inline styles/i);
   });
+
+  it('handles style attribute with inner single quotes (regression)', async () => {
+    // Quote-agnostic regex would have stopped at the inner `'` and
+    // left `Times New Roman'"` orphaned in the markup. The
+    // backreference pattern requires the closing quote to match the
+    // opening quote, so the full attribute value is consumed.
+    zip.file('ch1.xhtml', buildXhtml(`<p style="font-family: 'Times New Roman'">x</p>`));
+    await fixInlineStyles(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toContain('<p>x</p>');
+    expect(updated).not.toMatch(/style=/);
+    expect(updated).not.toContain("Times New Roman");
+  });
+
+  it('handles single-quoted style with inner double quotes', async () => {
+    zip.file('ch1.xhtml', buildXhtml(`<p style='font-family: "Helvetica Neue"'>y</p>`));
+    await fixInlineStyles(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).toContain('<p>y</p>');
+    expect(updated).not.toMatch(/style=/);
+  });
+
+  it('marks deferred files as success: false so the pipeline does not count them as fixed (regression)', async () => {
+    const bigContent = Array(60).fill('<p style="margin: 1em">x</p>').join('');
+    zip.file('big.xhtml', buildXhtml(bigContent));
+    const result = await fixInlineStyles(zip);
+    expect(result[0].success).toBe(false);
+    expect(result[0].description).toMatch(/deferred to operator review/i);
+  });
 });
 
 describe('fixEpubTypePlacement', () => {
@@ -240,6 +269,17 @@ describe('fixBodyPurity', () => {
     await fixBodyPurity(zip);
     const result = await fixBodyPurity(zip);
     expect(result[0].description).toMatch(/no <body> ARIA/i);
+  });
+
+  it('handles aria-label with inner apostrophe (regression)', async () => {
+    // Quote-agnostic strip would have stopped at the inner `'` and
+    // left `s start"` orphaned in the markup, breaking subsequent
+    // attributes. Backreference pattern handles it correctly.
+    zip.file('ch1.xhtml', buildXhtml('<p>x</p>', `aria-label="Chapter's start" epub:type="bodymatter"`));
+    await fixBodyPurity(zip);
+    const updated = await getFile(zip, 'ch1.xhtml');
+    expect(updated).not.toMatch(/aria-label/);
+    expect(updated).toMatch(/<body[^>]*epub:type="bodymatter"/);
   });
 });
 


### PR DESCRIPTION
## Summary

Wires P3 detect-only codes into the existing auto-remediation pipeline. Each fix is idempotent and conservative — high-FP cases defer to operator review.

## 10 codes promoted to auto-fixable

| Code | Fix |
|---|---|
| `PRH-MARKUP-DEPRECATED-TAG` | `<b>`→`<strong>`, `<i>`→`<em>`, `<strike>`→`<del>`; strip `<big>`/`<small>`/`<font>`/`<center>` wrappers keeping inner text. `<u>` intentionally skipped. |
| `PRH-MARKUP-INLINE-STYLE` | Strip `style="…"`. Defers files with >50 attrs (Q3 plan threshold). |
| `PRH-MARKUP-EPUB-TYPE-MISPLACED` | Swap `<section epub:type="chapter">` → `<section role="doc-chapter">` (8 forbidden values). |
| `PRH-ARIA-CHAPTER-ROLE-MISSING` + Part / Dedication / Epigraph / Appendix | Insert `role="doc-*"` on first matching section per filename. |
| `PRH-BODY-HAS-ARIA` | Strip `role`/`aria-label`/`aria-labelledby` from `<body>`. |
| `PRH-PAGEBREAK-MALFORMED` | Repair role + rewrite aria-label `"page 12"` → `"12"`. |

## Q3 plan answer baked in

Inline-style auto-strip threshold: **50 per file**. Files above the threshold defer to operator review (mutation skipped, result reports the deferral). Catches accidental template bugs without auto-erasing legitimate heavy inline styling.

## Concern investigated and dismissed

The P3 plan flagged that `addAriaLandmarks` could "chase" `PRH-BODY-HAS-ARIA` if it wrote `role="main"` onto `<body>`. Confirmed not an issue — the existing remediator wraps body content in `<main role="main">` rather than setting role on body directly. No guard needed.

## Test plan

- [x] 1508/1508 unit tests passing (30 new for the 6 markup fixes)
- [x] Each fix has happy-path + idempotency tests
- [x] Regex-anchor regression tests inherited from the validators (e.g. `data-style` doesn't false-match)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke: run auto-remediation on a PRH job → re-audit shows the 10 codes cleared

## P5 progress

| PR | Scope | Status |
|---|---|---|
| #382 | PR0: workflow-contracts enum reconciliation | merged |
| #383 | PR1: Boilerplate injector | merged |
| #384 | PR2: Copyright-page scaffolder | merged |
| **THIS** | **PR3: Auto-fix bundle** | **open** |
| — | PR4: Deliverable export + conformance report | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded auto-remediation for PRH UK EPUBs: auto-fixable handling for deprecated markup, inline styles (with review threshold), mis‑placed EPUB type, missing document ARIA roles, banned body ARIA attributes, and malformed page-break markup. These fixes are now available as part of the remediation toolset.

* **Tests**
  * Added comprehensive unit tests covering transformations, idempotency, thresholds, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/385)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->