### PR TITLE
feat(prh): CSS conventions validator (P6/PR1)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -501,6 +501,48 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'ALL-CAPS sequence with inserted separators (N.A.S.A. / F, B, I) — PRH wants compact form (NASA / FBI). Heuristic; review manually for legitimate formal abbreviations',
   },
+
+  // ── CSS conventions (P6/PR1) ──────────────────────────────────────────
+  // Publisher-gated and detect-only. Per Technical Guide §15 + Style
+  // Guide on the canonical stylesheet stack. Renaming basestyles.css,
+  // re-ordering @imports, or rewriting class-name conventions cascades
+  // across the publisher's dev pipeline; we surface the finding and let
+  // the operator fix in their authoring tool, not auto-remediate.
+  'PRH-CSS-BASESTYLES-RENAMED': {
+    code: 'PRH-CSS-BASESTYLES-RENAMED',
+    severity: 'serious',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'No file named basestyles.css under /styles — PRH Technical Guide §15 requires the canonical filename so Kindle ET, NCX-fallback CSS and brand fonts resolve correctly',
+  },
+  'PRH-CSS-IMPORT-ORDER-WRONG': {
+    code: 'PRH-CSS-IMPORT-ORDER-WRONG',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: '@import order in a PRH stylesheet deviates from the required cascade basestyles → complex → bespoke → mediaquery (Technical Guide §15)',
+  },
+  'PRH-CSS-CLASS-NAME-HYPHEN': {
+    code: 'PRH-CSS-CLASS-NAME-HYPHEN',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Publisher-defined class selector uses hyphen separator (e.g. .first-para) — PRH convention is underscore (.first_para). Vendor/utility prefixes (tw-, bs-, ng-) and non-publisher stylesheets are ignored',
+  },
+  'PRH-CSS-PER-PARAGRAPH-FONT': {
+    code: 'PRH-CSS-PER-PARAGRAPH-FONT',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'A class that sets font-family is applied to 10+ <p> elements — PRH disallows per-paragraph fonts because they break Kindle font-customisation. Set primary font on <body>, override only via bespoke.css',
+  },
+  'PRH-CSS-INLINE-STYLE-AT-SCALE': {
+    code: 'PRH-CSS-INLINE-STYLE-AT-SCALE',
+    severity: 'serious',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'EPUB contains 100+ inline style="…" attributes across all XHTML — book-wide pattern of inline styles; PRH demonstration carve-out (one per book) does not apply at this scale',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/prh-conformance-report.service.ts
+++ b/src/services/acr/prh-conformance-report.service.ts
@@ -260,8 +260,9 @@ const TIER_CODE_COUNT: Record<PriorityTier, number> = {
   P1: 17,
   // P2 — copyright (8) + brand (3) + title (4) + socials (5) + order (5) = 25
   P2: 25,
-  // P3 — body epub:type + doc-* ARIA (8) + forbidden (3) + notes/pagebreak (2) + text heuristics (3) = 16
-  P3: 16,
+  // P3 — body epub:type + doc-* ARIA (8) + forbidden (3) + notes/pagebreak (2)
+  // + text heuristics (3) + CSS conventions (5, P6/PR1) = 21
+  P3: 21,
   // P4 has no PRH-* codes (AI policy gate + cover-alt template were
   // implemented as behaviors, not new codes). 0 to keep the type happy.
   P4: 0,
@@ -292,6 +293,7 @@ function priorityTierForCode(code: string): PriorityTier | null {
   // P3
   if (code.startsWith('PRH-MARKUP-')) return 'P3';
   if (code.startsWith('PRH-ARIA-')) return 'P3';
+  if (code.startsWith('PRH-CSS-')) return 'P3';
   if (code === 'PRH-BODY-HAS-ARIA') return 'P3';
   if (code === 'PRH-PAGEBREAK-MALFORMED') return 'P3';
   if (code === 'PRH-FOOTNOTE-ID-MISMATCH') return 'P3';

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -194,11 +194,17 @@ async function readNavDoc(
 }
 
 /**
- * Read every CSS file in the zip and classify each as
+ * Read every CSS file REFERENCED BY THE MANIFEST and classify each as
  * publisher-owned vs. third-party / vendor. The CSS-conventions
  * validator only enforces class-name rules against publisher-owned
  * stylesheets so vendored utility frameworks (TailwindCSS, Bootstrap)
  * don't false-flag.
+ *
+ * Manifest-scoped: an EPUB may carry unused source / backup CSS files
+ * in the zip that aren't part of the publication. Iterating the zip
+ * blindly would produce false-positive findings on those. The
+ * manifest is the authoritative list of files that participate in
+ * the EPUB at runtime.
  *
  * Classification heuristic:
  *   - publisher-owned: path lives under a `/styles/` (or `/style/` /
@@ -210,15 +216,23 @@ async function readNavDoc(
  */
 async function readAllCss(
   zip: JSZip,
-  _opfPath: string,
-  _opfContent: string,
+  opfPath: string,
+  opfContent: string,
 ): Promise<PrhCssFile[]> {
+  const manifestMatch = opfContent.match(/<manifest\b[^>]*>([\s\S]*?)<\/manifest>/i);
+  if (!manifestMatch) return [];
+
   const out: PrhCssFile[] = [];
-  for (const filePath of Object.keys(zip.files)) {
-    if (!/\.css$/i.test(filePath)) continue;
-    const content = await zip.file(filePath)?.async('text');
+  for (const item of manifestMatch[1].matchAll(/<item\b([^>]*)\/?>/gi)) {
+    const attrs = item[1];
+    const mediaTypeMatch = attrs.match(/\bmedia-type\s*=\s*["']([^"']+)["']/i);
+    if (!mediaTypeMatch || mediaTypeMatch[1].toLowerCase() !== 'text/css') continue;
+    const hrefMatch = attrs.match(/\bhref\s*=\s*["']([^"']+)["']/i);
+    if (!hrefMatch) continue;
+    const cssPath = resolveOpfRelative(opfPath, hrefMatch[1]);
+    const content = await zip.file(cssPath)?.async('text');
     if (!content) continue;
-    out.push({ path: filePath, content, isPublisherOwned: classifyPublisherOwned(filePath) });
+    out.push({ path: cssPath, content, isPublisherOwned: classifyPublisherOwned(cssPath) });
   }
   return out;
 }

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -32,9 +32,10 @@ import { validatePrhPageBreakShape } from './validators/page-break-shape-validat
 import { validatePrhInlineLang } from './validators/inline-lang-validator';
 import { validatePrhHashtags } from './validators/hashtag-validator';
 import { validatePrhAcronyms } from './validators/acronym-validator';
+import { validatePrhCssConventions } from './validators/css-conventions-validator';
 import { getImprintRules } from './imprints';
 import type { PublisherProfile } from '../types';
-import type { PrhValidatorIssue, PrhXhtmlFile } from './validators/types';
+import type { PrhValidatorIssue, PrhXhtmlFile, PrhCssFile } from './validators/types';
 
 /**
  * Run all PRH UK validators against an EPUB buffer.
@@ -63,6 +64,7 @@ export async function runPrhUkValidators(
 
     const navDoc = await readNavDoc(zip, opf.path, opf.content);
     const xhtmlFiles = await readAllXhtml(zip);
+    const cssFiles = await readAllCss(zip, opf.path, opf.content);
     const bookTitle = readDcTitle(opf.content);
 
     const opfInput = { opfContent: opf.content, opfPath: opf.path };
@@ -75,6 +77,10 @@ export async function runPrhUkValidators(
       ...opfInput,
       xhtmlFiles,
       bookTitle,
+    };
+    const cssInput = {
+      ...perXhtmlInput,
+      cssFiles,
     };
 
     const issues: PrhValidatorIssue[] = [
@@ -106,6 +112,7 @@ export async function runPrhUkValidators(
         ...validatePrhInlineLang(perXhtmlInput),
         ...validatePrhHashtags(perXhtmlInput),
         ...validatePrhAcronyms(perXhtmlInput),
+        ...validatePrhCssConventions(cssInput),
       );
     }
 
@@ -184,6 +191,53 @@ async function readNavDoc(
     }
   }
   return null;
+}
+
+/**
+ * Read every CSS file in the zip and classify each as
+ * publisher-owned vs. third-party / vendor. The CSS-conventions
+ * validator only enforces class-name rules against publisher-owned
+ * stylesheets so vendored utility frameworks (TailwindCSS, Bootstrap)
+ * don't false-flag.
+ *
+ * Classification heuristic:
+ *   - publisher-owned: path lives under a `/styles/` (or `/style/` /
+ *     `/css/`) directory AND the basename is not one of the well-known
+ *     vendor filenames.
+ *   - vendor: everything else (including stylesheets under
+ *     `/vendor/`, `/lib/`, `/node_modules-style/`, or that match
+ *     filenames like `tailwind.css` / `bootstrap.css`).
+ */
+async function readAllCss(
+  zip: JSZip,
+  _opfPath: string,
+  _opfContent: string,
+): Promise<PrhCssFile[]> {
+  const out: PrhCssFile[] = [];
+  for (const filePath of Object.keys(zip.files)) {
+    if (!/\.css$/i.test(filePath)) continue;
+    const content = await zip.file(filePath)?.async('text');
+    if (!content) continue;
+    out.push({ path: filePath, content, isPublisherOwned: classifyPublisherOwned(filePath) });
+  }
+  return out;
+}
+
+function classifyPublisherOwned(filePath: string): boolean {
+  const lower = filePath.toLowerCase();
+  if (/(?:^|\/)(?:vendor|lib|third[_-]?party|node_modules)\//.test(lower)) return false;
+  const base = lower.slice(lower.lastIndexOf('/') + 1);
+  const vendorFilenames = [
+    'tailwind.css',
+    'bootstrap.css',
+    'bootstrap.min.css',
+    'normalize.css',
+    'reset.css',
+    'foundation.css',
+  ];
+  if (vendorFilenames.includes(base)) return false;
+  // Default to publisher-owned for anything under a /styles[/]?/ root.
+  return /(?:^|\/)(?:styles?|css)\//.test(lower);
 }
 
 /**

--- a/src/services/epub/profiles/prh-uk/validators/css-conventions-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/css-conventions-validator.ts
@@ -97,8 +97,17 @@ export function validatePrhCssConventions(input: PrhCssConventionsInput): PrhVal
 
 // ── helpers ──────────────────────────────────────────────────────────────
 
+/**
+ * basestyles.css must live UNDER `/styles/` per Technical Guide §15.
+ * A file at the EPUB root or under a different directory is still a
+ * violation because Kindle ET, NCX-fallback CSS, and the brand-font
+ * lookup all resolve relative to the canonical /styles location.
+ */
 function hasBasestyles(cssFiles: PrhCssFile[]): boolean {
-  return cssFiles.some((f) => basename(f.path).toLowerCase() === CANONICAL_BASESTYLES);
+  return cssFiles.some((f) => {
+    const lower = f.path.toLowerCase();
+    return lower.endsWith(`/styles/${CANONICAL_BASESTYLES}`) || lower === `styles/${CANONICAL_BASESTYLES}`;
+  });
 }
 
 /**
@@ -165,30 +174,37 @@ function collectHyphenatedPublisherClasses(cssFiles: PrhCssFile[]): string[] {
  * because that's what breaks Kindle font-customisation.
  */
 function findPerParagraphFontClasses(input: PrhCssConventionsInput): string[] {
-  const fontClasses = new Set<string>();
+  // Collect groups of classes that share a single font-family rule.
+  // Grouped selectors (`.a, .b { font-family: ... }`) form ONE scope:
+  // their per-paragraph counts aggregate because the font is applied
+  // identically to every paragraph carrying any of those classes.
+  const fontGroups: string[][] = [];
   for (const css of input.cssFiles) {
     if (!css.isPublisherOwned) continue;
-    // Match `.class-name { ... font-family: ... }`. Use [\s\S] so the
-    // body can span newlines; non-greedy to avoid swallowing adjacent
-    // rules.
-    const blocks = css.content.matchAll(/\.([a-z][a-z0-9_-]*)\b[^{]*\{([^}]*)\}/gi);
+    // Match `<selector> { <body> }` blocks. `[^{}@]+` skips at-rules
+    // (e.g. `@media`) which would otherwise confuse the flat parser.
+    const blocks = css.content.matchAll(/([^{}@]+)\{([^{}]*)\}/g);
     for (const m of blocks) {
-      const className = m[1];
+      const selector = m[1];
       const body = m[2];
-      if (/font-family\s*:/i.test(body)) {
-        fontClasses.add(className);
+      if (!/font-family\s*:/i.test(body)) continue;
+      const group: string[] = [];
+      for (const cm of selector.matchAll(/\.([a-z][a-z0-9_-]*)\b/gi)) {
+        group.push(cm[1]);
       }
+      if (group.length > 0) fontGroups.push(group);
     }
   }
-  if (fontClasses.size === 0) return [];
+  if (fontGroups.length === 0) return [];
 
-  const offenders: string[] = [];
-  for (const className of fontClasses) {
-    // Count <p> usages of this class across all XHTML. The `class`
-    // attribute can carry multiple space-separated tokens, so we use
-    // a token-aware regex rather than a substring match.
+  const offenders = new Set<string>();
+  for (const group of fontGroups) {
+    // Count <p> usages of ANY class in the group across all XHTML.
+    // The `class` attribute can carry multiple space-separated tokens,
+    // so we use a token-aware regex rather than a substring match.
+    const alternation = group.map(escapeRegex).join('|');
     const tokenRegex = new RegExp(
-      `<p\\b[^>]*\\bclass\\s*=\\s*["'][^"']*\\b${escapeRegex(className)}\\b[^"']*["']`,
+      `<p\\b[^>]*\\bclass\\s*=\\s*["'][^"']*\\b(?:${alternation})\\b[^"']*["']`,
       'gi',
     );
     let total = 0;
@@ -198,9 +214,11 @@ function findPerParagraphFontClasses(input: PrhCssConventionsInput): string[] {
       if (matches) total += matches.length;
       if (total >= PER_PARAGRAPH_FONT_THRESHOLD) break;
     }
-    if (total >= PER_PARAGRAPH_FONT_THRESHOLD) offenders.push(className);
+    if (total >= PER_PARAGRAPH_FONT_THRESHOLD) {
+      for (const c of group) offenders.add(c);
+    }
   }
-  return offenders.sort();
+  return [...offenders].sort();
 }
 
 function countInlineStyles(input: PrhCssConventionsInput): number {

--- a/src/services/epub/profiles/prh-uk/validators/css-conventions-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/css-conventions-validator.ts
@@ -1,0 +1,267 @@
+/**
+ * PRH UK CSS-conventions validator (P6/PR1).
+ *
+ * Per Technical Guide §15 + Style Guide, PRH expects a specific
+ * stylesheet stack and naming convention:
+ *
+ *   1. basestyles.css      (REQUIRED, MUST NOT be renamed)
+ *   2. complex.css         (optional, for complex layouts)
+ *   3. bespoke.css         (optional, book-specific overrides)
+ *   4. mediaquery.css      (REQUIRED-IF-PRESENT to be LAST)
+ *
+ * Class names use underscores (`.first_para`), not hyphens. Inline
+ * `style="…"` is disallowed at scale (P3 already flags per-instance;
+ * this rule fires on books with 100+ inline styles across all XHTML
+ * — a book-wide pattern the demonstration carve-out can't cover).
+ * Per-paragraph fonts break Kindle font-customisation; primary font
+ * goes on <body>, overrides in bespoke.css.
+ *
+ * Detect-only. Auto-remediation defers to publisher tooling because
+ * renaming basestyles.css, re-ordering @imports, or refactoring class
+ * names cascades through the publisher's dev pipeline.
+ *
+ * Vendor / utility classes (tw-, bs-, ng-) and classes declared in
+ * non-publisher stylesheets are exempt from the underscore rule.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type {
+  PrhValidatorIssue,
+  PrhCssConventionsInput,
+  PrhCssFile,
+} from './types';
+
+const CANONICAL_BASESTYLES = 'basestyles.css';
+const CANONICAL_STACK_ORDER = ['basestyles', 'complex', 'bespoke', 'mediaquery'] as const;
+const PER_PARAGRAPH_FONT_THRESHOLD = 10;
+const INLINE_STYLE_AT_SCALE_THRESHOLD = 100;
+
+/**
+ * Class-name prefixes that come from third-party utility frameworks.
+ * Any selector starting with one of these is ignored for the
+ * underscore-only rule because the publisher doesn't control the
+ * naming.
+ */
+const VENDOR_CLASS_PREFIXES = ['tw-', 'bs-', 'ng-'] as const;
+
+const INLINE_STYLE_REGEX = /(?:^|\s)style\s*=\s*["'][^"']*["']/gi;
+
+export function validatePrhCssConventions(input: PrhCssConventionsInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  if (!hasBasestyles(input.cssFiles)) {
+    issues.push(buildIssue('PRH-CSS-BASESTYLES-RENAMED', '/styles'));
+  }
+
+  for (const css of input.cssFiles) {
+    if (!isImportOrderValid(css.content)) {
+      issues.push(buildIssue('PRH-CSS-IMPORT-ORDER-WRONG', css.path));
+    }
+  }
+
+  const hyphenClasses = collectHyphenatedPublisherClasses(input.cssFiles);
+  if (hyphenClasses.length > 0) {
+    issues.push(
+      buildIssue(
+        'PRH-CSS-CLASS-NAME-HYPHEN',
+        '/styles',
+        ` (${hyphenClasses.length} class(es): ${formatSample(hyphenClasses)})`,
+      ),
+    );
+  }
+
+  const perParaFontClasses = findPerParagraphFontClasses(input);
+  if (perParaFontClasses.length > 0) {
+    issues.push(
+      buildIssue(
+        'PRH-CSS-PER-PARAGRAPH-FONT',
+        '/styles',
+        ` (class(es): ${formatSample(perParaFontClasses)})`,
+      ),
+    );
+  }
+
+  const inlineCount = countInlineStyles(input);
+  if (inlineCount >= INLINE_STYLE_AT_SCALE_THRESHOLD) {
+    issues.push(
+      buildIssue(
+        'PRH-CSS-INLINE-STYLE-AT-SCALE',
+        'EPUB',
+        ` (${inlineCount} inline style attributes across all XHTML)`,
+      ),
+    );
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function hasBasestyles(cssFiles: PrhCssFile[]): boolean {
+  return cssFiles.some((f) => basename(f.path).toLowerCase() === CANONICAL_BASESTYLES);
+}
+
+/**
+ * Walk the file's `@import` statements top-to-bottom and check the
+ * canonical stack order is respected. We only enforce the *relative*
+ * order — a file may legitimately omit `complex.css` or `bespoke.css`,
+ * but if both are present, basestyles must come before complex, complex
+ * before bespoke, bespoke before mediaquery.
+ *
+ * Returns true (valid) when:
+ *   - The file has zero @imports.
+ *   - All @imports we recognise appear in canonical order.
+ *   - Unknown filenames are ignored (they're publisher-extension files).
+ */
+function isImportOrderValid(cssContent: string): boolean {
+  const importPaths = [...cssContent.matchAll(/@import\s+(?:url\()?\s*["']([^"']+)["']/gi)].map(
+    (m) => basename(m[1]).toLowerCase().replace(/\.css$/, ''),
+  );
+
+  const positions: number[] = [];
+  for (const name of importPaths) {
+    const idx = CANONICAL_STACK_ORDER.findIndex((canonical) => name === canonical);
+    if (idx === -1) continue;
+    positions.push(idx);
+  }
+
+  for (let i = 1; i < positions.length; i++) {
+    if (positions[i] < positions[i - 1]) return false;
+  }
+  return true;
+}
+
+/**
+ * Extract class selectors that use hyphen separators, scoped to
+ * publisher-owned stylesheets only. We strip vendor prefixes and skip
+ * leading/trailing single-token selectors (`.btn`) — only multi-token
+ * hyphenated names (`.first-para`) violate the PRH underscore
+ * convention. Returns a deduped list, sorted, capped at a reasonable
+ * sample.
+ */
+function collectHyphenatedPublisherClasses(cssFiles: PrhCssFile[]): string[] {
+  const found = new Set<string>();
+  for (const css of cssFiles) {
+    if (!css.isPublisherOwned) continue;
+    const matches = css.content.matchAll(/\.([a-z][a-z0-9_-]*)\b/gi);
+    for (const m of matches) {
+      const name = m[1];
+      if (!name.includes('-')) continue;
+      if (VENDOR_CLASS_PREFIXES.some((p) => name.startsWith(p))) continue;
+      found.add(name);
+    }
+  }
+  return [...found].sort();
+}
+
+/**
+ * Find classes that:
+ *   1. Declare a `font-family` in a publisher stylesheet, AND
+ *   2. Are applied to ≥ PER_PARAGRAPH_FONT_THRESHOLD <p> elements
+ *      across the book.
+ *
+ * Returns the offending class names. Per-class font on a <span> or
+ * heading is fine; the rule is specifically about per-paragraph fonts
+ * because that's what breaks Kindle font-customisation.
+ */
+function findPerParagraphFontClasses(input: PrhCssConventionsInput): string[] {
+  const fontClasses = new Set<string>();
+  for (const css of input.cssFiles) {
+    if (!css.isPublisherOwned) continue;
+    // Match `.class-name { ... font-family: ... }`. Use [\s\S] so the
+    // body can span newlines; non-greedy to avoid swallowing adjacent
+    // rules.
+    const blocks = css.content.matchAll(/\.([a-z][a-z0-9_-]*)\b[^{]*\{([^}]*)\}/gi);
+    for (const m of blocks) {
+      const className = m[1];
+      const body = m[2];
+      if (/font-family\s*:/i.test(body)) {
+        fontClasses.add(className);
+      }
+    }
+  }
+  if (fontClasses.size === 0) return [];
+
+  const offenders: string[] = [];
+  for (const className of fontClasses) {
+    // Count <p> usages of this class across all XHTML. The `class`
+    // attribute can carry multiple space-separated tokens, so we use
+    // a token-aware regex rather than a substring match.
+    const tokenRegex = new RegExp(
+      `<p\\b[^>]*\\bclass\\s*=\\s*["'][^"']*\\b${escapeRegex(className)}\\b[^"']*["']`,
+      'gi',
+    );
+    let total = 0;
+    for (const file of input.xhtmlFiles) {
+      tokenRegex.lastIndex = 0;
+      const matches = file.content.match(tokenRegex);
+      if (matches) total += matches.length;
+      if (total >= PER_PARAGRAPH_FONT_THRESHOLD) break;
+    }
+    if (total >= PER_PARAGRAPH_FONT_THRESHOLD) offenders.push(className);
+  }
+  return offenders.sort();
+}
+
+function countInlineStyles(input: PrhCssConventionsInput): number {
+  let total = 0;
+  for (const file of input.xhtmlFiles) {
+    INLINE_STYLE_REGEX.lastIndex = 0;
+    const matches = file.content.match(INLINE_STYLE_REGEX);
+    if (matches) total += matches.length;
+  }
+  return total;
+}
+
+function basename(zipPath: string): string {
+  const idx = zipPath.lastIndexOf('/');
+  return idx === -1 ? zipPath : zipPath.slice(idx + 1);
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function formatSample(items: string[]): string {
+  const max = 5;
+  if (items.length <= max) return items.join(', ');
+  return `${items.slice(0, max).join(', ')}, …`;
+}
+
+function buildIssue(
+  code:
+    | 'PRH-CSS-BASESTYLES-RENAMED'
+    | 'PRH-CSS-IMPORT-ORDER-WRONG'
+    | 'PRH-CSS-CLASS-NAME-HYPHEN'
+    | 'PRH-CSS-PER-PARAGRAPH-FONT'
+    | 'PRH-CSS-INLINE-STYLE-AT-SCALE',
+  location: string,
+  detail = '',
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}${detail}`,
+    suggestion: suggestionFor(code),
+    location,
+  };
+}
+
+function suggestionFor(code: string): string {
+  switch (code) {
+    case 'PRH-CSS-BASESTYLES-RENAMED':
+      return 'Rename your primary stylesheet to basestyles.css and reference it from every XHTML <link>. Keep the file in /styles. See Technical Guide §15.';
+    case 'PRH-CSS-IMPORT-ORDER-WRONG':
+      return 'Re-order @import statements so the cascade reads basestyles → complex (when present) → bespoke (when present) → mediaquery (always last).';
+    case 'PRH-CSS-CLASS-NAME-HYPHEN':
+      return 'Replace hyphenated class names with underscored equivalents in your publisher stylesheets and the XHTML class="…" attributes that reference them. Vendor / utility prefixes (tw-, bs-, ng-) are exempt.';
+    case 'PRH-CSS-PER-PARAGRAPH-FONT':
+      return 'Move the primary font declaration onto <body>; isolate any genuine font overrides into bespoke.css scoped narrowly. Per-paragraph fonts break Kindle font-customisation.';
+    case 'PRH-CSS-INLINE-STYLE-AT-SCALE':
+      return 'Lift inline style="…" declarations into CSS classes in basestyles.css / bespoke.css. PRH allows one demonstration inline style per book; book-wide patterns must be classed.';
+    default:
+      return '';
+  }
+}

--- a/src/services/epub/profiles/prh-uk/validators/types.ts
+++ b/src/services/epub/profiles/prh-uk/validators/types.ts
@@ -53,3 +53,24 @@ export interface PrhNavInput extends PrhValidatorInput {
   /** Path of the nav doc inside the zip, or null. */
   navPath: string | null;
 }
+
+/** One CSS stylesheet's content + path. */
+export interface PrhCssFile {
+  /** Zip-relative path (e.g. 'EPUB/styles/basestyles.css'). */
+  path: string;
+  content: string;
+  /**
+   * Whether this stylesheet is part of the publisher's own /styles
+   * directory (vs. a vendor/utility file vendored into the EPUB).
+   * Class-name rules apply only to publisher stylesheets so we don't
+   * false-flag third-party utility frameworks (TailwindCSS,
+   * Bootstrap, NG-style) that the publisher may have embedded.
+   */
+  isPublisherOwned: boolean;
+}
+
+/** Inputs the CSS-conventions validator reads. */
+export interface PrhCssConventionsInput extends PrhPerXhtmlInput {
+  /** Every CSS file referenced by the manifest. */
+  cssFiles: PrhCssFile[];
+}

--- a/tests/unit/services/epub/profiles/prh-uk/validators/css-conventions-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/css-conventions-validator.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhCssConventions } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/css-conventions-validator';
+import type {
+  PrhCssFile,
+  PrhXhtmlFile,
+} from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function cssFile(path: string, content: string, isPublisherOwned = true): PrhCssFile {
+  return { path, content, isPublisherOwned };
+}
+
+function xhtmlFile(path: string, body: string): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title></head>
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+function input(opts: { cssFiles?: PrhCssFile[]; xhtmlFiles?: PrhXhtmlFile[] } = {}) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles: opts.xhtmlFiles ?? [],
+    cssFiles: opts.cssFiles ?? [],
+  };
+}
+
+describe('validatePrhCssConventions — PRH-CSS-BASESTYLES-RENAMED', () => {
+  it('emits when no basestyles.css is present', () => {
+    const issues = validatePrhCssConventions(
+      input({ cssFiles: [cssFile('EPUB/styles/core.css', 'body{}')] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-BASESTYLES-RENAMED')).toBe(true);
+  });
+
+  it('does NOT emit when basestyles.css exists', () => {
+    const issues = validatePrhCssConventions(
+      input({ cssFiles: [cssFile('EPUB/styles/basestyles.css', 'body{}')] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-BASESTYLES-RENAMED')).toBe(false);
+  });
+
+  it('is case-insensitive on the filename', () => {
+    const issues = validatePrhCssConventions(
+      input({ cssFiles: [cssFile('EPUB/styles/BaseStyles.css', 'body{}')] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-BASESTYLES-RENAMED')).toBe(false);
+  });
+});
+
+describe('validatePrhCssConventions — PRH-CSS-IMPORT-ORDER-WRONG', () => {
+  it('passes when @imports follow the canonical order', () => {
+    const css = `
+@import url("basestyles.css");
+@import url("complex.css");
+@import url("bespoke.css");
+@import url("mediaquery.css");`;
+    const issues = validatePrhCssConventions(
+      input({ cssFiles: [cssFile('EPUB/styles/basestyles.css', css)] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-IMPORT-ORDER-WRONG')).toBe(false);
+  });
+
+  it('passes when intermediate stages are skipped (basestyles → mediaquery)', () => {
+    const css = `
+@import "basestyles.css";
+@import "mediaquery.css";`;
+    const issues = validatePrhCssConventions(
+      input({ cssFiles: [cssFile('EPUB/styles/basestyles.css', css)] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-IMPORT-ORDER-WRONG')).toBe(false);
+  });
+
+  it('emits when mediaquery is imported BEFORE bespoke', () => {
+    const css = `
+@import "basestyles.css";
+@import "mediaquery.css";
+@import "bespoke.css";`;
+    const issues = validatePrhCssConventions(
+      input({ cssFiles: [cssFile('EPUB/styles/basestyles.css', css)] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-IMPORT-ORDER-WRONG')).toBe(true);
+  });
+
+  it('ignores unknown stylesheet names alongside canonical ones', () => {
+    const css = `
+@import "basestyles.css";
+@import "publisher_extras.css";
+@import "mediaquery.css";`;
+    const issues = validatePrhCssConventions(
+      input({ cssFiles: [cssFile('EPUB/styles/basestyles.css', css)] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-IMPORT-ORDER-WRONG')).toBe(false);
+  });
+
+  it('passes when there are zero @import statements', () => {
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [cssFile('EPUB/styles/basestyles.css', 'p { color: black; }')],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-IMPORT-ORDER-WRONG')).toBe(false);
+  });
+});
+
+describe('validatePrhCssConventions — PRH-CSS-CLASS-NAME-HYPHEN', () => {
+  it('emits for hyphenated class selectors in publisher stylesheets', () => {
+    const css = `.first-para { text-indent: 0; }`;
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/styles/bespoke.css', css),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-CLASS-NAME-HYPHEN')).toBe(true);
+  });
+
+  it('does NOT emit for underscored class selectors', () => {
+    const css = `.first_para { text-indent: 0; } .section_break { margin: 1em; }`;
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/styles/bespoke.css', css),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-CLASS-NAME-HYPHEN')).toBe(false);
+  });
+
+  it('exempts vendor prefixes (tw-, bs-, ng-)', () => {
+    const css = `.tw-flex { display: flex; } .bs-btn { padding: 8px; } .ng-cloak {}`;
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/styles/bespoke.css', css),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-CLASS-NAME-HYPHEN')).toBe(false);
+  });
+
+  it('ignores hyphenated classes declared in non-publisher stylesheets', () => {
+    const css = `.btn-primary {} .modal-header {}`;
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/vendor/bootstrap.css', css, /* isPublisherOwned */ false),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-CLASS-NAME-HYPHEN')).toBe(false);
+  });
+
+  it('does NOT emit for single-token classes without hyphens', () => {
+    const css = `.intro {} .chapter {} .footer {}`;
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/styles/bespoke.css', css),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-CLASS-NAME-HYPHEN')).toBe(false);
+  });
+});
+
+describe('validatePrhCssConventions — PRH-CSS-PER-PARAGRAPH-FONT', () => {
+  it('emits when a font-family class is used on 10+ paragraphs', () => {
+    const css = `.scriptface { font-family: "Snell Roundhand", cursive; }`;
+    const paras = Array.from({ length: 12 }, () => '<p class="scriptface">x</p>').join('');
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/styles/bespoke.css', css),
+        ],
+        xhtmlFiles: [xhtmlFile('ch1.xhtml', paras)],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-PER-PARAGRAPH-FONT')).toBe(true);
+  });
+
+  it('does NOT emit when the font class is used on fewer than 10 paragraphs', () => {
+    const css = `.scriptface { font-family: cursive; }`;
+    const paras = Array.from({ length: 5 }, () => '<p class="scriptface">x</p>').join('');
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/styles/bespoke.css', css),
+        ],
+        xhtmlFiles: [xhtmlFile('ch1.xhtml', paras)],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-PER-PARAGRAPH-FONT')).toBe(false);
+  });
+
+  it('does NOT emit when the font class is only applied to non-<p> elements', () => {
+    const css = `.scriptface { font-family: cursive; }`;
+    const body = Array.from({ length: 20 }, () => '<span class="scriptface">x</span>').join('');
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/styles/bespoke.css', css),
+        ],
+        xhtmlFiles: [xhtmlFile('ch1.xhtml', body)],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-PER-PARAGRAPH-FONT')).toBe(false);
+  });
+
+  it('aggregates paragraph counts across multiple XHTML files', () => {
+    const css = `.scriptface { font-family: cursive; }`;
+    const file1 = Array.from({ length: 6 }, () => '<p class="scriptface">x</p>').join('');
+    const file2 = Array.from({ length: 6 }, () => '<p class="scriptface">y</p>').join('');
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/styles/bespoke.css', css),
+        ],
+        xhtmlFiles: [xhtmlFile('ch1.xhtml', file1), xhtmlFile('ch2.xhtml', file2)],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-PER-PARAGRAPH-FONT')).toBe(true);
+  });
+
+  it('handles the class appearing alongside other tokens in class="..."', () => {
+    const css = `.scriptface { font-family: cursive; }`;
+    const paras = Array.from(
+      { length: 12 },
+      () => '<p class="indent scriptface no_break">x</p>',
+    ).join('');
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/styles/bespoke.css', css),
+        ],
+        xhtmlFiles: [xhtmlFile('ch1.xhtml', paras)],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-PER-PARAGRAPH-FONT')).toBe(true);
+  });
+});
+
+describe('validatePrhCssConventions — PRH-CSS-INLINE-STYLE-AT-SCALE', () => {
+  it('emits when 100+ inline styles exist across all XHTML', () => {
+    const paras = Array.from(
+      { length: 110 },
+      () => '<p style="color: red">x</p>',
+    ).join('');
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [cssFile('EPUB/styles/basestyles.css', 'body{}')],
+        xhtmlFiles: [xhtmlFile('ch1.xhtml', paras)],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-INLINE-STYLE-AT-SCALE')).toBe(true);
+  });
+
+  it('does NOT emit when inline-style count is below threshold', () => {
+    const paras = Array.from(
+      { length: 50 },
+      () => '<p style="color: red">x</p>',
+    ).join('');
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [cssFile('EPUB/styles/basestyles.css', 'body{}')],
+        xhtmlFiles: [xhtmlFile('ch1.xhtml', paras)],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-INLINE-STYLE-AT-SCALE')).toBe(false);
+  });
+
+  it('aggregates inline styles across multiple files', () => {
+    const partA = Array.from({ length: 60 }, () => '<p style="color: red">x</p>').join('');
+    const partB = Array.from({ length: 60 }, () => '<p style="color: blue">y</p>').join('');
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [cssFile('EPUB/styles/basestyles.css', 'body{}')],
+        xhtmlFiles: [xhtmlFile('a.xhtml', partA), xhtmlFile('b.xhtml', partB)],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-INLINE-STYLE-AT-SCALE')).toBe(true);
+  });
+
+  it('does NOT false-match data-style="…" attributes', () => {
+    const paras = Array.from(
+      { length: 110 },
+      () => '<p data-style="emphasis">x</p>',
+    ).join('');
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [cssFile('EPUB/styles/basestyles.css', 'body{}')],
+        xhtmlFiles: [xhtmlFile('ch1.xhtml', paras)],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-INLINE-STYLE-AT-SCALE')).toBe(false);
+  });
+});
+
+describe('validatePrhCssConventions — issue shape', () => {
+  it('carries the registered severity and a non-empty suggestion', () => {
+    const issues = validatePrhCssConventions(
+      input({ cssFiles: [cssFile('EPUB/styles/core.css', 'body{}')] }),
+    );
+    const basestylesIssue = issues.find((i) => i.code === 'PRH-CSS-BASESTYLES-RENAMED');
+    expect(basestylesIssue?.severity).toBe('serious');
+    expect(basestylesIssue?.suggestion.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it('emits zero issues for a fully conformant EPUB', () => {
+    const baseCss = `
+@import url("complex.css");
+@import url("bespoke.css");
+@import url("mediaquery.css");
+body { font-family: "Garamond", serif; }
+.first_para { text-indent: 0; }
+.section_break { margin: 1em; }`;
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', baseCss),
+          cssFile('EPUB/styles/bespoke.css', '.indent_topspace {}'),
+        ],
+        xhtmlFiles: [xhtmlFile('ch1.xhtml', '<p>Clean paragraph.</p>')],
+      }),
+    );
+    expect(issues).toEqual([]);
+  });
+});

--- a/tests/unit/services/epub/profiles/prh-uk/validators/css-conventions-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/css-conventions-validator.test.ts
@@ -51,6 +51,13 @@ describe('validatePrhCssConventions — PRH-CSS-BASESTYLES-RENAMED', () => {
     );
     expect(issues.some((i) => i.code === 'PRH-CSS-BASESTYLES-RENAMED')).toBe(false);
   });
+
+  it('emits when basestyles.css exists OUTSIDE /styles', () => {
+    const issues = validatePrhCssConventions(
+      input({ cssFiles: [cssFile('EPUB/basestyles.css', 'body{}')] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-CSS-BASESTYLES-RENAMED')).toBe(true);
+  });
 });
 
 describe('validatePrhCssConventions — PRH-CSS-IMPORT-ORDER-WRONG', () => {
@@ -235,6 +242,25 @@ describe('validatePrhCssConventions — PRH-CSS-PER-PARAGRAPH-FONT', () => {
       }),
     );
     expect(issues.some((i) => i.code === 'PRH-CSS-PER-PARAGRAPH-FONT')).toBe(true);
+  });
+
+  it('extracts every class from a grouped selector (.a, .b { font-family })', () => {
+    const css = `.scriptface_a, .scriptface_b { font-family: cursive; }`;
+    const aParas = Array.from({ length: 6 }, () => '<p class="scriptface_a">x</p>').join('');
+    const bParas = Array.from({ length: 6 }, () => '<p class="scriptface_b">y</p>').join('');
+    const issues = validatePrhCssConventions(
+      input({
+        cssFiles: [
+          cssFile('EPUB/styles/basestyles.css', 'body{}'),
+          cssFile('EPUB/styles/bespoke.css', css),
+        ],
+        xhtmlFiles: [xhtmlFile('ch1.xhtml', aParas + bParas)],
+      }),
+    );
+    const fontIssue = issues.find((i) => i.code === 'PRH-CSS-PER-PARAGRAPH-FONT');
+    expect(fontIssue).toBeDefined();
+    expect(fontIssue?.message).toMatch(/scriptface_a/);
+    expect(fontIssue?.message).toMatch(/scriptface_b/);
   });
 
   it('handles the class appearing alongside other tokens in class="..."', () => {


### PR DESCRIPTION
## Summary

First PR of P6 (PRH UK depth rules). Adds a detect-only validator for the canonical PRH stylesheet stack defined in Technical Guide §15 + the Style Guide CSS conventions.

Five new codes, all P3 (advisory — does not block deliverable export):

| Code | Severity | Detects |
|---|---|---|
| \`PRH-CSS-BASESTYLES-RENAMED\` | serious | No file named \`basestyles.css\` under \`/styles\` |
| \`PRH-CSS-IMPORT-ORDER-WRONG\` | moderate | \`@import\` cascade deviates from base → complex → bespoke → mediaquery |
| \`PRH-CSS-CLASS-NAME-HYPHEN\` | minor | Publisher-owned class uses \`-\` instead of \`_\` (vendor prefixes \`tw-\`, \`bs-\`, \`ng-\` and non-publisher stylesheets exempt) |
| \`PRH-CSS-PER-PARAGRAPH-FONT\` | moderate | A \`font-family\` class is applied to 10+ \`<p>\` elements (breaks Kindle font customisation) |
| \`PRH-CSS-INLINE-STYLE-AT-SCALE\` | serious | 100+ inline \`style="…"\` attributes across all XHTML |

Detect-only — auto-remediation defers to publisher tooling because renaming \`basestyles.css\`, re-ordering \`@imports\`, or refactoring class names cascades through the publisher's dev pipeline.

PRH-UK gated at medium-or-high confidence (same gate as the other P3 markup-hygiene validators).

Conformance report wiring:
- \`TIER_CODE_COUNT.P3\` bumped 16 → 21
- \`priorityTierForCode\` maps \`PRH-CSS-*\` → P3

## Test plan
- [x] 24 new unit tests cover all 5 rules (happy path + the false-positive edge cases: vendor classes, non-publisher stylesheets, single-token classes, data-style attributes, conformant EPUB)
- [x] Existing 19 conformance-report tests still pass (no behaviour change there beyond the tier count bump)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean (\`--max-warnings 0\`)
- [ ] Staging smoke: re-audit any PRH-UK book and confirm \`PRH-CSS-*\` codes surface as P3 advisory issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended PRH UK validation with CSS convention checks: stylesheet naming, import order, class-name style, per-paragraph font usage, and inline-style volume.
* **Updates**
  * Added new PRH issue codes for CSS conventions and mapped CSS-related findings to the P3 priority tier.
* **Tests**
  * Added comprehensive unit tests covering detection rules, thresholds, exemptions, and overall pass/fail behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/390)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->