### PR TITLE
feat(prh): deliverable export + conformance report + preflight (P5/PR4) — closes P5

### DIFF
--- a/src/controllers/epub.controller.ts
+++ b/src/controllers/epub.controller.ts
@@ -1686,6 +1686,11 @@ export const epubController = {
       const includeOriginal = req.query.includeOriginal === 'true';
       const includeComparison = req.query.includeComparison === 'true';
       const includeReport = req.query.includeReport === 'true';
+      // PRH conformance bundling defaults to true (soft on-by-default
+      // for any export — service skips silently on non-PRH jobs).
+      // FE can opt out with ?includePrhConformance=false on the rare
+      // case it doesn't want the extra files.
+      const includePrhConformance = req.query.includePrhConformance !== 'false';
 
       if (!tenantId) {
         return res.status(401).json({
@@ -1698,6 +1703,7 @@ export const epubController = {
         includeOriginal,
         includeComparison,
         includeReport,
+        includePrhConformance,
       });
 
       res.setHeader('Content-Type', result.mimeType);
@@ -1710,6 +1716,40 @@ export const epubController = {
       return res.status(500).json({
         success: false,
         error: error instanceof Error ? error.message : 'Failed to export',
+      });
+    }
+  },
+
+  /**
+   * Preflight check used by the FE before triggering an export.
+   * Returns whether the job has outstanding P1/P2 PRH issues that
+   * the operator should confirm before delivery. Non-PRH jobs
+   * return { applicable: false } so the FE can hide the PRH UI.
+   *
+   * Soft warning, not a hard block — the FE renders a confirmation
+   * dialog listing outstanding issues; operator can override and
+   * proceed to export.
+   */
+  async getPrhExportPreflight(req: AuthenticatedRequest, res: Response) {
+    try {
+      const { jobId } = req.params;
+      const tenantId = req.user?.tenantId;
+      if (!tenantId) {
+        return res.status(401).json({ success: false, error: 'Authentication required' });
+      }
+      // Defence-in-depth: verify the job belongs to this tenant.
+      const job = await prisma.job.findFirst({ where: { id: jobId, tenantId }, select: { id: true } });
+      if (!job) {
+        return res.status(404).json({ success: false, error: 'Job not found' });
+      }
+
+      const preflight = await epubExportService.getPrhConformancePreflight(jobId);
+      return res.json({ success: true, data: preflight });
+    } catch (error) {
+      logger.error('PRH export preflight failed', error instanceof Error ? error : undefined);
+      return res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Preflight check failed',
       });
     }
   },

--- a/src/routes/epub.routes.ts
+++ b/src/routes/epub.routes.ts
@@ -63,6 +63,7 @@ router.post('/batch/:batchId/retry/:jobId', authenticate, epubController.retryBa
 router.get('/batches', authenticate, epubController.listBatches);
 
 router.get('/job/:jobId/export', authenticate, authorizeJob, epubController.exportRemediated);
+router.get('/job/:jobId/export/prh-preflight', authenticate, authorizeJob, epubController.getPrhExportPreflight);
 router.post('/export-batch', authenticate, epubController.exportBatch);
 router.get('/job/:jobId/report', authenticate, authorizeJob, epubController.getAccessibilityReport);
 router.get('/job/:jobId/content', authenticate, authorizeJob, epubContentController.getContent);

--- a/src/routes/epub.routes.ts
+++ b/src/routes/epub.routes.ts
@@ -62,8 +62,10 @@ router.post('/batch/:batchId/cancel', authenticate, epubController.cancelBatch);
 router.post('/batch/:batchId/retry/:jobId', authenticate, epubController.retryBatchJob);
 router.get('/batches', authenticate, epubController.listBatches);
 
-router.get('/job/:jobId/export', authenticate, authorizeJob, epubController.exportRemediated);
+// Static / longer-prefix routes BEFORE parameterized routes to
+// prevent route shadowing (per the routes convention).
 router.get('/job/:jobId/export/prh-preflight', authenticate, authorizeJob, epubController.getPrhExportPreflight);
+router.get('/job/:jobId/export', authenticate, authorizeJob, epubController.exportRemediated);
 router.post('/export-batch', authenticate, epubController.exportBatch);
 router.get('/job/:jobId/report', authenticate, authorizeJob, epubController.getAccessibilityReport);
 router.get('/job/:jobId/content', authenticate, authorizeJob, epubContentController.getContent);

--- a/src/services/acr/prh-conformance-report.service.ts
+++ b/src/services/acr/prh-conformance-report.service.ts
@@ -1,0 +1,307 @@
+/**
+ * PRH UK conformance report (P5/PR4).
+ *
+ * Produces a structured "is this EPUB ready for PRH delivery?"
+ * report from the persisted audit result. Classifies outstanding
+ * PRH-* issues by priority tier (P1 — metadata/spine/nav, P2 —
+ * boilerplate/copyright/brand/title/socials/order, P3 — markup
+ * conventions + text-pattern heuristics) and reports per-tier
+ * pass/fail counts so operators can make an informed export
+ * decision.
+ *
+ * Two outputs:
+ *   - `generatePrhConformanceReport(jobId)` returns the JSON
+ *     structure (typed). Used by the export-bundle path and by
+ *     the preflight endpoint.
+ *   - `renderHtml(report)` returns a human-readable HTML version
+ *     bundled alongside the JSON in the export zip.
+ *
+ * Skips entirely on non-PRH jobs — throws a descriptive error
+ * the caller translates to a 400 / "not applicable" response.
+ */
+
+import prisma from '../../lib/prisma';
+
+export type PriorityTier = 'P1' | 'P2' | 'P3' | 'P4';
+
+export interface PrhConformanceIssue {
+  code: string;
+  severity: 'critical' | 'serious' | 'moderate' | 'minor';
+  message: string;
+  location: string;
+  priorityTier: PriorityTier;
+}
+
+export interface PrhConformancePriorityStatus {
+  tier: PriorityTier;
+  passed: number;
+  failed: number;
+  outstanding: PrhConformanceIssue[];
+}
+
+export interface PrhConformanceReport {
+  jobId: string;
+  fileName: string | null;
+  bookTitle: string | null;
+  publisherProfile: {
+    publisher: 'PRH-UK';
+    imprint: string | null;
+    confidence: 'medium' | 'high';
+  };
+  auditedAt: string;
+  /** Per-priority tier breakdown for at-a-glance status. */
+  priorityStatus: PrhConformancePriorityStatus[];
+  /** All outstanding PRH-* issues, flat list. */
+  outstandingIssues: PrhConformanceIssue[];
+  conformsTo: 'EPUB Accessibility 1.1 - WCAG 2.2 Level AA';
+  certifier: {
+    name: 'Penguin Random House UK';
+    credential: 'Ace by DAISY OK';
+    /** Public accessibility-statement URL, embedded in the VPAT too. */
+    publicUrl: 'https://www.penguin.co.uk/accessibility';
+  };
+  /**
+   * True when ALL P1 + P2 issues are resolved. P3 + P4 are
+   * advisory — the export doesn't block on them. When false, the
+   * UI surfaces a "requires operator confirmation" prompt before
+   * the export proceeds.
+   */
+  readyForDelivery: boolean;
+}
+
+/**
+ * Build the conformance report. Throws when the job isn't a
+ * PRH-UK build OR doesn't have an audit result yet — the caller
+ * (controller, exporter) catches these and returns 400 / "not
+ * applicable".
+ */
+export async function generatePrhConformanceReport(jobId: string): Promise<PrhConformanceReport> {
+  const job = await prisma.job.findUnique({
+    where: { id: jobId },
+    select: { id: true, output: true, input: true },
+  });
+  if (!job) throw new Error(`Job ${jobId} not found`);
+  if (!job.output) throw new Error(`Job ${jobId} has no audit output — run an audit first`);
+
+  const output = job.output as Record<string, unknown>;
+  const profile = (output.publisherProfile && typeof output.publisherProfile === 'object')
+    ? (output.publisherProfile as Record<string, unknown>)
+    : null;
+
+  if (!profile || profile.publisher !== 'PRH-UK') {
+    throw new Error('PRH conformance report only available on PRH-UK jobs');
+  }
+  if (profile.confidence !== 'medium' && profile.confidence !== 'high') {
+    throw new Error('PRH conformance report requires medium-or-high publisher-profile confidence');
+  }
+
+  const fileName = readJobInputFileName(job.input);
+  const bookTitle = typeof output.bookTitle === 'string' ? output.bookTitle : null;
+  const auditedAt = typeof output.auditedAt === 'string' ? output.auditedAt : new Date().toISOString();
+
+  // Walk combinedIssues, classify each PRH-* code by priority tier.
+  const issues = Array.isArray(output.combinedIssues) ? output.combinedIssues : [];
+  const outstandingIssues: PrhConformanceIssue[] = [];
+  for (const raw of issues) {
+    if (typeof raw !== 'object' || raw === null) continue;
+    const issue = raw as Record<string, unknown>;
+    const code = typeof issue.code === 'string' ? issue.code : null;
+    if (!code || !code.startsWith('PRH-')) continue;
+    const tier = priorityTierForCode(code);
+    if (!tier) continue;
+    outstandingIssues.push({
+      code,
+      severity: (typeof issue.severity === 'string' ? issue.severity : 'minor') as PrhConformanceIssue['severity'],
+      message: typeof issue.message === 'string' ? issue.message : code,
+      location: typeof issue.location === 'string' ? issue.location : 'EPUB',
+      priorityTier: tier,
+    });
+  }
+
+  const priorityStatus = (['P1', 'P2', 'P3', 'P4'] as const).map((tier) => {
+    const outstanding = outstandingIssues.filter((i) => i.priorityTier === tier);
+    return {
+      tier,
+      passed: TIER_CODE_COUNT[tier] - outstanding.length,
+      failed: outstanding.length,
+      outstanding,
+    };
+  });
+
+  const p1p2Outstanding = outstandingIssues.filter((i) => i.priorityTier === 'P1' || i.priorityTier === 'P2');
+  const readyForDelivery = p1p2Outstanding.length === 0;
+
+  return {
+    jobId,
+    fileName,
+    bookTitle,
+    publisherProfile: {
+      publisher: 'PRH-UK',
+      imprint: typeof profile.imprint === 'string' ? profile.imprint : null,
+      confidence: profile.confidence as 'medium' | 'high',
+    },
+    auditedAt,
+    priorityStatus,
+    outstandingIssues,
+    conformsTo: 'EPUB Accessibility 1.1 - WCAG 2.2 Level AA',
+    certifier: {
+      name: 'Penguin Random House UK',
+      credential: 'Ace by DAISY OK',
+      publicUrl: 'https://www.penguin.co.uk/accessibility',
+    },
+    readyForDelivery,
+  };
+}
+
+/**
+ * Render the report as a standalone HTML document — bundled
+ * alongside the JSON in the export zip so operators can open the
+ * report in a browser without tooling.
+ */
+export function renderHtml(report: PrhConformanceReport): string {
+  const escape = (s: string): string =>
+    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+  const tierRows = report.priorityStatus
+    .map((tier) => `
+      <tr>
+        <td>${tier.tier}</td>
+        <td>${tier.passed}</td>
+        <td>${tier.failed}</td>
+        <td>${tier.failed === 0 ? '✓ Pass' : '✗ Outstanding'}</td>
+      </tr>`)
+    .join('');
+
+  const issueRows = report.outstandingIssues
+    .map((issue) => `
+      <tr>
+        <td>${escape(issue.code)}</td>
+        <td>${escape(issue.priorityTier)}</td>
+        <td>${escape(issue.severity)}</td>
+        <td>${escape(issue.location)}</td>
+        <td>${escape(issue.message)}</td>
+      </tr>`)
+    .join('');
+
+  const verdictBanner = report.readyForDelivery
+    ? `<div style="background:#d4edda;color:#155724;padding:12px;border-radius:4px;margin:16px 0;">✓ Ready for PRH delivery — all P1 + P2 issues resolved.</div>`
+    : `<div style="background:#f8d7da;color:#721c24;padding:12px;border-radius:4px;margin:16px 0;">✗ NOT ready for delivery — ${report.priorityStatus.filter((t) => (t.tier === 'P1' || t.tier === 'P2') && t.failed > 0).reduce((sum, t) => sum + t.failed, 0)} P1/P2 issue(s) outstanding.</div>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>PRH UK Conformance Report — ${escape(report.bookTitle ?? report.fileName ?? report.jobId)}</title>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; max-width: 960px; margin: 2em auto; padding: 0 1em; color: #222; }
+  h1 { border-bottom: 2px solid #888; padding-bottom: 0.3em; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+  th, td { text-align: left; padding: 8px 12px; border-bottom: 1px solid #ddd; vertical-align: top; }
+  th { background: #f4f4f4; }
+  dl { display: grid; grid-template-columns: max-content 1fr; gap: 4px 16px; }
+  dt { font-weight: 600; }
+  .meta { background: #f9f9f9; padding: 16px; border-radius: 4px; }
+</style>
+</head>
+<body>
+<h1>PRH UK Conformance Report</h1>
+${verdictBanner}
+<div class="meta">
+<dl>
+  <dt>Job ID</dt><dd>${escape(report.jobId)}</dd>
+  <dt>Book title</dt><dd>${escape(report.bookTitle ?? '(not in OPF dc:title)')}</dd>
+  <dt>File</dt><dd>${escape(report.fileName ?? '(unknown)')}</dd>
+  <dt>Publisher</dt><dd>${escape(report.publisherProfile.publisher)} / ${escape(report.publisherProfile.imprint ?? 'unknown imprint')} (${escape(report.publisherProfile.confidence)} confidence)</dd>
+  <dt>Audited at</dt><dd>${escape(report.auditedAt)}</dd>
+  <dt>Conforms to</dt><dd>${escape(report.conformsTo)}</dd>
+  <dt>Certifier</dt><dd>${escape(report.certifier.name)} — ${escape(report.certifier.credential)}</dd>
+  <dt>Accessibility statement</dt><dd><a href="${escape(report.certifier.publicUrl)}">${escape(report.certifier.publicUrl)}</a></dd>
+</dl>
+</div>
+
+<h2>Status by Priority Tier</h2>
+<table>
+<thead><tr><th>Tier</th><th>Passed</th><th>Failed</th><th>Status</th></tr></thead>
+<tbody>${tierRows}</tbody>
+</table>
+
+<h2>Outstanding Issues (${report.outstandingIssues.length})</h2>
+${report.outstandingIssues.length === 0
+  ? '<p>No outstanding PRH issues — all checks pass.</p>'
+  : `<table>
+      <thead><tr><th>Code</th><th>Tier</th><th>Severity</th><th>Location</th><th>Message</th></tr></thead>
+      <tbody>${issueRows}</tbody>
+    </table>`}
+
+<p style="color:#666;font-size:0.9em;margin-top:3em;">
+P1 + P2 must pass for delivery readiness. P3 + P4 are advisory.
+Generated by Ninja Accessibility Platform.
+</p>
+</body>
+</html>
+`;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Total count of codes per priority tier in the canonical PRH-*
+ * code registry. Used to compute "passed" counts (total tier
+ * codes minus outstanding). Hard-coded so the report doesn't have
+ * to re-read prh-issue-codes.ts at runtime.
+ */
+const TIER_CODE_COUNT: Record<PriorityTier, number> = {
+  // P1 — metadata (6) + spine (2) + nav (5) + per-XHTML (2) + image (2) = 17
+  P1: 17,
+  // P2 — copyright (8) + brand (3) + title (4) + socials (5) + order (5) = 25
+  P2: 25,
+  // P3 — body epub:type + doc-* ARIA (8) + forbidden (3) + notes/pagebreak (2) + text heuristics (3) = 16
+  P3: 16,
+  // P4 has no PRH-* codes (AI policy gate + cover-alt template were
+  // implemented as behaviors, not new codes). 0 to keep the type happy.
+  P4: 0,
+};
+
+/**
+ * Map every PRH-* code prefix to its priority tier. Anything that
+ * doesn't match returns null — the report ignores codes outside
+ * the PRH validator family even if they happen to start with
+ * `PRH-`.
+ */
+function priorityTierForCode(code: string): PriorityTier | null {
+  // P1
+  if (code.startsWith('PRH-META-')) return 'P1';
+  if (code.startsWith('PRH-SPINE-')) return 'P1';
+  if (code.startsWith('PRH-NAV-')) return 'P1';
+  if (code.startsWith('PRH-XHTML-')) return 'P1';
+  if (code === 'PRH-COVER-ALT-EMPTY') return 'P1';
+  if (code === 'PRH-DECORATIVE-MISSING-PRESENTATION-ROLE') return 'P1';
+
+  // P2
+  if (code.startsWith('PRH-COPY-')) return 'P2';
+  if (code.startsWith('PRH-BRAND-')) return 'P2';
+  if (code.startsWith('PRH-TITLE-')) return 'P2';
+  if (code.startsWith('PRH-SOCIALS-')) return 'P2';
+  if (code.startsWith('PRH-ORDER-')) return 'P2';
+
+  // P3
+  if (code.startsWith('PRH-MARKUP-')) return 'P3';
+  if (code.startsWith('PRH-ARIA-')) return 'P3';
+  if (code === 'PRH-BODY-HAS-ARIA') return 'P3';
+  if (code === 'PRH-PAGEBREAK-MALFORMED') return 'P3';
+  if (code === 'PRH-FOOTNOTE-ID-MISMATCH') return 'P3';
+  if (code === 'PRH-TABLE-LAYOUT-WITHOUT-PRESENTATION') return 'P3';
+  if (code === 'PRH-LANG-INLINE-NOT-MARKED') return 'P3';
+  if (code === 'PRH-HASHTAG-NOT-CAMEL-CASE') return 'P3';
+  if (code === 'PRH-ACRONYM-INSERTED-SEPARATORS') return 'P3';
+
+  return null;
+}
+
+function readJobInputFileName(input: unknown): string | null {
+  if (!input || typeof input !== 'object') return null;
+  const inputObj = input as { originalName?: unknown; fileName?: unknown };
+  if (typeof inputObj.originalName === 'string') return inputObj.originalName;
+  if (typeof inputObj.fileName === 'string') return inputObj.fileName;
+  return null;
+}

--- a/src/services/acr/prh-conformance-report.service.ts
+++ b/src/services/acr/prh-conformance-report.service.ts
@@ -109,9 +109,10 @@ export async function generatePrhConformanceReport(jobId: string): Promise<PrhCo
     if (!code || !code.startsWith('PRH-')) continue;
     const tier = priorityTierForCode(code);
     if (!tier) continue;
+    const rawSeverity = typeof issue.severity === 'string' ? issue.severity : 'minor';
     outstandingIssues.push({
       code,
-      severity: (typeof issue.severity === 'string' ? issue.severity : 'minor') as PrhConformanceIssue['severity'],
+      severity: isValidSeverity(rawSeverity) ? rawSeverity : 'minor',
       message: typeof issue.message === 'string' ? issue.message : code,
       location: typeof issue.location === 'string' ? issue.location : 'EPUB',
       priorityTier: tier,
@@ -120,10 +121,14 @@ export async function generatePrhConformanceReport(jobId: string): Promise<PrhCo
 
   const priorityStatus = (['P1', 'P2', 'P3', 'P4'] as const).map((tier) => {
     const outstanding = outstandingIssues.filter((i) => i.priorityTier === tier);
+    // Dedupe by code so a single failing code with multiple instances
+    // doesn't subtract more than once from the passed count.
+    const uniqueFailingCodes = new Set(outstanding.map((i) => i.code));
+    const failed = uniqueFailingCodes.size;
     return {
       tier,
-      passed: TIER_CODE_COUNT[tier] - outstanding.length,
-      failed: outstanding.length,
+      passed: Math.max(0, TIER_CODE_COUNT[tier] - failed),
+      failed,
       outstanding,
     };
   });
@@ -296,6 +301,16 @@ function priorityTierForCode(code: string): PriorityTier | null {
   if (code === 'PRH-ACRONYM-INSERTED-SEPARATORS') return 'P3';
 
   return null;
+}
+
+/**
+ * Whitelist of allowed severity values. Audit issues come from
+ * unrelated validators that may use other vocabularies; anything
+ * outside this set falls back to 'minor' so the report keeps a
+ * sound type contract.
+ */
+function isValidSeverity(value: string): value is PrhConformanceIssue['severity'] {
+  return value === 'critical' || value === 'serious' || value === 'moderate' || value === 'minor';
 }
 
 function readJobInputFileName(input: unknown): string | null {

--- a/src/services/epub/epub-export.service.ts
+++ b/src/services/epub/epub-export.service.ts
@@ -195,7 +195,7 @@ class EPUBExportService {
         // jobs"); log at debug rather than warn so non-PRH exports
         // stay quiet.
         const msg = error instanceof Error ? error.message : 'Unknown error';
-        if (/only available on PRH-UK|no audit output/i.test(msg)) {
+        if (/only available on PRH-UK|no audit output|medium-or-high/i.test(msg)) {
           logger.debug(`PRH conformance report skipped: ${msg}`);
         } else {
           logger.warn(`Failed to generate PRH conformance report: ${msg}`);

--- a/src/services/epub/epub-export.service.ts
+++ b/src/services/epub/epub-export.service.ts
@@ -102,7 +102,19 @@ class EPUBExportService {
       throw new Error('Remediated EPUB not found. Run auto-remediation first.');
     }
 
-    if (!options.includeOriginal && !options.includeComparison && !options.includeReport) {
+    // Early-return short-circuit: when the caller wants ONLY the
+    // remediated EPUB (no original, comparison, report, or PRH
+    // conformance bundle), skip the zip pipeline and return the
+    // raw .epub. The PRH conformance check is included here so a
+    // PRH-job export that requests the conformance bundle still
+    // goes through the zip pipeline below — otherwise the bundle
+    // would silently be dropped.
+    if (
+      !options.includeOriginal
+      && !options.includeComparison
+      && !options.includeReport
+      && !options.includePrhConformance
+    ) {
       return {
         fileName: `${baseName}_remediated.epub`,
         mimeType: 'application/epub+zip',
@@ -574,8 +586,10 @@ class EPUBExportService {
       const msg = err instanceof Error ? err.message : 'unknown';
       // Non-PRH or pre-audit jobs: the gate doesn't apply. ok=true so
       // the FE doesn't show a confirmation dialog; applicable=false
-      // so it knows the PRH UI shouldn't render.
-      if (/only available on PRH-UK|no audit output|not found/i.test(msg)) {
+      // so it knows the PRH UI shouldn't render. We deliberately do
+      // NOT swallow "Job ... not found" here — that's an authorization
+      // / lookup failure the caller needs to see as an error.
+      if (/only available on PRH-UK|no audit output|medium-or-high/i.test(msg)) {
         return {
           ok: true,
           requiresConfirmation: false,

--- a/src/services/epub/epub-export.service.ts
+++ b/src/services/epub/epub-export.service.ts
@@ -4,11 +4,23 @@ import { epubComparisonService } from './epub-comparison.service';
 import { logger } from '../../lib/logger';
 import prisma from '../../lib/prisma';
 import { AUTO_FIXABLE_ISSUE_CODES } from '../../constants/auto-fix-codes';
+import {
+  generatePrhConformanceReport,
+  renderHtml as renderPrhConformanceHtml,
+} from '../acr/prh-conformance-report.service';
 
 interface ExportOptions {
   includeOriginal?: boolean;
   includeComparison?: boolean;
   includeReport?: boolean;
+  /**
+   * Bundle a PRH UK conformance report (JSON + HTML) alongside the
+   * standard ACR. Only applies to jobs detected as PRH-UK at
+   * medium-or-high confidence — the service skips silently on
+   * non-PRH jobs even when this is true. FE defaults this to true
+   * for PRH jobs.
+   */
+  includePrhConformance?: boolean;
   format?: 'epub' | 'zip';
 }
 
@@ -140,7 +152,7 @@ class EPUBExportService {
     if (options.includeReport) {
       try {
         const report = await this.generateAccessibilityReport(jobId, tenantId);
-        
+
         const reportJson = JSON.stringify(report, null, 2);
         zip.file(`${baseName}_accessibility_report.json`, reportJson);
         contents.push(`${baseName}_accessibility_report.json`);
@@ -150,6 +162,32 @@ class EPUBExportService {
         contents.push(`${baseName}_accessibility_report.md`);
       } catch (error) {
         logger.warn(`Failed to generate report for export: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+
+    // PRH UK conformance report. Skipped silently on non-PRH jobs —
+    // the service throws a descriptive error which we catch + log,
+    // never blocks the export. Bundled JSON + HTML alongside the
+    // standard ACR for operator review.
+    if (options.includePrhConformance) {
+      try {
+        const prhReport = await generatePrhConformanceReport(jobId);
+        const prhJsonName = `${baseName}_prh_conformance_report.json`;
+        const prhHtmlName = `${baseName}_prh_conformance_report.html`;
+        zip.file(prhJsonName, JSON.stringify(prhReport, null, 2));
+        zip.file(prhHtmlName, renderPrhConformanceHtml(prhReport));
+        contents.push(prhJsonName);
+        contents.push(prhHtmlName);
+      } catch (error) {
+        // Expected on non-PRH jobs ("only available on PRH-UK
+        // jobs"); log at debug rather than warn so non-PRH exports
+        // stay quiet.
+        const msg = error instanceof Error ? error.message : 'Unknown error';
+        if (/only available on PRH-UK|no audit output/i.test(msg)) {
+          logger.debug(`PRH conformance report skipped: ${msg}`);
+        } else {
+          logger.warn(`Failed to generate PRH conformance report: ${msg}`);
+        }
       }
     }
 
@@ -495,6 +533,59 @@ class EPUBExportService {
     compliance.sort((a, b) => a.criterion.localeCompare(b.criterion));
 
     return compliance;
+  }
+
+  /**
+   * Preflight check used by the FE before triggering an export.
+   * Returns either:
+   *   - { ok: true } — non-PRH job OR all P1+P2 issues resolved
+   *   - { ok: false, requiresConfirmation: true, outstanding } —
+   *     PRH job with remaining P1/P2 issues; operator can confirm
+   *     to proceed (soft warning, not a hard block)
+   *
+   * Non-PRH jobs always pass — the gate doesn't apply to them.
+   */
+  async getPrhConformancePreflight(jobId: string): Promise<{
+    ok: boolean;
+    requiresConfirmation: boolean;
+    outstanding: Array<{ code: string; severity: string; priorityTier: string; location: string; message: string }>;
+    readyForDelivery: boolean;
+    applicable: boolean;
+  }> {
+    try {
+      const report = await generatePrhConformanceReport(jobId);
+      const p1p2Outstanding = report.outstandingIssues.filter(
+        (i) => i.priorityTier === 'P1' || i.priorityTier === 'P2',
+      );
+      return {
+        ok: report.readyForDelivery,
+        requiresConfirmation: !report.readyForDelivery,
+        outstanding: p1p2Outstanding.map((i) => ({
+          code: i.code,
+          severity: i.severity,
+          priorityTier: i.priorityTier,
+          location: i.location,
+          message: i.message,
+        })),
+        readyForDelivery: report.readyForDelivery,
+        applicable: true,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown';
+      // Non-PRH or pre-audit jobs: the gate doesn't apply. ok=true so
+      // the FE doesn't show a confirmation dialog; applicable=false
+      // so it knows the PRH UI shouldn't render.
+      if (/only available on PRH-UK|no audit output|not found/i.test(msg)) {
+        return {
+          ok: true,
+          requiresConfirmation: false,
+          outstanding: [],
+          readyForDelivery: false,
+          applicable: false,
+        };
+      }
+      throw err;
+    }
   }
 
   private generateComparisonMarkdown(comparison: Record<string, unknown>): string {

--- a/tests/unit/services/acr/prh-conformance-report.service.test.ts
+++ b/tests/unit/services/acr/prh-conformance-report.service.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../../../src/lib/prisma', () => ({
+  default: {
+    job: { findUnique: vi.fn() },
+  },
+}));
+
+import prisma from '../../../../src/lib/prisma';
+import {
+  generatePrhConformanceReport,
+  renderHtml,
+} from '../../../../src/services/acr/prh-conformance-report.service';
+
+const mJobFindUnique = prisma.job.findUnique as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mJobFindUnique.mockReset();
+});
+
+function mockJob(output: Record<string, unknown>, input: Record<string, unknown> = { originalName: 'test.epub' }) {
+  mJobFindUnique.mockResolvedValue({ id: 'job-1', output, input });
+}
+
+describe('generatePrhConformanceReport — applicability gating', () => {
+  it('throws when the job is not found', async () => {
+    mJobFindUnique.mockResolvedValue(null);
+    await expect(generatePrhConformanceReport('missing')).rejects.toThrow(/not found/i);
+  });
+
+  it('throws when the job has no audit output', async () => {
+    mJobFindUnique.mockResolvedValue({ id: 'job-1', output: null, input: {} });
+    await expect(generatePrhConformanceReport('job-1')).rejects.toThrow(/no audit output/i);
+  });
+
+  it('throws on non-PRH-UK publishers', async () => {
+    mockJob({ publisherProfile: { publisher: 'HACHETTE-UK', confidence: 'high' } });
+    await expect(generatePrhConformanceReport('job-1')).rejects.toThrow(/only available on PRH-UK/i);
+  });
+
+  it('throws on low-confidence PRH-UK matches', async () => {
+    mockJob({ publisherProfile: { publisher: 'PRH-UK', confidence: 'low' } });
+    await expect(generatePrhConformanceReport('job-1')).rejects.toThrow(/medium-or-high/i);
+  });
+});
+
+describe('generatePrhConformanceReport — issue classification', () => {
+  it('classifies PRH-META-* as P1', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', imprint: 'penguin', confidence: 'high' },
+      combinedIssues: [
+        { code: 'PRH-META-CONFORMS-TO', severity: 'moderate', message: 'msg', location: 'package.opf' },
+      ],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    expect(report.outstandingIssues[0].priorityTier).toBe('P1');
+  });
+
+  it('classifies PRH-COPY-*, PRH-BRAND-*, PRH-TITLE-*, PRH-SOCIALS-*, PRH-ORDER-* as P2', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [
+        { code: 'PRH-COPY-TDM-PARAGRAPH-MISSING', message: 'a', location: 'copyright.xhtml' },
+        { code: 'PRH-BRAND-PAGE-MISSING', message: 'b', location: 'EPUB' },
+        { code: 'PRH-TITLE-PAGE-MISSING', message: 'c', location: 'EPUB' },
+        { code: 'PRH-SOCIALS-PAGE-MISSING', message: 'd', location: 'EPUB' },
+        { code: 'PRH-ORDER-COVER-NOT-FIRST', message: 'e', location: 'package.opf' },
+      ],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    expect(report.outstandingIssues.every((i) => i.priorityTier === 'P2')).toBe(true);
+  });
+
+  it('classifies PRH-MARKUP-*, PRH-ARIA-*, PRH-BODY-HAS-ARIA, PRH-PAGEBREAK-MALFORMED, heuristic codes as P3', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [
+        { code: 'PRH-MARKUP-DEPRECATED-TAG', message: 'a', location: 'ch1.xhtml' },
+        { code: 'PRH-ARIA-CHAPTER-ROLE-MISSING', message: 'b', location: 'ch1.xhtml' },
+        { code: 'PRH-BODY-HAS-ARIA', message: 'c', location: 'ch1.xhtml' },
+        { code: 'PRH-PAGEBREAK-MALFORMED', message: 'd', location: 'ch1.xhtml' },
+        { code: 'PRH-HASHTAG-NOT-CAMEL-CASE', message: 'e', location: 'ch1.xhtml' },
+      ],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    expect(report.outstandingIssues.every((i) => i.priorityTier === 'P3')).toBe(true);
+  });
+
+  it('ignores non-PRH-* codes', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [
+        { code: 'EPUB-IMG-001', message: 'missing alt', location: 'ch1.xhtml' },
+        { code: 'RSC-005', message: 'epubcheck warning', location: '' },
+        { code: 'PRH-META-CONFORMS-TO', message: 'a', location: 'package.opf' },
+      ],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    expect(report.outstandingIssues).toHaveLength(1);
+    expect(report.outstandingIssues[0].code).toBe('PRH-META-CONFORMS-TO');
+  });
+});
+
+describe('generatePrhConformanceReport — readyForDelivery', () => {
+  it('is true when no P1 or P2 issues remain', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [
+        { code: 'PRH-HASHTAG-NOT-CAMEL-CASE', message: 'a', location: 'ch1.xhtml' }, // P3
+      ],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    expect(report.readyForDelivery).toBe(true);
+  });
+
+  it('is false when any P1 issue remains', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [
+        { code: 'PRH-META-CONFORMS-TO', message: 'a', location: 'package.opf' },
+      ],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    expect(report.readyForDelivery).toBe(false);
+  });
+
+  it('is false when any P2 issue remains', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [
+        { code: 'PRH-COPY-TDM-PARAGRAPH-MISSING', message: 'a', location: 'copyright.xhtml' },
+      ],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    expect(report.readyForDelivery).toBe(false);
+  });
+
+  it('is true when only P3 issues remain (P3 is advisory)', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [
+        { code: 'PRH-MARKUP-DEPRECATED-TAG', message: 'a', location: 'ch1.xhtml' },
+        { code: 'PRH-LANG-INLINE-NOT-MARKED', message: 'b', location: 'ch1.xhtml' },
+      ],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    expect(report.readyForDelivery).toBe(true);
+  });
+});
+
+describe('generatePrhConformanceReport — report shape', () => {
+  it('embeds the canonical certifier metadata', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', imprint: 'penguin', confidence: 'high' },
+      combinedIssues: [],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    expect(report.certifier.name).toBe('Penguin Random House UK');
+    expect(report.certifier.credential).toBe('Ace by DAISY OK');
+    expect(report.certifier.publicUrl).toBe('https://www.penguin.co.uk/accessibility');
+    expect(report.conformsTo).toBe('EPUB Accessibility 1.1 - WCAG 2.2 Level AA');
+  });
+
+  it('reports per-tier counts (passed = total tier codes - failed)', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [
+        { code: 'PRH-META-CONFORMS-TO', message: 'a', location: 'package.opf' },
+        { code: 'PRH-META-CERTIFIED-BY', message: 'b', location: 'package.opf' },
+      ],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    const p1 = report.priorityStatus.find((t) => t.tier === 'P1');
+    expect(p1?.failed).toBe(2);
+    expect(p1?.passed).toBe(17 - 2); // 17 total P1 codes
+  });
+
+  it('surfaces bookTitle and imprint when present', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', imprint: 'penguin', confidence: 'medium' },
+      combinedIssues: [],
+      bookTitle: 'The Book',
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    expect(report.bookTitle).toBe('The Book');
+    expect(report.publisherProfile.imprint).toBe('penguin');
+    expect(report.publisherProfile.confidence).toBe('medium');
+  });
+});
+
+describe('renderHtml', () => {
+  it('produces a valid HTML document with the canonical structure', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', imprint: 'penguin', confidence: 'high' },
+      combinedIssues: [],
+      bookTitle: 'The Book',
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    const html = renderHtml(report);
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('<title>PRH UK Conformance Report');
+    expect(html).toContain('The Book');
+    expect(html).toContain('Status by Priority Tier');
+  });
+
+  it('shows the green "Ready for delivery" banner when readyForDelivery is true', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    const html = renderHtml(report);
+    expect(html).toMatch(/Ready for PRH delivery/);
+  });
+
+  it('shows the red "NOT ready" banner with the outstanding count', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [
+        { code: 'PRH-META-CONFORMS-TO', message: 'a', location: 'package.opf' },
+        { code: 'PRH-COPY-TDM-PARAGRAPH-MISSING', message: 'b', location: 'copyright.xhtml' },
+      ],
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    const html = renderHtml(report);
+    expect(html).toMatch(/NOT ready for delivery/);
+    expect(html).toMatch(/2 P1\/P2 issue\(s\) outstanding/);
+  });
+
+  it('HTML-escapes user-supplied content (book title, messages)', async () => {
+    mockJob({
+      publisherProfile: { publisher: 'PRH-UK', confidence: 'high' },
+      combinedIssues: [
+        { code: 'PRH-COPY-TDM-PARAGRAPH-MISSING', message: 'has <script>alert(1)</script>', location: 'ch.xhtml' },
+      ],
+      bookTitle: 'Book & Co. <Edition>',
+    });
+    const report = await generatePrhConformanceReport('job-1');
+    const html = renderHtml(report);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('Book &amp; Co. &lt;Edition&gt;');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the P5 series. Adds the PRH-specific conformance report bundled alongside the standard ACR on export, and a preflight endpoint the FE calls before triggering export to surface outstanding P1/P2 issues for operator confirmation.

## What ships

### 1. New service: `prh-conformance-report.service.ts`
- `generatePrhConformanceReport(jobId)` — classifies PRH-* issues by priority tier:
  - **P1**: metadata / spine / nav / per-XHTML / image (17 codes)
  - **P2**: copyright / brand / title / socials / order (25 codes)
  - **P3**: markup conventions + text heuristics (16 codes)
- `renderHtml(report)` — standalone HTML doc with verdict banner + per-tier status table + outstanding-issues table. XSS-escaped.
- `readyForDelivery = (no P1 outstanding) AND (no P2 outstanding)`. P3 is advisory.

### 2. Export bundle (`epub-export.service.ts`)
- New `includePrhConformance` option. Bundles `<baseName>_prh_conformance_report.{json,html}` alongside the standard ACR.
- New `getPrhConformancePreflight(jobId)` method. Returns `{ ok, requiresConfirmation, outstanding, readyForDelivery, applicable }`.
- Non-PRH and pre-audit jobs return `applicable: false` so the FE hides PRH UI.

### 3. New endpoint
```
GET /api/v1/epub/job/:jobId/export/prh-preflight
```
Defence-in-depth tenant check; returns the preflight payload.

### 4. Existing export endpoint enhanced
```
GET /api/v1/epub/job/:jobId/export?includePrhConformance=true
```
Defaults to `true` (soft on for any export — service skips silently on non-PRH jobs).

## Scoping decisions baked in

| Q | Answer | How |
|---|---|---|
| Q4 (export gate posture) | Soft warning + operator confirmation, not hard block | Preflight returns `requiresConfirmation: true` when P1/P2 outstanding; FE renders dialog; operator can override |
| Q5 (report storage) | Bundle alongside ACR | Files in the export zip; same lifecycle |
| Q7 (certifier URL) | `penguin.co.uk/accessibility` | Reused from P1/PR5 VPAT template |

## Test plan

- [x] 1536/1536 unit tests passing (19 new for the conformance service)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Staging smoke: GET preflight on a PRH job → returns outstanding P1/P2 list
- [ ] Staging smoke: export with `?includePrhConformance=true` → zip contains `_prh_conformance_report.json` + `.html`
- [ ] Staging smoke: non-PRH job preflight → `applicable: false`

## P5 complete

| PR | Scope | Status |
|---|---|---|
| #382 | PR0: workflow-contracts enum reconciliation | merged |
| #383 | PR1: Boilerplate injector | merged |
| #384 | PR2: Copyright-page scaffolder | merged |
| #385 | PR3: Auto-fix bundle (10 codes auto-fixable) | merged |
| **THIS** | **PR4: Deliverable export + conformance report + preflight** | **open** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PRH conformance reports are generated and bundled with remediated EPUB exports by default (toggle via query parameter).
  * New preflight endpoint to check PRH export readiness and surface outstanding P1/P2 issues before delivery.

* **Tests**
  * Added unit tests covering report generation, readiness logic, and HTML rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/387)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->