### PR TITLE
fix(spike): PDFBox spike Dockerfile + PDFBox 3.x API fixes

### DIFF
--- a/spikes/pdfbox-write/Dockerfile
+++ b/spikes/pdfbox-write/Dockerfile
@@ -31,33 +31,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /tmp/aws /tmp/aws.zip \
     && rm -rf /var/lib/apt/lists/*
 
-# veraPDF — installed from the same official tarball the main backend
-# image uses (matches /opt/verapdf/verapdf layout). The argument-style
-# installer needs xvfb/headless awareness, so use the package's own
-# installer-with-script payload.
-RUN mkdir -p /opt/verapdf \
-    && curl -fsSL "https://software.verapdf.org/rel/1.26/verapdf-greenfield-1.26.2-installer.zip" -o /tmp/verapdf.zip \
+# veraPDF — aligned with scripts/install-verapdf.sh in the main backend
+# image: use the rolling installer URL and the bundled verapdf-install
+# shell wrapper (rather than calling the IzPack jar directly), so panel
+# IDs and pack indices stay in sync with the installer's own assumptions.
+COPY verapdf-auto-install.xml /tmp/verapdf-auto-install.xml
+RUN set -eux \
+    && curl -fsSL --retry 3 "https://software.verapdf.org/rel/verapdf-installer.zip" -o /tmp/verapdf.zip \
     && unzip -q /tmp/verapdf.zip -d /tmp/verapdf-installer \
-    && INSTALLER_JAR=$(find /tmp/verapdf-installer -name 'verapdf-installer.jar' | head -1) \
-    && cat > /tmp/auto-install.xml <<'EOF'
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<AutomatedInstallation langpack="eng">
-    <com.izforge.izpack.panels.target.TargetPanel id="install.dir">
-        <installpath>/opt/verapdf</installpath>
-    </com.izforge.izpack.panels.target.TargetPanel>
-    <com.izforge.izpack.panels.packs.PacksPanel id="sdk.pack.select">
-        <pack index="0" name="veraPDF GUI" selected="true"/>
-        <pack index="1" name="veraPDF Mac and *nix Scripts" selected="true"/>
-        <pack index="2" name="veraPDF Validation model" selected="true"/>
-        <pack index="3" name="veraPDF Documentation" selected="false"/>
-        <pack index="4" name="veraPDF Sample Plugins" selected="false"/>
-    </com.izforge.izpack.panels.packs.PacksPanel>
-    <com.izforge.izpack.panels.install.InstallPanel id="install"/>
-    <com.izforge.izpack.panels.finish.FinishPanel id="finish"/>
-</AutomatedInstallation>
-EOF
-    && java -jar "$INSTALLER_JAR" /tmp/auto-install.xml \
-    && rm -rf /tmp/verapdf-installer /tmp/verapdf.zip /tmp/auto-install.xml
+    && VERAPDF_DIR=$(ls -d /tmp/verapdf-installer/verapdf-greenfield-*/ | head -1) \
+    && test -n "$VERAPDF_DIR" || { echo "verapdf-greenfield-* dir not found in installer zip"; find /tmp/verapdf-installer -maxdepth 2 -type d; exit 1; } \
+    && "$VERAPDF_DIR/verapdf-install" /tmp/verapdf-auto-install.xml \
+    && /opt/verapdf/verapdf --version \
+    && rm -rf /tmp/verapdf-installer /tmp/verapdf.zip /tmp/verapdf-auto-install.xml
 
 ENV VERAPDF_PATH=/opt/verapdf/verapdf
 

--- a/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/RunSpike.java
+++ b/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/RunSpike.java
@@ -159,17 +159,22 @@ public final class RunSpike {
 
     static Validation runVerapdf(File pdf) {
         String bin = System.getenv().getOrDefault("VERAPDF_PATH", "C:/verapdf/verapdf.bat");
+        // veraPDF can take 1–3 minutes on multi-megabyte tagged PDFs (PDFBox
+        // saves richer files than pikepdf, so 60s isn't enough). Override
+        // via VERAPDF_TIMEOUT_SEC for outlier docs.
+        int timeoutSec = Integer.parseInt(
+            System.getenv().getOrDefault("VERAPDF_TIMEOUT_SEC", "600"));
         Validation v = new Validation();
         v.failures = new ArrayList<>();
         try {
             ProcessBuilder pb = new ProcessBuilder(bin, "--flavour", "ua1", pdf.getAbsolutePath());
             pb.redirectErrorStream(true);
             Process p = pb.start();
-            boolean finished = p.waitFor(60, TimeUnit.SECONDS);
+            boolean finished = p.waitFor(timeoutSec, TimeUnit.SECONDS);
             if (!finished) {
                 p.destroyForcibly();
                 v.passed = false;
-                v.failures.add("Validation timed out");
+                v.failures.add("Validation timed out after " + timeoutSec + "s");
                 return v;
             }
             String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);

--- a/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/WriteTaggedPdf.java
+++ b/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/WriteTaggedPdf.java
@@ -91,8 +91,12 @@ public final class WriteTaggedPdf {
             catalog.setLanguage("en-US");
 
             // 3) ViewerPreferences/DisplayDocTitle = true (7.1 test 10).
-            PDViewerPreferences viewerPrefs = new PDViewerPreferences(new COSDictionary());
-            viewerPrefs.setShowTitleBar(true);
+            //    The high-level setter on PDViewerPreferences was renamed
+            //    between PDFBox 2.x and 3.x; set the COS field directly to
+            //    stay version-agnostic.
+            COSDictionary viewerPrefsDict = new COSDictionary();
+            viewerPrefsDict.setBoolean(COSName.getPDFName("DisplayDocTitle"), true);
+            PDViewerPreferences viewerPrefs = new PDViewerPreferences(viewerPrefsDict);
             catalog.setViewerPreferences(viewerPrefs);
 
             // 4) Document title — required when DisplayDocTitle is true.

--- a/spikes/pdfbox-write/verapdf-auto-install.xml
+++ b/spikes/pdfbox-write/verapdf-auto-install.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  IzPack automated-install descriptor for veraPDF Greenfield.
+
+  Aligned with scripts/install-verapdf.sh (the production backend image's
+  installer). Panel IDs use underscores (not dots) and the pack list
+  matches the 1.28.x installer's resources/packs/ entries. If a future
+  veraPDF release renumbers packs, regenerate by running the installer
+  interactively once and copying its auto-install.xml.
+-->
+<AutomatedInstallation langpack="eng">
+    <com.izforge.izpack.panels.htmlhello.HTMLHelloPanel id="welcome"/>
+    <com.izforge.izpack.panels.target.TargetPanel id="install_dir">
+        <installpath>/opt/verapdf</installpath>
+    </com.izforge.izpack.panels.target.TargetPanel>
+    <com.izforge.izpack.panels.packs.PacksPanel id="sdk_pack_select">
+        <pack index="0" name="veraPDF GUI" selected="true"/>
+        <pack index="1" name="veraPDF Mac and *nix Scripts" selected="true"/>
+        <pack index="2" name="veraPDF Batch files" selected="false"/>
+        <pack index="3" name="veraPDF Validation model" selected="true"/>
+        <pack index="4" name="veraPDF Documentation" selected="false"/>
+        <pack index="5" name="veraPDF Sample Plugins" selected="false"/>
+    </com.izforge.izpack.panels.packs.PacksPanel>
+    <com.izforge.izpack.panels.install.InstallPanel id="install"/>
+    <com.izforge.izpack.panels.finish.FinishPanel id="finish"/>
+</AutomatedInstallation>


### PR DESCRIPTION
## Summary

Follow-up to #389 — three blockers found during the local Docker build for Issue #388:

1. **Heredoc-in-RUN broke Docker's parser.** Inlining a multi-line XML via \`cat > … <<'EOF' … EOF\` inside a \`RUN\` with \`\\` continuations is unsupported. Extracted to \`verapdf-auto-install.xml\` and \`COPY\`'d in.
2. **veraPDF installer path wrong.** The 1.26.2 zip contains \`verapdf-izpack-installer-*.jar\` and ships a \`verapdf-install\` wrapper script. Aligned with the main backend's proven \`scripts/install-verapdf.sh\`: rolling installer URL + shell wrapper + correct panel IDs/pack indices.
3. **\`PDViewerPreferences.setShowTitleBar(boolean)\` removed in PDFBox 3.x.** Setting \`DisplayDocTitle\` directly on the COS dict instead — same version-agnostic pattern we used for RoleMap.

## Verification

- [x] \`docker build\` completes locally end-to-end (~30 s warm cache)
- [x] veraPDF smoke test inside image: \`/opt/verapdf/verapdf --version\` → 1.30.1
- [x] Spike JAR runs, entrypoint exits cleanly on missing-bundle path
- [ ] End-to-end run on the 20-doc bundle (started in parallel — results land in a follow-up commit / new CalibrationRun row)

## Why this isn't squashed into #389

#389 already merged. Splitting the build fixes into their own PR keeps the change set focused and reviewable — particularly the proof-by-build that the spike scaffolding actually compiles + runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Viewer preferences adjusted for broader PDF viewer compatibility.
  * Increased and configurable veraPDF validation timeout to avoid false failures on larger files.

* **Chores**
  * Dockerized veraPDF installation updated to use the rolling installer for fresher releases.
  * Added an automated installer configuration to standardize veraPDF deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/391)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->