### PR TITLE
feat(prh): file/dir/size validator (P6/PR2)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -543,6 +543,48 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'EPUB contains 100+ inline style="…" attributes across all XHTML — book-wide pattern of inline styles; PRH demonstration carve-out (one per book) does not apply at this scale',
   },
+
+  // ── File / directory / size (P6/PR2) ──────────────────────────────────
+  // Publisher-gated and detect-only. Per Technical Guide §3 + §15.
+  // Renaming files / restructuring directories cascades through the
+  // manifest, hrefs and fragment identifiers, so auto-remediation is
+  // unsafe; surface the finding and let the operator fix in their
+  // authoring tool.
+  'PRH-FILE-XHTML-OVERSIZE': {
+    code: 'PRH-FILE-XHTML-OVERSIZE',
+    severity: 'serious',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'XHTML chapter exceeds 600KB — PRH requires chapter splits at section boundaries to keep Kindle / older e-readers responsive (Technical Guide §3)',
+  },
+  'PRH-FILE-PLATE-OVERSIZE': {
+    code: 'PRH-FILE-PLATE-OVERSIZE',
+    severity: 'serious',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Plate XHTML exceeds 11MB — too large for Kindle ET / KFX rendering; split image-heavy plate sections',
+  },
+  'PRH-DIR-LAYOUT-NONSTANDARD': {
+    code: 'PRH-DIR-LAYOUT-NONSTANDARD',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'EPUB content exists outside the canonical /xhtml /images /fonts /styles directory layout — PRH Technical Guide §3 requires resources under fixed sub-directories so reading systems can resolve cross-file references reliably',
+  },
+  'PRH-FILE-NAMING-NONSTANDARD': {
+    code: 'PRH-FILE-NAMING-NONSTANDARD',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Filename contains uppercase / multiple dots / disallowed characters — PRH requires lowercase alphanumeric + underscore + hyphen with a single dot before the extension',
+  },
+  'PRH-FILE-FIXED-NAME-MISSING': {
+    code: 'PRH-FILE-FIXED-NAME-MISSING',
+    severity: 'serious',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'EPUB is missing a required fixed-name file (package.opf / toc.ncx when EPUB2-compat / nav.xhtml / cover.<ext>) — Kindle popup links, NCX fallback navigation and the cover-image surface all resolve by canonical filename',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/prh-conformance-report.service.ts
+++ b/src/services/acr/prh-conformance-report.service.ts
@@ -261,8 +261,9 @@ const TIER_CODE_COUNT: Record<PriorityTier, number> = {
   // P2 — copyright (8) + brand (3) + title (4) + socials (5) + order (5) = 25
   P2: 25,
   // P3 — body epub:type + doc-* ARIA (8) + forbidden (3) + notes/pagebreak (2)
-  // + text heuristics (3) + CSS conventions (5, P6/PR1) = 21
-  P3: 21,
+  // + text heuristics (3) + CSS conventions (5, P6/PR1) + file/dir/size
+  // (5, P6/PR2) = 26
+  P3: 26,
   // P4 has no PRH-* codes (AI policy gate + cover-alt template were
   // implemented as behaviors, not new codes). 0 to keep the type happy.
   P4: 0,
@@ -294,6 +295,8 @@ function priorityTierForCode(code: string): PriorityTier | null {
   if (code.startsWith('PRH-MARKUP-')) return 'P3';
   if (code.startsWith('PRH-ARIA-')) return 'P3';
   if (code.startsWith('PRH-CSS-')) return 'P3';
+  if (code.startsWith('PRH-FILE-')) return 'P3';
+  if (code.startsWith('PRH-DIR-')) return 'P3';
   if (code === 'PRH-BODY-HAS-ARIA') return 'P3';
   if (code === 'PRH-PAGEBREAK-MALFORMED') return 'P3';
   if (code === 'PRH-FOOTNOTE-ID-MISMATCH') return 'P3';

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -33,9 +33,15 @@ import { validatePrhInlineLang } from './validators/inline-lang-validator';
 import { validatePrhHashtags } from './validators/hashtag-validator';
 import { validatePrhAcronyms } from './validators/acronym-validator';
 import { validatePrhCssConventions } from './validators/css-conventions-validator';
+import { validatePrhFileLayout } from './validators/file-layout-validator';
 import { getImprintRules } from './imprints';
 import type { PublisherProfile } from '../types';
-import type { PrhValidatorIssue, PrhXhtmlFile, PrhCssFile } from './validators/types';
+import type {
+  PrhValidatorIssue,
+  PrhXhtmlFile,
+  PrhCssFile,
+  PrhManifestEntry,
+} from './validators/types';
 
 /**
  * Run all PRH UK validators against an EPUB buffer.
@@ -65,6 +71,9 @@ export async function runPrhUkValidators(
     const navDoc = await readNavDoc(zip, opf.path, opf.content);
     const xhtmlFiles = await readAllXhtml(zip);
     const cssFiles = await readAllCss(zip, opf.path, opf.content);
+    const manifestEntries = await readManifestEntries(zip, opf.path, opf.content);
+    const zipPaths = Object.keys(zip.files);
+    const requiresNcx = /\<spine\b[^>]*\btoc\s*=\s*["']ncx["']/i.test(opf.content);
     const bookTitle = readDcTitle(opf.content);
 
     const opfInput = { opfContent: opf.content, opfPath: opf.path };
@@ -81,6 +90,12 @@ export async function runPrhUkValidators(
     const cssInput = {
       ...perXhtmlInput,
       cssFiles,
+    };
+    const fileLayoutInput = {
+      ...opfInput,
+      manifestEntries,
+      zipPaths,
+      requiresNcx,
     };
 
     const issues: PrhValidatorIssue[] = [
@@ -113,6 +128,7 @@ export async function runPrhUkValidators(
         ...validatePrhHashtags(perXhtmlInput),
         ...validatePrhAcronyms(perXhtmlInput),
         ...validatePrhCssConventions(cssInput),
+        ...validatePrhFileLayout(fileLayoutInput),
       );
     }
 
@@ -191,6 +207,49 @@ async function readNavDoc(
     }
   }
   return null;
+}
+
+/**
+ * Walk the OPF manifest and resolve every item into a
+ * `PrhManifestEntry`. Sizes come from JSZip's already-loaded entry
+ * table when available (we use `async('uint8array').then(u => u.length)`
+ * because JSZip doesn't expose a stable public sync size accessor;
+ * decompression is one-time and cheap on the typical EPUB).
+ */
+async function readManifestEntries(
+  zip: JSZip,
+  opfPath: string,
+  opfContent: string,
+): Promise<PrhManifestEntry[]> {
+  const manifestMatch = opfContent.match(/<manifest\b[^>]*>([\s\S]*?)<\/manifest>/i);
+  if (!manifestMatch) return [];
+
+  const out: PrhManifestEntry[] = [];
+  for (const item of manifestMatch[1].matchAll(/<item\b([^>]*)\/?>/gi)) {
+    const attrs = item[1];
+    const hrefMatch = attrs.match(/\bhref\s*=\s*["']([^"']+)["']/i);
+    const mediaTypeMatch = attrs.match(/\bmedia-type\s*=\s*["']([^"']+)["']/i);
+    if (!hrefMatch || !mediaTypeMatch) continue;
+    const propsMatch = attrs.match(/\bproperties\s*=\s*["']([^"']+)["']/i);
+    const itemPath = resolveOpfRelative(opfPath, hrefMatch[1]);
+    let sizeBytes: number | null = null;
+    const zipEntry = zip.file(itemPath);
+    if (zipEntry) {
+      try {
+        const u = await zipEntry.async('uint8array');
+        sizeBytes = u.length;
+      } catch {
+        sizeBytes = null;
+      }
+    }
+    out.push({
+      path: itemPath,
+      mediaType: mediaTypeMatch[1].toLowerCase(),
+      properties: propsMatch ? propsMatch[1].toLowerCase().split(/\s+/).filter(Boolean) : [],
+      sizeBytes,
+    });
+  }
+  return out;
 }
 
 /**

--- a/src/services/epub/profiles/prh-uk/validators/file-layout-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/file-layout-validator.ts
@@ -220,33 +220,35 @@ function findMissingFixedNames(input: PrhFileLayoutInput): string[] {
     missing.push(`package.opf (actual: ${input.opfPath})`);
   }
 
-  // nav.xhtml — the manifest item with properties="nav" must have
-  // basename nav.xhtml.
-  const navEntry = input.manifestEntries.find((e) => e.properties.includes('nav'));
-  if (navEntry) {
-    if (basename(navEntry.path).toLowerCase() !== 'nav.xhtml') {
-      missing.push(`nav.xhtml (actual: ${navEntry.path})`);
-    }
-  } else {
+  // nav.xhtml — pass if ANY manifest item with properties="nav" has
+  // basename nav.xhtml. EPUB 3 specifies exactly one such item, but a
+  // non-conformant input could carry more than one; matching on "any"
+  // avoids order-dependent false negatives.
+  const navEntries = input.manifestEntries.filter((e) => e.properties.includes('nav'));
+  if (navEntries.length === 0) {
     missing.push('nav.xhtml (no manifest item with properties="nav")');
+  } else if (!navEntries.some((e) => basename(e.path).toLowerCase() === 'nav.xhtml')) {
+    missing.push(`nav.xhtml (actual: ${navEntries[0].path})`);
   }
 
   // toc.ncx — only when EPUB2 compat is in use.
   if (input.requiresNcx) {
-    const ncxEntry = input.manifestEntries.find((e) => e.mediaType === 'application/x-dtbncx+xml');
-    if (!ncxEntry) {
+    const ncxEntries = input.manifestEntries.filter(
+      (e) => e.mediaType === 'application/x-dtbncx+xml',
+    );
+    if (ncxEntries.length === 0) {
       missing.push('toc.ncx (spine declares toc="ncx" but no NCX manifest item)');
-    } else if (basename(ncxEntry.path).toLowerCase() !== 'toc.ncx') {
-      missing.push(`toc.ncx (actual: ${ncxEntry.path})`);
+    } else if (!ncxEntries.some((e) => basename(e.path).toLowerCase() === 'toc.ncx')) {
+      missing.push(`toc.ncx (actual: ${ncxEntries[0].path})`);
     }
   }
 
   // cover.<ext> — image (via properties="cover-image").
-  const coverImage = input.manifestEntries.find((e) => e.properties.includes('cover-image'));
-  if (!coverImage) {
+  const coverImages = input.manifestEntries.filter((e) => e.properties.includes('cover-image'));
+  if (coverImages.length === 0) {
     missing.push('cover.<ext> (no manifest item with properties="cover-image")');
-  } else if (!/^cover\.[a-z0-9]+$/i.test(basename(coverImage.path))) {
-    missing.push(`cover.<ext> image (actual: ${coverImage.path})`);
+  } else if (!coverImages.some((e) => /^cover\.[a-z0-9]+$/i.test(basename(e.path)))) {
+    missing.push(`cover.<ext> image (actual: ${coverImages[0].path})`);
   }
 
   return missing;

--- a/src/services/epub/profiles/prh-uk/validators/file-layout-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/file-layout-validator.ts
@@ -1,0 +1,293 @@
+/**
+ * PRH UK file / directory / size validator (P6/PR2).
+ *
+ * Per Technical Guide §3 + §15:
+ *   - XHTML chapter files must be ≤ 600KB (split at section
+ *     boundaries above that).
+ *   - Plate XHTML (image-heavy spreads) must be ≤ 11MB.
+ *   - Required subdirectories: `/xhtml`, `/images`, `/fonts`,
+ *     `/styles`. Optional `/media`, `/scripts`.
+ *   - Filenames are lowercase, alphanumeric + `_` + `-`, with a
+ *     single `.` before the extension.
+ *   - Fixed names: `package.opf`, `toc.ncx` (EPUB2-compat),
+ *     `nav.xhtml`, `cover.<ext>`, `basestyles.css`.
+ *
+ * Detect-only — renaming a file cascades through the manifest,
+ * hrefs and fragment identifiers, and is operator-confirmed only.
+ *
+ * Note: `basestyles.css` presence is already covered by
+ * `PRH-CSS-BASESTYLES-RENAMED` (P6/PR1). This validator omits it
+ * from the fixed-name check to avoid double-counting.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type {
+  PrhValidatorIssue,
+  PrhFileLayoutInput,
+  PrhManifestEntry,
+} from './types';
+
+const XHTML_OVERSIZE_LIMIT = 600 * 1024;
+const PLATE_OVERSIZE_LIMIT = 11 * 1024 * 1024;
+const XHTML_MEDIA_TYPE = 'application/xhtml+xml';
+
+/**
+ * Filenames in a manifested EPUB that should NOT be scanned for
+ * naming-convention violations because they're metadata or
+ * boilerplate that lives at the EPUB root (where PRH's lowercase
+ * rule doesn't apply by convention).
+ */
+const NAMING_EXCEPTIONS = new Set([
+  'mimetype',
+  'META-INF/container.xml',
+  'META-INF/encryption.xml',
+  'META-INF/signatures.xml',
+  'META-INF/metadata.xml',
+  'META-INF/rights.xml',
+  'META-INF/manifest.xml',
+]);
+
+/** Filename pattern: lowercase alphanumeric + `_` + `-`, single `.` before extension. */
+const VALID_FILENAME = /^[a-z0-9][a-z0-9_-]*\.[a-z0-9]+$/;
+
+export function validatePrhFileLayout(input: PrhFileLayoutInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  // 1. XHTML / plate oversize. Iterate XHTML manifest entries and
+  //    branch on plate-ness via filename heuristic.
+  for (const entry of input.manifestEntries) {
+    if (entry.mediaType !== XHTML_MEDIA_TYPE) continue;
+    if (entry.sizeBytes === null) continue;
+    if (isPlateXhtml(entry.path)) {
+      if (entry.sizeBytes > PLATE_OVERSIZE_LIMIT) {
+        issues.push(
+          buildIssue(
+            'PRH-FILE-PLATE-OVERSIZE',
+            entry.path,
+            ` (${formatBytes(entry.sizeBytes)} > 11MB)`,
+          ),
+        );
+      }
+    } else if (entry.sizeBytes > XHTML_OVERSIZE_LIMIT) {
+      issues.push(
+        buildIssue(
+          'PRH-FILE-XHTML-OVERSIZE',
+          entry.path,
+          ` (${formatBytes(entry.sizeBytes)} > 600KB)`,
+        ),
+      );
+    }
+  }
+
+  // 2. Directory layout. For each expected directory, check whether
+  //    content of that type lives at a non-canonical path. Only fire
+  //    when content exists but isn't in the canonical place — empty
+  //    sub-directories are not enforced.
+  for (const violation of findDirLayoutViolations(input.manifestEntries)) {
+    issues.push(buildIssue('PRH-DIR-LAYOUT-NONSTANDARD', violation.detail));
+  }
+
+  // 3. Filename convention.
+  for (const violation of findNamingViolations(input.zipPaths)) {
+    issues.push(buildIssue('PRH-FILE-NAMING-NONSTANDARD', violation));
+  }
+
+  // 4. Fixed-name presence.
+  for (const missing of findMissingFixedNames(input)) {
+    issues.push(buildIssue('PRH-FILE-FIXED-NAME-MISSING', missing));
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Plate XHTML heuristic. PRH plates use the `_plate` token in the
+ * basename or live under an `/images/plates/` subdir; both are
+ * defensible signals. We deliberately don't trust the spine
+ * `linear="no"` attribute alone because non-linear pages can also
+ * be footnotes / endnotes / long descriptions, which are subject
+ * to the 600KB cap, not the 11MB cap.
+ */
+function isPlateXhtml(zipPath: string): boolean {
+  const lower = zipPath.toLowerCase();
+  const base = lower.slice(lower.lastIndexOf('/') + 1);
+  // `\bplate\b` fails inside `plate_001` because `_` is a word char,
+  // so the trailing `\b` doesn't land between `e` and `_`. Match `plate`
+  // explicitly delimited by start-of-basename / `_` / `-` on the left
+  // and `_` / `-` / `.` / end on the right.
+  if (/(?:^|[_-])plate(?:[_-]|\.|$)/.test(base)) return true;
+  if (/\/plates?\//.test(lower)) return true;
+  return false;
+}
+
+/**
+ * Walk manifest entries and identify content that lives outside its
+ * canonical sub-directory. Returns one entry per affected type, not
+ * per file, so a book with 50 mis-located images produces a single
+ * finding rather than 50.
+ */
+function findDirLayoutViolations(
+  entries: PrhManifestEntry[],
+): Array<{ detail: string }> {
+  const typeGroups: Array<{ pred: (e: PrhManifestEntry) => boolean; dirSegment: string; label: string }> = [
+    {
+      pred: (e) => e.mediaType.startsWith('image/'),
+      dirSegment: '/images/',
+      label: 'images',
+    },
+    {
+      pred: (e) => e.mediaType === 'text/css',
+      dirSegment: '/styles/',
+      label: 'stylesheets',
+    },
+    {
+      pred: (e) => e.mediaType.startsWith('font/') || /\b(application\/vnd\.ms-opentype|application\/font-woff2?)\b/.test(e.mediaType),
+      dirSegment: '/fonts/',
+      label: 'fonts',
+    },
+    {
+      pred: (e) => e.mediaType === XHTML_MEDIA_TYPE,
+      dirSegment: '/xhtml/',
+      label: 'XHTML files',
+    },
+  ];
+
+  const out: Array<{ detail: string }> = [];
+  for (const group of typeGroups) {
+    const matching = entries.filter(group.pred);
+    if (matching.length === 0) continue;
+    const offenders = matching.filter((e) => !e.path.toLowerCase().includes(group.dirSegment));
+    if (offenders.length > 0) {
+      const sample = offenders.slice(0, 3).map((e) => e.path).join(', ');
+      const more = offenders.length > 3 ? `, +${offenders.length - 3} more` : '';
+      out.push({
+        detail: `${group.label} not under ${group.dirSegment} (${offenders.length} file(s): ${sample}${more})`,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk every zip entry and check the basename against the
+ * lowercase / single-dot / `[a-z0-9_-]` rule. Returns a deduped,
+ * sample-capped list.
+ */
+function findNamingViolations(zipPaths: string[]): string[] {
+  const offenders: string[] = [];
+  for (const path of zipPaths) {
+    if (NAMING_EXCEPTIONS.has(path)) continue;
+    if (path === '' || path.endsWith('/')) continue; // directory entries
+    const base = basename(path);
+    if (!VALID_FILENAME.test(base)) {
+      offenders.push(path);
+    }
+  }
+  return offenders;
+}
+
+/**
+ * Check the EPUB has every required fixed-name file. Returns a list
+ * of human-readable "missing X" strings.
+ *
+ * Required:
+ *   - `package.opf`         (always — basename of opfPath must match)
+ *   - `nav.xhtml`           (always — locate via manifest properties="nav")
+ *   - `toc.ncx`             (only when spine declares toc="ncx")
+ *   - `cover.<ext>`         (always — locate via properties="cover-image"
+ *                            for the image, AND cover.xhtml for the surface)
+ *
+ * `basestyles.css` is intentionally NOT checked here — it's already
+ * covered by `PRH-CSS-BASESTYLES-RENAMED` (P6/PR1) and double-emitting
+ * dilutes the operator signal.
+ */
+function findMissingFixedNames(input: PrhFileLayoutInput): string[] {
+  const missing: string[] = [];
+
+  // package.opf
+  if (basename(input.opfPath).toLowerCase() !== 'package.opf') {
+    missing.push(`package.opf (actual: ${input.opfPath})`);
+  }
+
+  // nav.xhtml — the manifest item with properties="nav" must have
+  // basename nav.xhtml.
+  const navEntry = input.manifestEntries.find((e) => e.properties.includes('nav'));
+  if (navEntry) {
+    if (basename(navEntry.path).toLowerCase() !== 'nav.xhtml') {
+      missing.push(`nav.xhtml (actual: ${navEntry.path})`);
+    }
+  } else {
+    missing.push('nav.xhtml (no manifest item with properties="nav")');
+  }
+
+  // toc.ncx — only when EPUB2 compat is in use.
+  if (input.requiresNcx) {
+    const ncxEntry = input.manifestEntries.find((e) => e.mediaType === 'application/x-dtbncx+xml');
+    if (!ncxEntry) {
+      missing.push('toc.ncx (spine declares toc="ncx" but no NCX manifest item)');
+    } else if (basename(ncxEntry.path).toLowerCase() !== 'toc.ncx') {
+      missing.push(`toc.ncx (actual: ${ncxEntry.path})`);
+    }
+  }
+
+  // cover.<ext> — image (via properties="cover-image").
+  const coverImage = input.manifestEntries.find((e) => e.properties.includes('cover-image'));
+  if (!coverImage) {
+    missing.push('cover.<ext> (no manifest item with properties="cover-image")');
+  } else if (!/^cover\.[a-z0-9]+$/i.test(basename(coverImage.path))) {
+    missing.push(`cover.<ext> image (actual: ${coverImage.path})`);
+  }
+
+  return missing;
+}
+
+function basename(zipPath: string): string {
+  const idx = zipPath.lastIndexOf('/');
+  return idx === -1 ? zipPath : zipPath.slice(idx + 1);
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)}KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function buildIssue(
+  code:
+    | 'PRH-FILE-XHTML-OVERSIZE'
+    | 'PRH-FILE-PLATE-OVERSIZE'
+    | 'PRH-DIR-LAYOUT-NONSTANDARD'
+    | 'PRH-FILE-NAMING-NONSTANDARD'
+    | 'PRH-FILE-FIXED-NAME-MISSING',
+  location: string,
+  detail = '',
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location}${detail}`,
+    suggestion: suggestionFor(code),
+    location,
+  };
+}
+
+function suggestionFor(code: string): string {
+  switch (code) {
+    case 'PRH-FILE-XHTML-OVERSIZE':
+      return 'Split this chapter at the next section boundary so each XHTML is ≤ 600KB. Update spine + nav references after splitting.';
+    case 'PRH-FILE-PLATE-OVERSIZE':
+      return 'Reduce the image set or split the plate sequence into multiple XHTML files; each plate must be ≤ 11MB.';
+    case 'PRH-DIR-LAYOUT-NONSTANDARD':
+      return 'Move the listed resources into /xhtml, /images, /fonts, or /styles as appropriate and update manifest hrefs.';
+    case 'PRH-FILE-NAMING-NONSTANDARD':
+      return 'Rename the file to lowercase alphanumeric + underscore + hyphen with a single dot before the extension (e.g. chapter_001.xhtml).';
+    case 'PRH-FILE-FIXED-NAME-MISSING':
+      return 'Rename the file to the canonical name so reading-system fallbacks and the cover surface resolve correctly.';
+    default:
+      return '';
+  }
+}

--- a/src/services/epub/profiles/prh-uk/validators/file-layout-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/file-layout-validator.ts
@@ -32,20 +32,17 @@ const PLATE_OVERSIZE_LIMIT = 11 * 1024 * 1024;
 const XHTML_MEDIA_TYPE = 'application/xhtml+xml';
 
 /**
- * Filenames in a manifested EPUB that should NOT be scanned for
- * naming-convention violations because they're metadata or
- * boilerplate that lives at the EPUB root (where PRH's lowercase
- * rule doesn't apply by convention).
+ * Paths that are exempt from the naming-convention check. The
+ * canonical exemptions are:
+ *   - the literal `mimetype` file at the zip root
+ *   - anything under the `META-INF/` directory (reader-specific
+ *     display options like `META-INF/com.apple.ibooks.display-options.xml`
+ *     are legitimate even though they don't match the lowercase /
+ *     underscore-only rule)
  */
-const NAMING_EXCEPTIONS = new Set([
-  'mimetype',
-  'META-INF/container.xml',
-  'META-INF/encryption.xml',
-  'META-INF/signatures.xml',
-  'META-INF/metadata.xml',
-  'META-INF/rights.xml',
-  'META-INF/manifest.xml',
-]);
+function isNamingException(zipPath: string): boolean {
+  return zipPath === 'mimetype' || /^META-INF\//i.test(zipPath);
+}
 
 /** Filename pattern: lowercase alphanumeric + `_` + `-`, single `.` before extension. */
 const VALID_FILENAME = /^[a-z0-9][a-z0-9_-]*\.[a-z0-9]+$/;
@@ -83,7 +80,7 @@ export function validatePrhFileLayout(input: PrhFileLayoutInput): PrhValidatorIs
   //    content of that type lives at a non-canonical path. Only fire
   //    when content exists but isn't in the canonical place — empty
   //    sub-directories are not enforced.
-  for (const violation of findDirLayoutViolations(input.manifestEntries)) {
+  for (const violation of findDirLayoutViolations(input.manifestEntries, input.opfPath)) {
     issues.push(buildIssue('PRH-DIR-LAYOUT-NONSTANDARD', violation.detail));
   }
 
@@ -127,29 +124,40 @@ function isPlateXhtml(zipPath: string): boolean {
  * canonical sub-directory. Returns one entry per affected type, not
  * per file, so a book with 50 mis-located images produces a single
  * finding rather than 50.
+ *
+ * Canonical = directly under the OPF root. We anchor on the OPF dir
+ * because manifest hrefs are resolved relative to it; both common
+ * EPUB layouts (`EPUB/package.opf` + `EPUB/images/...` and the
+ * root-level `package.opf` + `images/...`) are accepted, while
+ * nested paths like `EPUB/xhtml/images/foo.png` are flagged because
+ * they don't live directly under the canonical top-level dir.
  */
 function findDirLayoutViolations(
   entries: PrhManifestEntry[],
+  opfPath: string,
 ): Array<{ detail: string }> {
+  const opfDir = opfPath.includes('/')
+    ? opfPath.slice(0, opfPath.lastIndexOf('/')).toLowerCase()
+    : '';
   const typeGroups: Array<{ pred: (e: PrhManifestEntry) => boolean; dirSegment: string; label: string }> = [
     {
       pred: (e) => e.mediaType.startsWith('image/'),
-      dirSegment: '/images/',
+      dirSegment: 'images',
       label: 'images',
     },
     {
       pred: (e) => e.mediaType === 'text/css',
-      dirSegment: '/styles/',
+      dirSegment: 'styles',
       label: 'stylesheets',
     },
     {
       pred: (e) => e.mediaType.startsWith('font/') || /\b(application\/vnd\.ms-opentype|application\/font-woff2?)\b/.test(e.mediaType),
-      dirSegment: '/fonts/',
+      dirSegment: 'fonts',
       label: 'fonts',
     },
     {
       pred: (e) => e.mediaType === XHTML_MEDIA_TYPE,
-      dirSegment: '/xhtml/',
+      dirSegment: 'xhtml',
       label: 'XHTML files',
     },
   ];
@@ -158,12 +166,13 @@ function findDirLayoutViolations(
   for (const group of typeGroups) {
     const matching = entries.filter(group.pred);
     if (matching.length === 0) continue;
-    const offenders = matching.filter((e) => !e.path.toLowerCase().includes(group.dirSegment));
+    const canonicalPrefix = opfDir ? `${opfDir}/${group.dirSegment}/` : `${group.dirSegment}/`;
+    const offenders = matching.filter((e) => !e.path.toLowerCase().startsWith(canonicalPrefix));
     if (offenders.length > 0) {
       const sample = offenders.slice(0, 3).map((e) => e.path).join(', ');
       const more = offenders.length > 3 ? `, +${offenders.length - 3} more` : '';
       out.push({
-        detail: `${group.label} not under ${group.dirSegment} (${offenders.length} file(s): ${sample}${more})`,
+        detail: `${group.label} not under ${canonicalPrefix} (${offenders.length} file(s): ${sample}${more})`,
       });
     }
   }
@@ -178,7 +187,7 @@ function findDirLayoutViolations(
 function findNamingViolations(zipPaths: string[]): string[] {
   const offenders: string[] = [];
   for (const path of zipPaths) {
-    if (NAMING_EXCEPTIONS.has(path)) continue;
+    if (isNamingException(path)) continue;
     if (path === '' || path.endsWith('/')) continue; // directory entries
     const base = basename(path);
     if (!VALID_FILENAME.test(base)) {

--- a/src/services/epub/profiles/prh-uk/validators/types.ts
+++ b/src/services/epub/profiles/prh-uk/validators/types.ts
@@ -74,3 +74,28 @@ export interface PrhCssConventionsInput extends PrhPerXhtmlInput {
   /** Every CSS file referenced by the manifest. */
   cssFiles: PrhCssFile[];
 }
+
+/** One manifest item resolved into a zip path + media type. */
+export interface PrhManifestEntry {
+  /** Resolved zip-relative path. */
+  path: string;
+  /** OPF media-type attribute (lowercased). */
+  mediaType: string;
+  /** Manifest item `properties` tokens, lowercased + split on whitespace. */
+  properties: string[];
+  /** Uncompressed size in bytes. May be `null` when the entry is
+   *  manifested but absent from the zip (a separate concern handled
+   *  by epubcheck). */
+  sizeBytes: number | null;
+}
+
+/** Inputs the file-layout validator reads. */
+export interface PrhFileLayoutInput extends PrhValidatorInput {
+  /** Resolved manifest entries with sizes. */
+  manifestEntries: PrhManifestEntry[];
+  /** Every zip entry path (for dir-layout + fixed-name checks). */
+  zipPaths: string[];
+  /** True when the spine declares `toc="ncx"` (EPUB2 compat — toc.ncx
+   *  becomes required when this flag is set). */
+  requiresNcx: boolean;
+}

--- a/tests/unit/services/epub/profiles/prh-uk/validators/file-layout-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/file-layout-validator.test.ts
@@ -181,6 +181,46 @@ describe('validatePrhFileLayout — PRH-DIR-LAYOUT-NONSTANDARD', () => {
     expect(issues.some((i) => i.code === 'PRH-DIR-LAYOUT-NONSTANDARD')).toBe(false);
   });
 
+  it('accepts a root-level OPF layout (package.opf at zip root, images/ at zip root)', () => {
+    const issues = validatePrhFileLayout(
+      input({
+        opfPath: 'package.opf',
+        manifestEntries: [
+          manifestEntry('xhtml/nav.xhtml', 'application/xhtml+xml', {
+            properties: ['nav'],
+            sizeBytes: 5000,
+          }),
+          manifestEntry('xhtml/chapter_001.xhtml', 'application/xhtml+xml', {
+            sizeBytes: 200 * 1024,
+          }),
+          manifestEntry('images/cover.jpg', 'image/jpeg', {
+            properties: ['cover-image'],
+            sizeBytes: 500_000,
+          }),
+        ],
+        zipPaths: [
+          'mimetype',
+          'META-INF/container.xml',
+          'package.opf',
+          'xhtml/nav.xhtml',
+          'xhtml/chapter_001.xhtml',
+          'images/cover.jpg',
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-DIR-LAYOUT-NONSTANDARD')).toBe(false);
+  });
+
+  it('rejects nested-canonical paths like EPUB/xhtml/images/foo.png', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/xhtml/images/diagram_01.png', 'image/png'),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    expect(issues.some((i) => i.code === 'PRH-DIR-LAYOUT-NONSTANDARD')).toBe(true);
+  });
+
   it('emits ONE issue per content type even with many violators', () => {
     const base = conformantBaseline();
     const entries = [
@@ -236,6 +276,21 @@ describe('validatePrhFileLayout — PRH-FILE-NAMING-NONSTANDARD', () => {
       input({
         ...conformantBaseline(),
         zipPaths: ['mimetype', 'META-INF/container.xml', 'EPUB/package.opf'],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-FILE-NAMING-NONSTANDARD')).toBe(false);
+  });
+
+  it('exempts reader-specific META-INF files (e.g. iBooks display-options)', () => {
+    const issues = validatePrhFileLayout(
+      input({
+        ...conformantBaseline(),
+        zipPaths: [
+          'mimetype',
+          'META-INF/container.xml',
+          'META-INF/com.apple.ibooks.display-options.xml',
+          'EPUB/package.opf',
+        ],
       }),
     );
     expect(issues.some((i) => i.code === 'PRH-FILE-NAMING-NONSTANDARD')).toBe(false);

--- a/tests/unit/services/epub/profiles/prh-uk/validators/file-layout-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/file-layout-validator.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhFileLayout } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/file-layout-validator';
+import type {
+  PrhFileLayoutInput,
+  PrhManifestEntry,
+} from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function manifestEntry(
+  path: string,
+  mediaType: string,
+  opts: { sizeBytes?: number | null; properties?: string[] } = {},
+): PrhManifestEntry {
+  return {
+    path,
+    mediaType,
+    properties: opts.properties ?? [],
+    sizeBytes: opts.sizeBytes ?? 1000,
+  };
+}
+
+function input(opts: Partial<PrhFileLayoutInput> = {}): PrhFileLayoutInput {
+  return {
+    opfContent: opts.opfContent ?? '<?xml version="1.0"?><package/>',
+    opfPath: opts.opfPath ?? 'EPUB/package.opf',
+    manifestEntries: opts.manifestEntries ?? [],
+    zipPaths: opts.zipPaths ?? [],
+    requiresNcx: opts.requiresNcx ?? false,
+  };
+}
+
+/** A minimal conformant baseline: package.opf at canonical path, nav.xhtml,
+ *  cover image, and an XHTML chapter — no violations. */
+function conformantBaseline(): Partial<PrhFileLayoutInput> {
+  return {
+    opfPath: 'EPUB/package.opf',
+    manifestEntries: [
+      manifestEntry('EPUB/xhtml/nav.xhtml', 'application/xhtml+xml', {
+        properties: ['nav'],
+        sizeBytes: 5000,
+      }),
+      manifestEntry('EPUB/xhtml/chapter_001.xhtml', 'application/xhtml+xml', {
+        sizeBytes: 200 * 1024,
+      }),
+      manifestEntry('EPUB/images/cover.jpg', 'image/jpeg', {
+        properties: ['cover-image'],
+        sizeBytes: 500_000,
+      }),
+    ],
+    zipPaths: [
+      'mimetype',
+      'META-INF/container.xml',
+      'EPUB/package.opf',
+      'EPUB/xhtml/nav.xhtml',
+      'EPUB/xhtml/chapter_001.xhtml',
+      'EPUB/images/cover.jpg',
+    ],
+    requiresNcx: false,
+  };
+}
+
+describe('validatePrhFileLayout — PRH-FILE-XHTML-OVERSIZE', () => {
+  it('emits when a non-plate XHTML exceeds 600KB', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/xhtml/chapter_002.xhtml', 'application/xhtml+xml', {
+        sizeBytes: 700 * 1024,
+      }),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    expect(issues.some((i) => i.code === 'PRH-FILE-XHTML-OVERSIZE')).toBe(true);
+  });
+
+  it('does NOT emit for XHTML at or below 600KB', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/xhtml/chapter_002.xhtml', 'application/xhtml+xml', {
+        sizeBytes: 600 * 1024,
+      }),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    expect(issues.some((i) => i.code === 'PRH-FILE-XHTML-OVERSIZE')).toBe(false);
+  });
+
+  it('treats plate XHTML as a separate category (no 600KB-rule emission)', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/xhtml/plate_001.xhtml', 'application/xhtml+xml', {
+        sizeBytes: 5 * 1024 * 1024, // 5MB plate, under the 11MB cap
+      }),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    expect(issues.some((i) => i.code === 'PRH-FILE-XHTML-OVERSIZE')).toBe(false);
+  });
+
+  it('does not emit when sizeBytes is null (manifested but absent from zip)', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/xhtml/chapter_002.xhtml', 'application/xhtml+xml', {
+        sizeBytes: null,
+      }),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    expect(issues.some((i) => i.code === 'PRH-FILE-XHTML-OVERSIZE')).toBe(false);
+  });
+});
+
+describe('validatePrhFileLayout — PRH-FILE-PLATE-OVERSIZE', () => {
+  it('emits when a plate XHTML exceeds 11MB', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/xhtml/plate_001.xhtml', 'application/xhtml+xml', {
+        sizeBytes: 12 * 1024 * 1024,
+      }),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    expect(issues.some((i) => i.code === 'PRH-FILE-PLATE-OVERSIZE')).toBe(true);
+  });
+
+  it('does NOT emit for plate XHTML at or below 11MB', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/xhtml/plate_001.xhtml', 'application/xhtml+xml', {
+        sizeBytes: 11 * 1024 * 1024,
+      }),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    expect(issues.some((i) => i.code === 'PRH-FILE-PLATE-OVERSIZE')).toBe(false);
+  });
+
+  it('detects plates by /plates/ directory segment too', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/plates/plate_001.xhtml', 'application/xhtml+xml', {
+        sizeBytes: 12 * 1024 * 1024,
+      }),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    expect(issues.some((i) => i.code === 'PRH-FILE-PLATE-OVERSIZE')).toBe(true);
+  });
+});
+
+describe('validatePrhFileLayout — PRH-DIR-LAYOUT-NONSTANDARD', () => {
+  it('emits when images live outside /images/', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/figures/diagram_01.png', 'image/png'),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    const dirIssue = issues.find((i) => i.code === 'PRH-DIR-LAYOUT-NONSTANDARD');
+    expect(dirIssue).toBeDefined();
+    expect(dirIssue?.message).toMatch(/images/);
+  });
+
+  it('emits when stylesheets live outside /styles/', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/css/basestyles.css', 'text/css'),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    expect(issues.some((i) => i.code === 'PRH-DIR-LAYOUT-NONSTANDARD')).toBe(true);
+  });
+
+  it('does NOT emit when each content type is under its canonical dir', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/images/diagram_01.png', 'image/png'),
+      manifestEntry('EPUB/styles/basestyles.css', 'text/css'),
+      manifestEntry('EPUB/fonts/garamond.otf', 'font/otf'),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    expect(issues.some((i) => i.code === 'PRH-DIR-LAYOUT-NONSTANDARD')).toBe(false);
+  });
+
+  it('emits ONE issue per content type even with many violators', () => {
+    const base = conformantBaseline();
+    const entries = [
+      ...(base.manifestEntries ?? []),
+      manifestEntry('EPUB/figures/diagram_01.png', 'image/png'),
+      manifestEntry('EPUB/figures/diagram_02.png', 'image/png'),
+      manifestEntry('EPUB/figures/diagram_03.png', 'image/png'),
+      manifestEntry('EPUB/figures/diagram_04.png', 'image/png'),
+    ];
+    const issues = validatePrhFileLayout(input({ ...base, manifestEntries: entries }));
+    const dirIssues = issues.filter((i) => i.code === 'PRH-DIR-LAYOUT-NONSTANDARD');
+    expect(dirIssues).toHaveLength(1);
+    expect(dirIssues[0].message).toMatch(/4 file/);
+  });
+});
+
+describe('validatePrhFileLayout — PRH-FILE-NAMING-NONSTANDARD', () => {
+  it('emits for uppercase characters in the basename', () => {
+    const base = conformantBaseline();
+    const issues = validatePrhFileLayout(
+      input({
+        ...base,
+        zipPaths: [...(base.zipPaths ?? []), 'EPUB/xhtml/Chapter_002.xhtml'],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-FILE-NAMING-NONSTANDARD')).toBe(true);
+  });
+
+  it('emits for multiple dots in the basename', () => {
+    const base = conformantBaseline();
+    const issues = validatePrhFileLayout(
+      input({
+        ...base,
+        zipPaths: [...(base.zipPaths ?? []), 'EPUB/xhtml/chapter.001.xhtml'],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-FILE-NAMING-NONSTANDARD')).toBe(true);
+  });
+
+  it('emits for disallowed characters (spaces, parens)', () => {
+    const base = conformantBaseline();
+    const issues = validatePrhFileLayout(
+      input({
+        ...base,
+        zipPaths: [...(base.zipPaths ?? []), 'EPUB/xhtml/chapter (1).xhtml'],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-FILE-NAMING-NONSTANDARD')).toBe(true);
+  });
+
+  it('exempts mimetype + META-INF boilerplate from the naming rule', () => {
+    const issues = validatePrhFileLayout(
+      input({
+        ...conformantBaseline(),
+        zipPaths: ['mimetype', 'META-INF/container.xml', 'EPUB/package.opf'],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-FILE-NAMING-NONSTANDARD')).toBe(false);
+  });
+
+  it('does NOT emit for conformant filenames (lowercase, underscores, hyphens)', () => {
+    const issues = validatePrhFileLayout(
+      input({
+        ...conformantBaseline(),
+        zipPaths: [
+          'EPUB/xhtml/chapter_001.xhtml',
+          'EPUB/xhtml/chapter-introduction.xhtml',
+          'EPUB/images/diagram-01.png',
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-FILE-NAMING-NONSTANDARD')).toBe(false);
+  });
+
+  it('skips directory entries (trailing slash)', () => {
+    const issues = validatePrhFileLayout(
+      input({
+        ...conformantBaseline(),
+        zipPaths: ['EPUB/', 'EPUB/xhtml/', 'EPUB/package.opf'],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-FILE-NAMING-NONSTANDARD')).toBe(false);
+  });
+});
+
+describe('validatePrhFileLayout — PRH-FILE-FIXED-NAME-MISSING', () => {
+  it('emits when package.opf is named otherwise', () => {
+    const issues = validatePrhFileLayout(
+      input({
+        ...conformantBaseline(),
+        opfPath: 'EPUB/content.opf',
+      }),
+    );
+    expect(
+      issues.some(
+        (i) => i.code === 'PRH-FILE-FIXED-NAME-MISSING' && /package\.opf/i.test(i.message),
+      ),
+    ).toBe(true);
+  });
+
+  it('emits when no manifest item has properties="nav"', () => {
+    const base = conformantBaseline();
+    const issues = validatePrhFileLayout(
+      input({
+        ...base,
+        manifestEntries: (base.manifestEntries ?? []).filter(
+          (e) => !e.properties.includes('nav'),
+        ),
+      }),
+    );
+    expect(
+      issues.some(
+        (i) => i.code === 'PRH-FILE-FIXED-NAME-MISSING' && /nav\.xhtml/i.test(i.message),
+      ),
+    ).toBe(true);
+  });
+
+  it('emits when the nav item is named other than nav.xhtml', () => {
+    const issues = validatePrhFileLayout(
+      input({
+        ...conformantBaseline(),
+        manifestEntries: [
+          manifestEntry('EPUB/xhtml/toc.xhtml', 'application/xhtml+xml', {
+            properties: ['nav'],
+          }),
+          manifestEntry('EPUB/images/cover.jpg', 'image/jpeg', {
+            properties: ['cover-image'],
+          }),
+        ],
+      }),
+    );
+    expect(
+      issues.some(
+        (i) => i.code === 'PRH-FILE-FIXED-NAME-MISSING' && /toc\.xhtml/.test(i.message),
+      ),
+    ).toBe(true);
+  });
+
+  it('emits when requiresNcx is true but no NCX item is present', () => {
+    const issues = validatePrhFileLayout(
+      input({
+        ...conformantBaseline(),
+        requiresNcx: true,
+      }),
+    );
+    expect(
+      issues.some(
+        (i) => i.code === 'PRH-FILE-FIXED-NAME-MISSING' && /toc\.ncx/.test(i.message),
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT emit for a missing toc.ncx when requiresNcx is false', () => {
+    const issues = validatePrhFileLayout(input({ ...conformantBaseline(), requiresNcx: false }));
+    expect(
+      issues.some(
+        (i) => i.code === 'PRH-FILE-FIXED-NAME-MISSING' && /toc\.ncx/.test(i.message),
+      ),
+    ).toBe(false);
+  });
+
+  it('emits when no manifest item has properties="cover-image"', () => {
+    const base = conformantBaseline();
+    const issues = validatePrhFileLayout(
+      input({
+        ...base,
+        manifestEntries: (base.manifestEntries ?? []).filter(
+          (e) => !e.properties.includes('cover-image'),
+        ),
+      }),
+    );
+    expect(
+      issues.some(
+        (i) => i.code === 'PRH-FILE-FIXED-NAME-MISSING' && /cover/i.test(i.message),
+      ),
+    ).toBe(true);
+  });
+
+  it('emits when the cover-image item is not named cover.<ext>', () => {
+    const issues = validatePrhFileLayout(
+      input({
+        ...conformantBaseline(),
+        manifestEntries: [
+          manifestEntry('EPUB/xhtml/nav.xhtml', 'application/xhtml+xml', {
+            properties: ['nav'],
+          }),
+          manifestEntry('EPUB/images/front_cover.jpg', 'image/jpeg', {
+            properties: ['cover-image'],
+          }),
+        ],
+      }),
+    );
+    expect(
+      issues.some(
+        (i) =>
+          i.code === 'PRH-FILE-FIXED-NAME-MISSING' && /front_cover\.jpg/.test(i.message),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('validatePrhFileLayout — overall', () => {
+  it('emits zero issues for a conformant EPUB', () => {
+    const issues = validatePrhFileLayout(input(conformantBaseline()));
+    expect(issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Second PR of P6. Adds a detect-only validator for the canonical PRH file-layout + size rules defined in Technical Guide §3 + §15.

Five new codes, all P3 (advisory — does not block deliverable export):

| Code | Severity | Detects |
|---|---|---|
| \`PRH-FILE-XHTML-OVERSIZE\` | serious | Chapter XHTML > 600KB (plates excluded — routed to the plate rule) |
| \`PRH-FILE-PLATE-OVERSIZE\` | serious | Plate XHTML > 11MB |
| \`PRH-DIR-LAYOUT-NONSTANDARD\` | minor | Content lives outside its canonical \`/xhtml\` \`/images\` \`/fonts\` \`/styles\` directory; one finding per offending content type |
| \`PRH-FILE-NAMING-NONSTANDARD\` | moderate | Basename violates lowercase / single-dot / \`[a-z0-9_-]\` convention; \`mimetype\` and \`META-INF/*\` exempt |
| \`PRH-FILE-FIXED-NAME-MISSING\` | serious | Required fixed-name file missing (\`package.opf\`, \`nav.xhtml\`, \`cover.<ext>\`; \`toc.ncx\` only when spine declares \`toc="ncx"\`) |

Detect-only — renaming a file cascades through the manifest, hrefs and fragment identifiers, so auto-remediation is operator-confirmed only.

\`basestyles.css\` is intentionally NOT included in the fixed-name check — already covered by \`PRH-CSS-BASESTYLES-RENAMED\` (P6/PR1). Avoiding double-emission keeps the operator signal focused.

### Plate detection: explicit boundary regex

The plate-XHTML heuristic uses \`/(?:^|[_-])plate(?:[_-]|\.|$)/\` on the basename rather than \`\bplate\b\`, because \`_\` is a word char in JS regex — \`\bplate\b\` silently fails to match \`plate_001.xhtml\`. Caught early by the unit tests; a memory note has been added.

### Orchestrator changes

- \`readManifestEntries()\` parses the OPF manifest, resolves hrefs to zip paths, captures media-type + properties + decompressed size
- \`runPrhUkValidators()\` detects the \`<spine toc=\"ncx\">\` declaration and passes \`requiresNcx\` through to the validator

### Conformance report

- \`TIER_CODE_COUNT.P3\` bumped 21 → 26
- \`priorityTierForCode\` maps \`PRH-FILE-*\` and \`PRH-DIR-*\` → P3

## Test plan
- [x] 25 new unit tests — all 5 rules + edge cases (plate-detection basename boundary, null-\`sizeBytes\` safety, \`requiresNcx\` gating, exempt boilerplate paths)
- [x] Existing 19 conformance-report tests still pass (no behaviour change beyond the tier count bump)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean (\`--max-warnings 0\`)
- [ ] Staging smoke: re-audit any PRH-UK book and confirm \`PRH-FILE-*\` / \`PRH-DIR-*\` codes surface as P3 advisory issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detect-only file/directory/size validations for EPUBs: oversized XHTML/plate thresholds, canonical resource directory checks, filename convention enforcement, and required fixed-name file presence checks.
* **Enhancements**
  * These file/layout issues are now included in priority-level reporting so they appear in outstanding/HTML reports.
* **Tests**
  * Added unit tests covering the new layout rules and thresholds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/392)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->