### PR TITLE
feat(spike): PDFBox write spike — Phase-2 alternative after pikepdf NO-GO

### DIFF
--- a/spikes/pdfbox-write/.gitignore
+++ b/spikes/pdfbox-write/.gitignore
@@ -1,0 +1,9 @@
+target/
+.idea/
+.vscode/
+*.iml
+*.classpath
+*.project
+.settings/
+output/
+bundle/

--- a/spikes/pdfbox-write/Dockerfile
+++ b/spikes/pdfbox-write/Dockerfile
@@ -1,0 +1,73 @@
+# syntax=docker/dockerfile:1.4
+
+# ─── Stage 1: build the uber-jar with Maven + JDK 17 ───────────────────
+FROM maven:3.9-eclipse-temurin-17 AS builder
+WORKDIR /build
+
+# Cache deps first (pom.xml-only layer changes rarely).
+COPY pom.xml .
+RUN mvn -B -q dependency:go-offline
+
+# Compile + package.
+COPY src ./src
+RUN mvn -B -q -DskipTests package
+# Output JAR ends up at /build/target/pdfbox-write-spike.jar.
+
+# ─── Stage 2: runtime image (JRE + veraPDF + the JAR) ──────────────────
+FROM eclipse-temurin:17-jre-jammy AS runtime
+WORKDIR /app
+
+# Install minimal runtime utilities + AWS CLI (used by entrypoint.sh
+# when running as an ECS one-shot that ships results back to S3).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        unzip \
+        zip \
+        python3 \
+    && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/aws.zip \
+    && unzip -q /tmp/aws.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/aws /tmp/aws.zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# veraPDF — installed from the same official tarball the main backend
+# image uses (matches /opt/verapdf/verapdf layout). The argument-style
+# installer needs xvfb/headless awareness, so use the package's own
+# installer-with-script payload.
+RUN mkdir -p /opt/verapdf \
+    && curl -fsSL "https://software.verapdf.org/rel/1.26/verapdf-greenfield-1.26.2-installer.zip" -o /tmp/verapdf.zip \
+    && unzip -q /tmp/verapdf.zip -d /tmp/verapdf-installer \
+    && INSTALLER_JAR=$(find /tmp/verapdf-installer -name 'verapdf-installer.jar' | head -1) \
+    && cat > /tmp/auto-install.xml <<'EOF'
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<AutomatedInstallation langpack="eng">
+    <com.izforge.izpack.panels.target.TargetPanel id="install.dir">
+        <installpath>/opt/verapdf</installpath>
+    </com.izforge.izpack.panels.target.TargetPanel>
+    <com.izforge.izpack.panels.packs.PacksPanel id="sdk.pack.select">
+        <pack index="0" name="veraPDF GUI" selected="true"/>
+        <pack index="1" name="veraPDF Mac and *nix Scripts" selected="true"/>
+        <pack index="2" name="veraPDF Validation model" selected="true"/>
+        <pack index="3" name="veraPDF Documentation" selected="false"/>
+        <pack index="4" name="veraPDF Sample Plugins" selected="false"/>
+    </com.izforge.izpack.panels.packs.PacksPanel>
+    <com.izforge.izpack.panels.install.InstallPanel id="install"/>
+    <com.izforge.izpack.panels.finish.FinishPanel id="finish"/>
+</AutomatedInstallation>
+EOF
+    && java -jar "$INSTALLER_JAR" /tmp/auto-install.xml \
+    && rm -rf /tmp/verapdf-installer /tmp/verapdf.zip /tmp/auto-install.xml
+
+ENV VERAPDF_PATH=/opt/verapdf/verapdf
+
+# Copy the JAR from the build stage.
+COPY --from=builder /build/target/pdfbox-write-spike.jar /app/pdfbox-write-spike.jar
+
+# Entrypoint: download bundle from S3 if BUNDLE_S3_URI is set; run the
+# spike; optionally upload the report back to S3 if RESULTS_S3_URI is set.
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+WORKDIR /work
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/spikes/pdfbox-write/README.md
+++ b/spikes/pdfbox-write/README.md
@@ -1,0 +1,112 @@
+# PDFBox Write Spike — ML-3.9 (Issue #388)
+
+## Purpose
+
+Time-boxed spike to determine whether **Apache PDFBox** can write a valid
+PDF/UA-1 Tagged PDF structure tree from Ninja zone ground-truth data.
+Parallels `spikes/pikepdf-write/`; the two spikes consume the same
+`ground_truth.json` shape, run the same veraPDF validation, and emit
+reports in the same format so the pass-rates are directly comparable.
+
+**Go/No-Go threshold:** ≥ 95% veraPDF PDF/UA-1 pass rate across all
+content types individually.
+
+| | pikepdf spike | PDFBox spike |
+|---|---|---|
+| Language | Python | Java |
+| Library | `pikepdf` (qpdf bindings) | `org.apache.pdfbox:pdfbox` 3.x |
+| Validator | veraPDF | veraPDF |
+| Inputs | identical ground_truth.json | identical ground_truth.json |
+| Reports | `spike_report.md` + `spike_results.json` | same shape |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `pom.xml` | Maven build (Java 17, shaded uber-jar) |
+| `Dockerfile` | Multi-stage: Maven build → JRE + veraPDF + jar |
+| `entrypoint.sh` | Container entry: optional S3 bundle pull + run + S3 results upload |
+| `src/main/java/.../ZoneToTags.java` | Zone-type → PDF tag role mapping (mirrors `zone_to_tags.py`) |
+| `src/main/java/.../WriteTaggedPdf.java` | Core PDFBox write impl |
+| `src/main/java/.../RunSpike.java` | Batch runner + report generator |
+| `src/test/java/.../ZoneToTagsTest.java` | JUnit 5 tests mirroring `test_zone_to_tags.py` |
+
+## Local build & run
+
+```bash
+# Requires JDK 17+ and Maven 3.9+.
+mvn -B -DskipTests package
+
+# Spike runner — same args as pikepdf's run_spike.py.
+export VERAPDF_PATH=/path/to/verapdf   # or .bat on Windows
+java -jar target/pdfbox-write-spike.jar \
+     /path/to/bundle/ground_truth.json \
+     ./output/
+
+# spike_report.md + spike_results.json land in ./output/.
+```
+
+## Docker run (preferred — no local JDK / Maven / veraPDF setup)
+
+```bash
+docker build -t ninja-pdfbox-spike .
+
+# Mode A — local bundle:
+docker run --rm \
+    -v /local/spike-bundle:/work/bundle \
+    -v /local/output:/work/output \
+    ninja-pdfbox-spike
+
+# Mode B — bundle from S3 (one-shot, results stay in container):
+docker run --rm \
+    -e BUNDLE_S3_URI=s3://ninja-epub-staging/admin-scripts/pikepdf-spike-bundle-2026-05-13.zip \
+    -e AWS_ACCESS_KEY_ID=... -e AWS_SECRET_ACCESS_KEY=... -e AWS_DEFAULT_REGION=ap-south-1 \
+    ninja-pdfbox-spike
+
+# Mode C — full end-to-end (results uploaded to S3 + presigned URL printed):
+docker run --rm \
+    -e BUNDLE_S3_URI=s3://ninja-epub-staging/admin-scripts/pikepdf-spike-bundle-2026-05-13.zip \
+    -e RESULTS_S3_PREFIX=s3://ninja-epub-staging/admin-scripts/ \
+    -e AWS_ACCESS_KEY_ID=... -e AWS_SECRET_ACCESS_KEY=... -e AWS_DEFAULT_REGION=ap-south-1 \
+    ninja-pdfbox-spike
+```
+
+## ECS one-shot (same pattern the pikepdf export used)
+
+After this image is pushed to ECR, run via Fargate:
+
+```bash
+aws ecs run-task \
+  --cluster ninja-cluster \
+  --task-definition ninja-pdfbox-spike \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[…],securityGroups=[…],assignPublicIp=DISABLED}" \
+  --overrides '{
+    "containerOverrides": [{
+      "name": "pdfbox-spike",
+      "environment": [
+        {"name": "BUNDLE_S3_URI",      "value": "s3://ninja-epub-staging/admin-scripts/pikepdf-spike-bundle-2026-05-13.zip"},
+        {"name": "RESULTS_S3_PREFIX",  "value": "s3://ninja-epub-staging/admin-scripts/"}
+      ]
+    }]
+  }'
+```
+
+(Task definition + ECR push are separate infra steps — see Issue #388 acceptance criteria.)
+
+## Output decision tree
+
+| Result | Action |
+|---|---|
+| Pass rate ≥ 95% (all content types) | **PROCEED with PDFBox** for Phase 2 write step. Update phase-gate criterion C5 → GREEN. |
+| Pass rate < 95% on any content type | **EVALUATE next alternatives** — manual pikepdf completion (1-2 sprints) vs commercial library vs combined approach. |
+
+## Comparison baseline
+
+The pikepdf spike ran 2026-05-13 and produced **0.0% pass rate** (10
+distinct PDF/UA-1 clauses failing across 20 docs — see
+`spikes/pikepdf-write/` and `CalibrationRun cmp4gp95a0001c92mznflwkve`).
+Any PDFBox result substantially higher than 0% confirms the spike's
+hypothesis that PDFBox's more mature Tagged-PDF support is the right
+fallback. Even a non-passing result that fails fewer clauses informs
+the effort estimate for completing the implementation.

--- a/spikes/pdfbox-write/entrypoint.sh
+++ b/spikes/pdfbox-write/entrypoint.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Entrypoint for the PDFBox spike container.
+#
+# Three modes:
+#   1. Local file mode (default):
+#        docker run -v /local/bundle:/work/bundle pdfbox-spike \
+#            bundle/ground_truth.json output/
+#
+#   2. S3-bundle mode (set BUNDLE_S3_URI):
+#        docker run -e BUNDLE_S3_URI=s3://bucket/key.zip pdfbox-spike
+#      Container downloads + unzips the bundle, runs the spike, exits.
+#
+#   3. ECS one-shot mode (set BUNDLE_S3_URI + RESULTS_S3_PREFIX):
+#        Container downloads bundle, runs spike, uploads spike_report.md +
+#        spike_results.json to RESULTS_S3_PREFIX, prints presigned URL.
+#
+# VERAPDF_PATH defaults to /opt/verapdf/verapdf (set by Dockerfile).
+set -euo pipefail
+
+WORK_DIR=${WORK_DIR:-/work}
+mkdir -p "$WORK_DIR" && cd "$WORK_DIR"
+
+BUNDLE_DIR=${BUNDLE_DIR:-$WORK_DIR/bundle}
+OUTPUT_DIR=${OUTPUT_DIR:-$WORK_DIR/output}
+mkdir -p "$OUTPUT_DIR"
+
+# Mode 2/3: pull bundle from S3 if requested.
+if [[ -n "${BUNDLE_S3_URI:-}" ]]; then
+  echo "[entrypoint] Downloading bundle from $BUNDLE_S3_URI"
+  aws s3 cp "$BUNDLE_S3_URI" "$WORK_DIR/bundle.zip"
+  rm -rf "$BUNDLE_DIR" && mkdir -p "$BUNDLE_DIR"
+  unzip -q "$WORK_DIR/bundle.zip" -d "$BUNDLE_DIR"
+  rm "$WORK_DIR/bundle.zip"
+fi
+
+# If positional args were passed, honour them; otherwise infer from $BUNDLE_DIR.
+if [[ "$#" -ge 2 ]]; then
+  GT_PATH="$1"
+  OUT_PATH="$2"
+else
+  GT_PATH="$BUNDLE_DIR/ground_truth.json"
+  OUT_PATH="$OUTPUT_DIR"
+fi
+
+echo "[entrypoint] ground_truth: $GT_PATH"
+echo "[entrypoint] output dir:   $OUT_PATH"
+echo "[entrypoint] veraPDF:      ${VERAPDF_PATH:-not set}"
+
+# Run the spike. Java tunings: cap heap to leave room for veraPDF child.
+java -Xmx4g -jar /app/pdfbox-write-spike.jar "$GT_PATH" "$OUT_PATH"
+
+# Mode 3: upload artefacts to S3.
+if [[ -n "${RESULTS_S3_PREFIX:-}" ]]; then
+  DATE_TAG=$(date -u +%Y-%m-%d)
+  RESULTS_KEY="${RESULTS_S3_PREFIX%/}/pdfbox-spike-results-${DATE_TAG}"
+  echo "[entrypoint] Uploading results to ${RESULTS_KEY}.{md,json}"
+  aws s3 cp "$OUT_PATH/spike_report.md"   "${RESULTS_KEY}.md"
+  aws s3 cp "$OUT_PATH/spike_results.json" "${RESULTS_KEY}.json"
+  # 24-hour presigned URL for the report (read-only convenience).
+  aws s3 presign "${RESULTS_KEY}.md" --expires-in 86400
+fi
+
+echo "[entrypoint] DONE"

--- a/spikes/pdfbox-write/pom.xml
+++ b/spikes/pdfbox-write/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.ninja</groupId>
+  <artifactId>pdfbox-write-spike</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Ninja PDFBox Write Spike</name>
+  <description>
+    Time-boxed spike (ML-3.9, Issue #388): determine whether Apache PDFBox
+    can write a valid Tagged PDF structure tree from Ninja zone ground
+    truth data. Parallels spikes/pikepdf-write. Go/No-Go threshold:
+    >=95% veraPDF PDF/UA-1 pass rate across all content types.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <pdfbox.version>3.0.2</pdfbox.version>
+    <jackson.version>2.17.2</jackson.version>
+    <junit.version>5.10.3</junit.version>
+  </properties>
+
+  <dependencies>
+    <!-- PDFBox 3.x — Apache 2.0. Provides PDStructureTreeRoot,
+         PDStructureElement, PDMarkedContent for Tagged PDF authoring. -->
+    <dependency>
+      <groupId>org.apache.pdfbox</groupId>
+      <artifactId>pdfbox</artifactId>
+      <version>${pdfbox.version}</version>
+    </dependency>
+
+    <!-- Ground-truth JSON deserialization. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>pdfbox-write-spike</finalName>
+    <plugins>
+      <!-- Build an uber-jar so the spike runs via a single `java -jar`. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.ninja.pdfboxspike.RunSpike</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/RunSpike.java
+++ b/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/RunSpike.java
@@ -1,0 +1,307 @@
+package com.ninja.pdfboxspike;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Batch runner + report generator. Mirrors {@code spikes/pikepdf-write/run_spike.py}:
+ *
+ *   1. Read ground_truth.json (documents[] with documentId, pdfPath,
+ *      contentType, publisher, zones[]).
+ *   2. For each document, write a tagged PDF via {@link WriteTaggedPdf}.
+ *   3. Run veraPDF in PDF/UA-1 mode (binary path from VERAPDF_PATH env).
+ *   4. Emit spike_results.json + spike_report.md to output dir.
+ *   5. Print GO/NO-GO based on >=95% pass rate threshold.
+ *
+ * Invocation: {@code java -jar pdfbox-write-spike.jar <ground_truth.json> <output_dir>}
+ */
+public final class RunSpike {
+
+    private RunSpike() {}
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            System.err.println("Usage: java -jar pdfbox-write-spike.jar <ground_truth.json> <output_dir>");
+            System.exit(2);
+        }
+
+        File groundTruth = new File(args[0]);
+        File outputDir = new File(args[1]);
+        outputDir.mkdirs();
+        File bundleRoot = groundTruth.getAbsoluteFile().getParentFile();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(groundTruth);
+        JsonNode docs = root.get("documents");
+        if (docs == null || !docs.isArray()) {
+            System.err.println("ground_truth.json missing documents array");
+            System.exit(2);
+        }
+
+        System.out.println();
+        System.out.println("Ninja PDFBox Write Spike");
+        System.out.println("Documents: " + docs.size());
+        System.out.println("Output:    " + outputDir.getAbsolutePath());
+        System.out.println();
+
+        List<Map<String, Object>> results = new ArrayList<>();
+        int total = docs.size();
+        int i = 0;
+        for (JsonNode doc : docs) {
+            i++;
+            String docId = doc.path("documentId").asText("doc-" + i);
+            String pdfPath = doc.path("pdfPath").asText("");
+            String contentType = doc.path("contentType").asText("unknown");
+            String publisher = doc.path("publisher").asText("unknown");
+
+            File pdfFile = resolveAgainst(bundleRoot, pdfPath);
+            int zoneCount = doc.path("zones").isArray() ? doc.path("zones").size() : 0;
+            System.out.printf("[%d/%d] %s (%s, %d zones)...%n", i, total, docId, contentType, zoneCount);
+
+            if (!pdfFile.exists()) {
+                results.add(skipped(docId, contentType, publisher, "PDF not found: " + pdfFile.getAbsolutePath()));
+                System.out.println("  SKIPPED - PDF not found");
+                continue;
+            }
+
+            List<WriteTaggedPdf.Zone> zones = parseZones(doc.path("zones"));
+            File outputPdf = new File(outputDir, docId + "_tagged.pdf");
+
+            long t0 = System.nanoTime();
+            WriteTaggedPdf.Result wr = WriteTaggedPdf.writeTaggedPdf(pdfFile, zones, outputPdf);
+            long writeMs = Duration.ofNanos(System.nanoTime() - t0).toMillis();
+
+            if (!wr.success) {
+                Map<String, Object> row = baseRow(docId, contentType, publisher);
+                row.put("status", "WRITE_FAILED");
+                row.put("error", wr.errorMessage);
+                results.add(row);
+                System.out.println("  WRITE FAILED: " + wr.errorMessage);
+                continue;
+            }
+
+            Validation v = runVerapdf(outputPdf);
+            String status = v.passed == null ? "NO_VALIDATOR" : (v.passed ? "PASS" : "FAIL");
+
+            Map<String, Object> row = baseRow(docId, contentType, publisher);
+            row.put("status", status);
+            row.put("zoneCount", wr.zoneCount);
+            row.put("writeMs", writeMs);
+            row.put("failures", v.failures);
+            results.add(row);
+
+            String symbol = "NO_VALIDATOR".equals(status) ? "?" : ("PASS".equals(status) ? "v" : "x");
+            System.out.printf("  %s %s - %d zones, %dms%n", symbol, status, wr.zoneCount, writeMs);
+        }
+
+        Map<String, Object> resultsJson = new LinkedHashMap<>();
+        resultsJson.put("documents", results);
+        Files.writeString(
+            new File(outputDir, "spike_results.json").toPath(),
+            mapper.writerWithDefaultPrettyPrinter().writeValueAsString(resultsJson),
+            StandardCharsets.UTF_8
+        );
+
+        generateReport(results, outputDir);
+        System.out.println();
+        System.out.println("Results: " + new File(outputDir, "spike_results.json").getAbsolutePath());
+    }
+
+    private static List<WriteTaggedPdf.Zone> parseZones(JsonNode arr) {
+        List<WriteTaggedPdf.Zone> out = new ArrayList<>();
+        if (arr == null || !arr.isArray()) return out;
+        for (JsonNode z : arr) {
+            WriteTaggedPdf.Zone zone = new WriteTaggedPdf.Zone();
+            zone.pageNumber = z.path("pageNumber").asInt(1);
+            zone.type = z.path("type").asText(null);
+            zone.operatorLabel = z.path("operatorLabel").asText(null);
+            zone.altText = z.path("altText").asText(null);
+            if (z.has("headingLevel") && !z.path("headingLevel").isNull()) {
+                zone.headingLevel = z.path("headingLevel").asInt(1);
+            }
+            JsonNode b = z.path("bounds");
+            if (b != null && b.isObject()) {
+                WriteTaggedPdf.BBox bb = new WriteTaggedPdf.BBox();
+                bb.x = b.path("x").asDouble(0);
+                bb.y = b.path("y").asDouble(0);
+                bb.w = b.path("w").asDouble(0);
+                bb.h = b.path("h").asDouble(0);
+                zone.bounds = bb;
+            }
+            out.add(zone);
+        }
+        return out;
+    }
+
+    private static File resolveAgainst(File bundleRoot, String pdfPath) {
+        File f = new File(pdfPath);
+        if (f.isAbsolute()) return f;
+        return new File(bundleRoot, pdfPath);
+    }
+
+    /** Lightweight veraPDF run result. */
+    static class Validation {
+        Boolean passed;        // true / false / null (no validator)
+        List<String> failures;
+        String raw;
+    }
+
+    static Validation runVerapdf(File pdf) {
+        String bin = System.getenv().getOrDefault("VERAPDF_PATH", "C:/verapdf/verapdf.bat");
+        Validation v = new Validation();
+        v.failures = new ArrayList<>();
+        try {
+            ProcessBuilder pb = new ProcessBuilder(bin, "--flavour", "ua1", pdf.getAbsolutePath());
+            pb.redirectErrorStream(true);
+            Process p = pb.start();
+            boolean finished = p.waitFor(60, TimeUnit.SECONDS);
+            if (!finished) {
+                p.destroyForcibly();
+                v.passed = false;
+                v.failures.add("Validation timed out");
+                return v;
+            }
+            String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            v.raw = output.length() > 500 ? output.substring(0, 500) : output;
+            v.passed = output.contains("isCompliant=\"true\"");
+            for (String line : output.split("\n")) {
+                if (line.contains("status=\"failed\"")) {
+                    v.failures.add(line.strip());
+                    if (v.failures.size() >= 10) break;
+                }
+            }
+        } catch (IOException notFound) {
+            v.passed = null; // NO_VALIDATOR
+            v.raw = "veraPDF not found at " + bin + " — skipping validation";
+        } catch (Exception e) {
+            v.passed = false;
+            v.failures.add("Validation error: " + e.getMessage());
+        }
+        return v;
+    }
+
+    private static Map<String, Object> baseRow(String docId, String contentType, String publisher) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("documentId", docId);
+        row.put("contentType", contentType);
+        row.put("publisher", publisher);
+        return row;
+    }
+
+    private static Map<String, Object> skipped(String docId, String ct, String pub, String reason) {
+        Map<String, Object> row = baseRow(docId, ct, pub);
+        row.put("status", "SKIPPED");
+        row.put("reason", reason);
+        return row;
+    }
+
+    /**
+     * Generate spike_report.md — same shape and headings as the pikepdf
+     * spike's Python report so they're trivially comparable.
+     */
+    @SuppressWarnings("unchecked")
+    static void generateReport(List<Map<String, Object>> results, File outputDir) throws IOException {
+        int total = results.size();
+        int passed = (int) results.stream().filter(r -> "PASS".equals(r.get("status"))).count();
+        int failed = (int) results.stream().filter(r -> "FAIL".equals(r.get("status"))).count();
+        int skipped = (int) results.stream().filter(r -> {
+            String s = String.valueOf(r.get("status"));
+            return "SKIPPED".equals(s) || "WRITE_FAILED".equals(s);
+        }).count();
+        int noVal = (int) results.stream().filter(r -> "NO_VALIDATOR".equals(r.get("status"))).count();
+
+        int denom = total - skipped - noVal;
+        double passRate = denom > 0 ? (double) passed / denom : 0.0;
+        boolean go = passRate >= 0.95;
+
+        Map<String, int[]> ctStats = new LinkedHashMap<>(); // {ct: [pass, fail, total]}
+        for (Map<String, Object> r : results) {
+            String ct = String.valueOf(r.get("contentType"));
+            int[] s = ctStats.computeIfAbsent(ct, k -> new int[3]);
+            if ("PASS".equals(r.get("status"))) s[0]++;
+            else if ("FAIL".equals(r.get("status"))) s[1]++;
+            s[2]++;
+        }
+
+        Map<String, Integer> failureCats = new LinkedHashMap<>();
+        for (Map<String, Object> r : results) {
+            Object failuresObj = r.get("failures");
+            if (failuresObj instanceof List<?> failures) {
+                for (Object f : failures) {
+                    String key = String.valueOf(f);
+                    failureCats.merge(key, 1, Integer::sum);
+                }
+            }
+        }
+
+        List<String> lines = new ArrayList<>();
+        lines.add("# Ninja PDFBox Write Spike - Report");
+        lines.add("");
+        lines.add("## Summary");
+        lines.add("");
+        lines.add("| Metric | Value |");
+        lines.add("|--------|-------|");
+        lines.add("| Total documents | " + total + " |");
+        lines.add("| Passed (PAC/veraPDF) | " + passed + " |");
+        lines.add("| Failed | " + failed + " |");
+        lines.add("| Skipped (PDF not found / write failed) | " + skipped + " |");
+        lines.add("| No validator | " + noVal + " |");
+        lines.add(String.format("| **Overall pass rate** | **%.1f%%** |", passRate * 100));
+        lines.add("| **Go/No-Go threshold** | **95%** |");
+        lines.add("| **Decision** | **" + (go ? "GO" : "NO-GO") + "** |");
+        lines.add("");
+        lines.add("## Per Content Type");
+        lines.add("");
+        lines.add("| Content Type | Pass | Fail | Rate |");
+        lines.add("|-------------|------|------|------|");
+        for (Map.Entry<String, int[]> e : ctStats.entrySet()) {
+            int[] s = e.getValue();
+            double rate = s[2] > 0 ? (double) s[0] / s[2] : 0.0;
+            lines.add(String.format("| %s | %d | %d | %.1f%% |", e.getKey(), s[0], s[1], rate * 100));
+        }
+        lines.add("");
+        lines.add("## Failure Categories");
+        lines.add("");
+        if (failureCats.isEmpty()) {
+            lines.add("No failures recorded.");
+        } else {
+            lines.add("| Failure | Count |");
+            lines.add("|---------|-------|");
+            failureCats.entrySet().stream()
+                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                .forEach(e -> lines.add("| " +
+                    (e.getKey().length() > 80 ? e.getKey().substring(0, 80) : e.getKey())
+                    + " | " + e.getValue() + " |"));
+        }
+        lines.add("");
+        lines.add("## Recommendation");
+        lines.add("");
+        lines.add(go
+            ? "**PROCEED to Phase 2 write step migration with PDFBox**"
+            : "**EVALUATE alternatives — pass rate below 95% threshold**");
+        lines.add("");
+
+        Files.writeString(new File(outputDir, "spike_report.md").toPath(),
+            String.join("\n", lines), StandardCharsets.UTF_8);
+
+        System.out.println();
+        System.out.println("==================================================");
+        System.out.println("Go/No-Go: " + (go ? "GO" : "NO-GO"));
+        System.out.printf("Pass rate: %.1f%% (%s 95%% threshold)%n",
+            passRate * 100, go ? ">=" : "<");
+        System.out.println("Report: " + new File(outputDir, "spike_report.md").getAbsolutePath());
+        System.out.println("==================================================");
+    }
+
+}

--- a/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/WriteTaggedPdf.java
+++ b/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/WriteTaggedPdf.java
@@ -1,0 +1,201 @@
+package com.ninja.pdfboxspike;
+
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSStream;
+import org.apache.pdfbox.cos.COSString;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDMetadata;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDMarkInfo;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
+import org.apache.pdfbox.pdmodel.interactive.viewerpreferences.PDViewerPreferences;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Core spike: takes a PDF + zone ground truth and writes a Tagged PDF
+ * structure tree using PDFBox. Sets the PDF/UA-1 requirements that
+ * veraPDF checks at the document level:
+ *   - /MarkInfo Marked=true (7.1)
+ *   - /Lang at document root (7.2)
+ *   - /ViewerPreferences DisplayDocTitle=true (7.1 test 10)
+ *   - XMP /pdfuaid:part=1 (7.1 test 8)
+ *   - /StructTreeRoot with /RoleMap → standard types
+ *   - /Document → page-grouped structure elements
+ *
+ * Mirrors {@code spikes/pikepdf-write/write_tagged_pdf.py} in shape so
+ * the two spikes' results are comparable.
+ *
+ * Limitations (intentional, time-boxed):
+ *   - Does not bind /StructElem objects to content via /MCID. veraPDF
+ *     PDF/UA-1 7.1 test 3 will still flag pages whose existing content
+ *     isn't covered, but the structure tree itself will validate.
+ *   - Does not rewrite running headers/footers as /Artifact in content
+ *     streams; they are simply excluded from the struct tree.
+ *   - Treats annotations as out-of-scope for the spike.
+ */
+public final class WriteTaggedPdf {
+
+    public static class Result {
+        public final boolean success;
+        public final String outputPath;
+        public final int zoneCount;
+        public final String errorMessage;
+
+        Result(boolean success, String outputPath, int zoneCount, String errorMessage) {
+            this.success = success;
+            this.outputPath = outputPath;
+            this.zoneCount = zoneCount;
+            this.errorMessage = errorMessage;
+        }
+
+        static Result ok(String path, int zoneCount) { return new Result(true, path, zoneCount, null); }
+        static Result fail(String path, String message) { return new Result(false, path, 0, message); }
+    }
+
+    /** Minimal zone shape consumed by the writer — matches ground_truth.json entries. */
+    public static class Zone {
+        public int pageNumber;
+        public BBox bounds;
+        public String type;
+        public String operatorLabel;
+        public String altText;
+        public Integer headingLevel;
+    }
+
+    public static class BBox {
+        public double x, y, w, h;
+    }
+
+    private WriteTaggedPdf() {}
+
+    public static Result writeTaggedPdf(File inputPdf, List<Zone> zones, File outputPdf) {
+        try (PDDocument pdf = org.apache.pdfbox.Loader.loadPDF(inputPdf)) {
+            PDDocumentCatalog catalog = pdf.getDocumentCatalog();
+
+            // 1) MarkInfo — required for any Tagged PDF.
+            PDMarkInfo markInfo = new PDMarkInfo();
+            markInfo.setMarked(true);
+            catalog.setMarkInfo(markInfo);
+
+            // 2) Document language at root.
+            catalog.setLanguage("en-US");
+
+            // 3) ViewerPreferences/DisplayDocTitle = true (7.1 test 10).
+            PDViewerPreferences viewerPrefs = new PDViewerPreferences(new COSDictionary());
+            viewerPrefs.setShowTitleBar(true);
+            catalog.setViewerPreferences(viewerPrefs);
+
+            // 4) Document title — required when DisplayDocTitle is true.
+            if (pdf.getDocumentInformation() != null) {
+                if (pdf.getDocumentInformation().getTitle() == null
+                        || pdf.getDocumentInformation().getTitle().isBlank()) {
+                    pdf.getDocumentInformation().setTitle("Tagged PDF");
+                }
+            }
+
+            // 5) XMP metadata declaring pdfuaid:part = 1 (7.1 test 8).
+            String xmp = ""
+                + "<?xpacket begin=\"﻿\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>"
+                + "<x:xmpmeta xmlns:x=\"adobe:ns:meta/\">"
+                + " <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">"
+                + "  <rdf:Description rdf:about=\"\""
+                + "    xmlns:dc=\"http://purl.org/dc/elements/1.1/\""
+                + "    xmlns:pdfuaid=\"http://www.aiim.org/pdfua/ns/id/\">"
+                + "   <pdfuaid:part>1</pdfuaid:part>"
+                + "   <dc:title><rdf:Alt>"
+                + "     <rdf:li xml:lang=\"x-default\">Tagged PDF</rdf:li>"
+                + "   </rdf:Alt></dc:title>"
+                + "  </rdf:Description>"
+                + " </rdf:RDF>"
+                + "</x:xmpmeta>"
+                + "<?xpacket end=\"w\"?>";
+            COSStream metadataStream = pdf.getDocument().createCOSStream();
+            try (var os = metadataStream.createOutputStream()) {
+                os.write(xmp.getBytes(StandardCharsets.UTF_8));
+            }
+            metadataStream.setItem(COSName.TYPE, COSName.METADATA);
+            metadataStream.setItem(COSName.SUBTYPE, COSName.getPDFName("XML"));
+            PDMetadata md = new PDMetadata(metadataStream);
+            catalog.setMetadata(md);
+
+            // 6) Structure tree root with role map so any non-standard child
+            //    types still validate (covers PDF/UA-1 7.3 test 1). The
+            //    PDStructureTreeRoot.setRoleMap signature has varied across
+            //    PDFBox minor versions; setting the COS item directly side-
+            //    steps that and matches the PDF 1.7 spec exactly.
+            PDStructureTreeRoot treeRoot = new PDStructureTreeRoot();
+            COSDictionary roleMap = new COSDictionary();
+            for (String role : new String[] {
+                "P", "Table", "Figure", "Caption", "Note",
+                "H", "H1", "H2", "H3", "H4", "H5", "H6"
+            }) {
+                roleMap.setItem(COSName.getPDFName(role), COSName.getPDFName(role));
+            }
+            treeRoot.getCOSObject().setItem(COSName.getPDFName("RoleMap"), roleMap);
+            catalog.setStructureTreeRoot(treeRoot);
+
+            // 7) Group zones by page (skipping artefacts), in zone-input order.
+            Map<Integer, List<Zone>> byPage = new TreeMap<>();
+            for (Zone z : zones) {
+                if (z == null || z.type == null || ZoneToTags.isArtifact(z.type)) continue;
+                byPage.computeIfAbsent(z.pageNumber, k -> new ArrayList<>()).add(z);
+            }
+
+            // 8) Build a Document → page → element hierarchy. Each StructElem
+            //    references its page (so PDF readers can map back) and uses
+            //    the canonical PDF tag role.
+            PDStructureElement docElem = new PDStructureElement("Document", treeRoot);
+            treeRoot.appendKid(docElem);
+
+            int zoneCount = 0;
+            int totalPages = pdf.getNumberOfPages();
+            for (Map.Entry<Integer, List<Zone>> entry : byPage.entrySet()) {
+                int pageNumber = entry.getKey();
+                int pageIdx = pageNumber - 1;
+                if (pageIdx < 0 || pageIdx >= totalPages) continue;
+                PDPage page = pdf.getPage(pageIdx);
+
+                for (Zone zone : entry.getValue()) {
+                    String chosenType = zone.operatorLabel != null && !zone.operatorLabel.isBlank()
+                        ? zone.operatorLabel : zone.type;
+                    String role = "section-header".equals(chosenType)
+                        ? ZoneToTags.getHeadingTag(zone.headingLevel == null ? 1 : zone.headingLevel)
+                        : ZoneToTags.getPdfRole(chosenType);
+
+                    PDStructureElement elem = new PDStructureElement(role, docElem);
+                    elem.setPage(page);
+                    if ("Figure".equals(role) && zone.altText != null && !zone.altText.isBlank()) {
+                        elem.setAlternateDescription(zone.altText);
+                    }
+                    if ("Note".equals(role)) {
+                        // Note tags require an ID entry (PDF/UA 7.9 test 1).
+                        elem.getCOSObject().setItem(
+                            COSName.getPDFName("ID"),
+                            new COSString("note-p" + pageNumber + "-" + zoneCount)
+                        );
+                    }
+                    docElem.appendKid(elem);
+                    zoneCount++;
+                }
+            }
+
+            pdf.save(outputPdf);
+            return Result.ok(outputPdf.getAbsolutePath(), zoneCount);
+        } catch (IOException ioe) {
+            return Result.fail(outputPdf.getAbsolutePath(), ioe.getMessage());
+        } catch (Exception e) {
+            return Result.fail(outputPdf.getAbsolutePath(), e.toString());
+        }
+    }
+
+}

--- a/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/ZoneToTags.java
+++ b/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/ZoneToTags.java
@@ -1,0 +1,69 @@
+package com.ninja.pdfboxspike;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Ninja canonical zone type → PDF structure tag role.
+ * Mirrors {@code spikes/pikepdf-write/zone_to_tags.py} so the two spikes
+ * can be compared cleanly. Both spikes consume the same ground-truth JSON
+ * shape ({@code zone.type} drawn from CanonicalZoneType) and emit the same
+ * PDF tag roles, so any pass-rate delta is attributable to library
+ * differences, not taxonomy.
+ *
+ * Canonical Zone Type ↔ PDF 1.7 / ISO 32000-1 standard structure type:
+ *   paragraph      → P
+ *   section-header → H (with H1..H6 based on headingLevel)
+ *   table          → Table
+ *   figure         → Figure
+ *   caption        → Caption
+ *   footnote       → Note
+ *   header         → Artifact (running head — not in struct tree)
+ *   footer         → Artifact (running foot — not in struct tree)
+ */
+public final class ZoneToTags {
+
+    private ZoneToTags() {}
+
+    /** Default fallback when a zone type isn't in the canonical 8. */
+    public static final String DEFAULT_ROLE = "P";
+
+    private static final Map<String, String> ROLE_MAP = Map.of(
+        "paragraph",      "P",
+        "section-header", "H",
+        "table",          "Table",
+        "figure",         "Figure",
+        "caption",        "Caption",
+        "footnote",       "Note",
+        "header",         "Artifact",
+        "footer",         "Artifact"
+    );
+
+    /** Zone types that should be marked as /Artifact and excluded from the struct tree. */
+    private static final Set<String> ARTIFACT_TYPES = Set.of("header", "footer");
+
+    /** Returns the PDF structure tag role for a given zone type. */
+    public static String getPdfRole(String zoneType) {
+        if (zoneType == null) return DEFAULT_ROLE;
+        return ROLE_MAP.getOrDefault(zoneType, DEFAULT_ROLE);
+    }
+
+    /** True if the zone should be marked /Artifact (not included in the struct tree). */
+    public static boolean isArtifact(String zoneType) {
+        return zoneType != null && ARTIFACT_TYPES.contains(zoneType);
+    }
+
+    /**
+     * Heading-level extractor for section-header zones. Defaults to 1 when
+     * unspecified or out of range. Mirrors the Python spike's clamp 1..6.
+     */
+    public static int getHeadingLevel(Integer level) {
+        if (level == null) return 1;
+        return Math.max(1, Math.min(6, level));
+    }
+
+    /** Returns the heading tag (H1..H6) for the given level. */
+    public static String getHeadingTag(int level) {
+        return "H" + getHeadingLevel(level);
+    }
+}

--- a/spikes/pdfbox-write/src/test/java/com/ninja/pdfboxspike/ZoneToTagsTest.java
+++ b/spikes/pdfbox-write/src/test/java/com/ninja/pdfboxspike/ZoneToTagsTest.java
@@ -1,0 +1,90 @@
+package com.ninja.pdfboxspike;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JUnit 5 mirror of {@code spikes/pikepdf-write/test_zone_to_tags.py}.
+ * Every behaviour the Python tests pin should be testable here so the
+ * two spikes have the same contract.
+ */
+class ZoneToTagsTest {
+
+    @Test @DisplayName("paragraph maps to /P")
+    void paragraph_maps_to_P() {
+        assertEquals("P", ZoneToTags.getPdfRole("paragraph"));
+    }
+
+    @Test @DisplayName("section-header maps to /H")
+    void section_header_maps_to_H() {
+        assertEquals("H", ZoneToTags.getPdfRole("section-header"));
+    }
+
+    @Test @DisplayName("table maps to /Table")
+    void table_maps_to_Table() {
+        assertEquals("Table", ZoneToTags.getPdfRole("table"));
+    }
+
+    @Test @DisplayName("figure maps to /Figure")
+    void figure_maps_to_Figure() {
+        assertEquals("Figure", ZoneToTags.getPdfRole("figure"));
+    }
+
+    @Test @DisplayName("caption maps to /Caption")
+    void caption_maps_to_Caption() {
+        assertEquals("Caption", ZoneToTags.getPdfRole("caption"));
+    }
+
+    @Test @DisplayName("footnote maps to /Note")
+    void footnote_maps_to_Note() {
+        assertEquals("Note", ZoneToTags.getPdfRole("footnote"));
+    }
+
+    @Test @DisplayName("running header/footer map to /Artifact role")
+    void artifact_roles() {
+        assertEquals("Artifact", ZoneToTags.getPdfRole("header"));
+        assertEquals("Artifact", ZoneToTags.getPdfRole("footer"));
+    }
+
+    @Test @DisplayName("unknown zone type falls back to /P")
+    void unknown_maps_to_P() {
+        assertEquals("P", ZoneToTags.getPdfRole("totally-bogus"));
+        assertEquals("P", ZoneToTags.getPdfRole(null));
+    }
+
+    @Test @DisplayName("isArtifact true for header/footer only")
+    void isArtifact_true_for_artefacts() {
+        assertTrue(ZoneToTags.isArtifact("header"));
+        assertTrue(ZoneToTags.isArtifact("footer"));
+        assertFalse(ZoneToTags.isArtifact("paragraph"));
+        assertFalse(ZoneToTags.isArtifact("table"));
+        assertFalse(ZoneToTags.isArtifact(null));
+    }
+
+    @Test @DisplayName("heading level clamps to 1..6")
+    void heading_level_clamps() {
+        assertEquals(1, ZoneToTags.getHeadingLevel(null));
+        assertEquals(1, ZoneToTags.getHeadingLevel(0));
+        assertEquals(1, ZoneToTags.getHeadingLevel(-3));
+        assertEquals(1, ZoneToTags.getHeadingLevel(1));
+        assertEquals(3, ZoneToTags.getHeadingLevel(3));
+        assertEquals(6, ZoneToTags.getHeadingLevel(6));
+        assertEquals(6, ZoneToTags.getHeadingLevel(7));
+        assertEquals(6, ZoneToTags.getHeadingLevel(99));
+    }
+
+    @Test @DisplayName("heading tags use H1..H6")
+    void heading_tag_format() {
+        assertEquals("H1", ZoneToTags.getHeadingTag(1));
+        assertEquals("H2", ZoneToTags.getHeadingTag(2));
+        assertEquals("H3", ZoneToTags.getHeadingTag(3));
+        assertEquals("H4", ZoneToTags.getHeadingTag(4));
+        assertEquals("H5", ZoneToTags.getHeadingTag(5));
+        assertEquals("H6", ZoneToTags.getHeadingTag(6));
+        // out-of-range clamps before formatting
+        assertEquals("H6", ZoneToTags.getHeadingTag(9));
+        assertEquals("H1", ZoneToTags.getHeadingTag(0));
+    }
+}


### PR DESCRIPTION
## Summary

Closes scaffolding for Issue #388. Scaffolds \`spikes/pdfbox-write/\` as the Phase-2 alternative to the pikepdf write path, which came back at **0.0% PDF/UA-1 pass rate** on 2026-05-13 (10 distinct clauses failing across 20 docs; CalibrationRun \`cmp4gp95a0001c92mznflwkve\` records the result).

The two spikes share **inputs** (same \`ground_truth.json\` bundle) and **report shape** (markdown summary + per-content-type rates + failure categories + GO/NO-GO line) so pass-rates are directly comparable.

## What's in this PR

| File | Role |
|---|---|
| \`pom.xml\` | Maven build, Java 17, PDFBox 3.0.2 + Jackson + JUnit 5, shade plugin for uber-jar |
| \`src/main/java/.../ZoneToTags.java\` | Canonical zone type → PDF tag mapping (mirror of \`zone_to_tags.py\`) |
| \`src/main/java/.../WriteTaggedPdf.java\` | Core Tagged-PDF writer using PDFBox: MarkInfo, Lang, ViewerPreferences/DisplayDocTitle, XMP pdfuaid:part=1, RoleMap, Document→StructElem hierarchy |
| \`src/main/java/.../RunSpike.java\` | Batch runner + report generator (same shape as \`run_spike.py\`) |
| \`src/test/java/.../ZoneToTagsTest.java\` | JUnit 5 mirror of \`test_zone_to_tags.py\` (11 cases) |
| \`Dockerfile\` | Multi-stage: Maven build → JRE + veraPDF + uber-jar |
| \`entrypoint.sh\` | Local-file / S3-bundle / full-ECS-roundtrip modes |
| \`README.md\` | Build/run instructions for local, Docker, and ECS |

## Scope limitations (intentional — match pikepdf)

- No \`/MCID\` content-stream binding (veraPDF 7.1 test 3 may flag uncovered content)
- No \`/Artifact\` rewriting for running headers/footers in content streams; they're excluded from the struct tree
- Annotations are out-of-scope

These are deliberate so we measure the **library's** ability to produce a valid struct tree, not the completeness of our own implementation. If PDFBox passes more clauses than pikepdf at the same level of effort, it's the right Phase-2 stack.

## Why no local build verification in this PR

Local env has JRE only — no JDK / Maven. The Dockerfile validates the entire build chain on \`docker build\`, which is the path the spike will actually run on. CI will build the Docker image and run the JUnit tests via Surefire when this PR triggers it (assuming the workflow picks up the new spike directory; if not, that's a follow-on).

## Test plan

- [ ] CI (or local) \`docker build\` succeeds
- [ ] \`mvn test\` produces 11/11 ZoneToTags pass
- [ ] Run on the 2026-05-13 bundle → \`output/spike_report.md\` exists, has a pass rate, decision line
- [ ] Pass rate compared to pikepdf's 0%:
  - Strictly higher → PDFBox is the right Phase-2 fallback; insert CalibrationRun row, flip C5 if ≥ 95%
  - Comparable / lower → revisit completing pikepdf or evaluate a commercial library

## Open follow-ups (tracked in Issue #388)

- Build + push Docker image to ECR
- Register \`pdfbox-spike\` ECS task definition for one-shot runs
- Run on the existing \`s3://ninja-epub-staging/admin-scripts/pikepdf-spike-bundle-2026-05-13.zip\`
- Record result as a new CalibrationRun; possibly add a \`PDFBOX_SPIKE\` type to \`phase-gate.service.ts\` C5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a PDFBox experimental spike for testing PDF/UA-1 Tagged PDF generation from ground truth data.
  * Spike validates output PDFs against PDF/UA-1 compliance standards and generates a detailed pass/fail report.
  * Supports local execution and containerized deployment options.

* **Documentation**
  * Added spike documentation including setup instructions and execution modes.

* **Chores**
  * Added project configuration for Maven builds, Docker containerization, and environment setup.
  * Added test suite for validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/389)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->