### PR TITLE
feat(prh): image-assets validator (P6/PR3)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -585,6 +585,47 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'EPUB is missing a required fixed-name file (package.opf / toc.ncx when EPUB2-compat / nav.xhtml / cover.<ext>) — Kindle popup links, NCX fallback navigation and the cover-image surface all resolve by canonical filename',
   },
+
+  // ── Image assets (P6/PR3) ─────────────────────────────────────────────
+  // Publisher-gated and detect-only. Per Technical Guide §§11-12 image
+  // asset rules: canonical capture sizes per CSS class, ≥300dpi, sRGB,
+  // PNG-8 for line-drawings, JPEG quality cap. Operator fixes in their
+  // image-prep pipeline; auto-resize lives in P7 if/when demanded.
+  'PRH-IMG-CAPTURE-SIZE-WRONG': {
+    code: 'PRH-IMG-CAPTURE-SIZE-WRONG',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Image width does not match its CSS-class capture size (e.g. .portrait_large requires 1900px ±5%) — Technical Guide §11 per-class capture sizes',
+  },
+  'PRH-IMG-DPI-TOO-LOW': {
+    code: 'PRH-IMG-DPI-TOO-LOW',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Image density is below the PRH 300dpi minimum — Technical Guide §11. Images with no embedded DPI metadata are NOT flagged here (EXIF-stripped sources are common)',
+  },
+  'PRH-IMG-COLORSPACE-NOT-SRGB': {
+    code: 'PRH-IMG-COLORSPACE-NOT-SRGB',
+    severity: 'moderate',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'Image color space is not sRGB — Technical Guide §11 requires all images to be converted to sRGB so Kindle / KFX rendering is colour-accurate',
+  },
+  'PRH-IMG-PNG-EXPECTED-JPEG': {
+    code: 'PRH-IMG-PNG-EXPECTED-JPEG',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'JPEG image is a low-resolution low-colour line drawing / schematic — PRH recommends PNG-8 for line drawings and text-replacement glyphs. Heuristic: width ≤ 800 AND ≤256 distinct colours',
+  },
+  'PRH-IMG-JPEG-QUALITY-SUSPECT': {
+    code: 'PRH-IMG-JPEG-QUALITY-SUSPECT',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'JPEG file-size-to-pixel ratio suggests quality > 9 — PRH wants JPEG quality 8 (NOT max). Heuristic; cover.jpg is exempt because covers are deliberately kept at maximum quality',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/prh-conformance-report.service.ts
+++ b/src/services/acr/prh-conformance-report.service.ts
@@ -262,8 +262,8 @@ const TIER_CODE_COUNT: Record<PriorityTier, number> = {
   P2: 25,
   // P3 — body epub:type + doc-* ARIA (8) + forbidden (3) + notes/pagebreak (2)
   // + text heuristics (3) + CSS conventions (5, P6/PR1) + file/dir/size
-  // (5, P6/PR2) = 26
-  P3: 26,
+  // (5, P6/PR2) + image assets (5, P6/PR3) = 31
+  P3: 31,
   // P4 has no PRH-* codes (AI policy gate + cover-alt template were
   // implemented as behaviors, not new codes). 0 to keep the type happy.
   P4: 0,
@@ -297,6 +297,7 @@ function priorityTierForCode(code: string): PriorityTier | null {
   if (code.startsWith('PRH-CSS-')) return 'P3';
   if (code.startsWith('PRH-FILE-')) return 'P3';
   if (code.startsWith('PRH-DIR-')) return 'P3';
+  if (code.startsWith('PRH-IMG-')) return 'P3';
   if (code === 'PRH-BODY-HAS-ARIA') return 'P3';
   if (code === 'PRH-PAGEBREAK-MALFORMED') return 'P3';
   if (code === 'PRH-FOOTNOTE-ID-MISMATCH') return 'P3';

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -34,13 +34,16 @@ import { validatePrhHashtags } from './validators/hashtag-validator';
 import { validatePrhAcronyms } from './validators/acronym-validator';
 import { validatePrhCssConventions } from './validators/css-conventions-validator';
 import { validatePrhFileLayout } from './validators/file-layout-validator';
+import { validatePrhImageAssets } from './validators/image-assets-validator';
 import { getImprintRules } from './imprints';
+import sharp from 'sharp';
 import type { PublisherProfile } from '../types';
 import type {
   PrhValidatorIssue,
   PrhXhtmlFile,
   PrhCssFile,
   PrhManifestEntry,
+  PrhImageMetadata,
 } from './validators/types';
 
 /**
@@ -97,6 +100,11 @@ export async function runPrhUkValidators(
       zipPaths,
       requiresNcx,
     };
+    const imageMetadata = await readImageMetadata(zip, manifestEntries);
+    const imageAssetsInput = {
+      ...perXhtmlInput,
+      images: imageMetadata,
+    };
 
     const issues: PrhValidatorIssue[] = [
       ...validatePrhMetadata(opfInput),
@@ -129,6 +137,7 @@ export async function runPrhUkValidators(
         ...validatePrhAcronyms(perXhtmlInput),
         ...validatePrhCssConventions(cssInput),
         ...validatePrhFileLayout(fileLayoutInput),
+        ...validatePrhImageAssets(imageAssetsInput),
       );
     }
 
@@ -207,6 +216,82 @@ async function readNavDoc(
     }
   }
   return null;
+}
+
+/**
+ * Run sharp once per manifested image and build the per-image
+ * metadata the image-assets validator consumes. The validator is
+ * synchronous + pure; all sharp I/O lives here.
+ *
+ * Per-image failures are caught locally — a corrupt image or one
+ * sharp can't decode produces a `null`-fields entry so the validator
+ * simply skips it rather than aborting the whole audit.
+ *
+ * `colorCount` is intentionally NOT computed for images wider than
+ * 800px: the PNG-vs-JPEG heuristic only fires below that width, so
+ * computing the palette for a 4000px hero illustration would be
+ * wasted work.
+ */
+async function readImageMetadata(
+  zip: JSZip,
+  manifestEntries: PrhManifestEntry[],
+): Promise<PrhImageMetadata[]> {
+  const out: PrhImageMetadata[] = [];
+  for (const entry of manifestEntries) {
+    if (!entry.mediaType.startsWith('image/')) continue;
+    const zipFile = zip.file(entry.path);
+    if (!zipFile) continue;
+    try {
+      const buf = await zipFile.async('nodebuffer');
+      const isCover = entry.properties.includes('cover-image');
+      const meta = await sharp(buf).metadata();
+      let colorCount: number | null = null;
+      if (
+        entry.mediaType === 'image/jpeg'
+        && typeof meta.width === 'number'
+        && meta.width <= 800
+      ) {
+        try {
+          const stats = await sharp(buf).stats();
+          // sharp's `stats.channels` doesn't expose distinct colour
+          // count directly. Use raw pixels + a Set for small images.
+          const { data, info } = await sharp(buf)
+            .raw()
+            .toBuffer({ resolveWithObject: true });
+          const seen = new Set<number>();
+          const stride = info.channels;
+          for (let i = 0; i + stride <= data.length; i += stride) {
+            // Pack RGB(A) into a single 32-bit integer for the Set.
+            const r = data[i];
+            const g = stride >= 2 ? data[i + 1] : 0;
+            const b = stride >= 3 ? data[i + 2] : 0;
+            seen.add((r << 16) | (g << 8) | b);
+            if (seen.size > 256) break;
+          }
+          colorCount = seen.size;
+          void stats;
+        } catch {
+          colorCount = null;
+        }
+      }
+      out.push({
+        path: entry.path,
+        mediaType: entry.mediaType,
+        width: typeof meta.width === 'number' ? meta.width : null,
+        height: typeof meta.height === 'number' ? meta.height : null,
+        density: typeof meta.density === 'number' && meta.density > 0 ? meta.density : null,
+        colorSpace: typeof meta.space === 'string' ? meta.space : null,
+        colorCount,
+        sizeBytes: buf.length,
+        isCover,
+      });
+    } catch (err) {
+      logger.warn(
+        `[PRH image metadata] sharp failed for ${entry.path}; skipping: ${err instanceof Error ? err.message : 'unknown'}`,
+      );
+    }
+  }
+  return out;
 }
 
 /**

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -100,11 +100,6 @@ export async function runPrhUkValidators(
       zipPaths,
       requiresNcx,
     };
-    const imageMetadata = await readImageMetadata(zip, manifestEntries);
-    const imageAssetsInput = {
-      ...perXhtmlInput,
-      images: imageMetadata,
-    };
 
     const issues: PrhValidatorIssue[] = [
       ...validatePrhMetadata(opfInput),
@@ -123,6 +118,14 @@ export async function runPrhUkValidators(
       publisherProfile?.publisher === 'PRH-UK'
       && publisherProfile.confidence !== 'low';
     if (isPrhAtMediumConfidence) {
+      // Image metadata is read lazily here — `readImageMetadata` runs
+      // sharp once per manifested image, so we only pay that cost when
+      // the P3 gate is open and `validatePrhImageAssets` will actually
+      // consume the result.
+      const imageAssetsInput = {
+        ...perXhtmlInput,
+        images: await readImageMetadata(zip, manifestEntries),
+      };
       issues.push(
         ...validatePrhEpubTypePlacement(perXhtmlInput),
         ...validatePrhDocAriaRoles(perXhtmlInput),

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -219,6 +219,33 @@ async function readNavDoc(
 }
 
 /**
+ * Cap total pixels for the palette-probe fast path. The PNG-vs-JPEG
+ * heuristic only fires below 800px width AND ≤256 distinct colours,
+ * so the typical line-drawing is well under this ceiling. Bound to
+ * stop a very tall narrow image (e.g. 800×100000) from forcing a
+ * multi-megapixel raw decode.
+ */
+const MAX_PALETTE_PROBE_PIXELS = 800 * 1200;
+
+/**
+ * Normalise sharp's `density` field to a trustworthy value or null.
+ *
+ * sharp returns `density: 72` even for JPEGs that carry no embedded
+ * density metadata at all — that's libvips' default, not a signal
+ * from the source. We can't distinguish "stripped EXIF" from "EXIF
+ * present at 72dpi" given sharp's API alone, so we treat any 72dpi
+ * reading as ambiguous and yield null rather than fire a false
+ * `PRH-IMG-DPI-TOO-LOW`. Genuine 72dpi sources will be silently
+ * accepted; this is an explicit trade-off favouring zero false
+ * positives on an advisory rule.
+ */
+function extractDensity(rawDensity: unknown): number | null {
+  if (typeof rawDensity !== 'number' || rawDensity <= 0) return null;
+  if (rawDensity === 72) return null;
+  return rawDensity;
+}
+
+/**
  * Run sharp once per manifested image and build the per-image
  * metadata the image-assets validator consumes. The validator is
  * synchronous + pure; all sharp I/O lives here.
@@ -249,10 +276,14 @@ async function readImageMetadata(
       if (
         entry.mediaType === 'image/jpeg'
         && typeof meta.width === 'number'
+        && typeof meta.height === 'number'
         && meta.width <= 800
+        // Guardrail: cap total pixels examined to keep palette probing
+        // bounded — even within the 800px width gate, a very tall image
+        // could otherwise decode a multi-MB raw buffer.
+        && meta.width * meta.height <= MAX_PALETTE_PROBE_PIXELS
       ) {
         try {
-          const stats = await sharp(buf).stats();
           // sharp's `stats.channels` doesn't expose distinct colour
           // count directly. Use raw pixels + a Set for small images.
           const { data, info } = await sharp(buf)
@@ -269,7 +300,6 @@ async function readImageMetadata(
             if (seen.size > 256) break;
           }
           colorCount = seen.size;
-          void stats;
         } catch {
           colorCount = null;
         }
@@ -279,7 +309,7 @@ async function readImageMetadata(
         mediaType: entry.mediaType,
         width: typeof meta.width === 'number' ? meta.width : null,
         height: typeof meta.height === 'number' ? meta.height : null,
-        density: typeof meta.density === 'number' && meta.density > 0 ? meta.density : null,
+        density: extractDensity(meta.density),
         colorSpace: typeof meta.space === 'string' ? meta.space : null,
         colorCount,
         sizeBytes: buf.length,

--- a/src/services/epub/profiles/prh-uk/validators/image-assets-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/image-assets-validator.ts
@@ -1,0 +1,271 @@
+/**
+ * PRH UK image-assets validator (P6/PR3).
+ *
+ * Per Technical Guide §§11-12 image-asset rules:
+ *   - Each image has a canonical capture size driven by its CSS
+ *     class (e.g. `.portrait_large` → 1900px width). Tolerance is
+ *     ±5% to account for legitimate scaling rounding.
+ *   - 300dpi minimum density.
+ *   - All images converted to sRGB.
+ *   - PNG-8 preferred for line drawings / schematics / text glyphs
+ *     (heuristic: small-width low-colour-count JPEGs).
+ *   - JPEG quality cap at "8" (heuristic on bytes-per-pixel).
+ *
+ * Detect-only. Auto-resize / re-encode lives in P7 if/when demanded.
+ *
+ * The validator is pure: the orchestrator runs sharp once per image
+ * and passes pre-computed metadata in. Tests therefore don't need
+ * sharp — they fabricate metadata directly.
+ *
+ * Image-class lookup: each rule that depends on the host class
+ * (currently only capture-size) walks the XHTML files to find
+ * `<img>` elements whose `src` resolves to the image path and
+ * collects their `class` tokens.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type {
+  PrhValidatorIssue,
+  PrhImageAssetsInput,
+  PrhImageMetadata,
+  PrhXhtmlFile,
+} from './types';
+
+const DPI_MIN = 300;
+const CAPTURE_SIZE_TOLERANCE = 0.05;
+const PNG_EXPECTED_WIDTH_MAX = 800;
+const PNG_EXPECTED_COLOR_COUNT_MAX = 256;
+const JPEG_QUALITY_BYTES_PER_PIXEL_MAX = 0.5;
+
+/**
+ * Canonical capture sizes from Technical Guide §11. Keyed on the
+ * CSS class applied to the `<img>`. Wildcard variants (e.g.
+ * `image_full_caption_landscape`) are normalised to their base
+ * size via the `imageFullVariant` prefix check.
+ */
+const CAPTURE_SIZES: Record<string, number> = {
+  cover_image: 1900,
+  portrait_large: 1900,
+  portrait_medium: 1600,
+  portrait_small: 1024,
+  portrait_xsmall: 500,
+  landscape_large: 1900,
+  landscape_medium: 1600,
+  landscape_small: 1024,
+  landscape_xsmall: 500,
+  plate_image_portrait: 1024,
+  plate_image_landscape: 1024,
+};
+
+/** Classes that share the 1900px capture size as `image_full`. */
+const IMAGE_FULL_PREFIX = 'image_full';
+
+export function validatePrhImageAssets(input: PrhImageAssetsInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  const hostClassMap = buildHostClassMap(input.xhtmlFiles, input.images);
+
+  for (const image of input.images) {
+    if (!image.mediaType.startsWith('image/')) continue;
+
+    // 1. Capture size — requires a class match.
+    const captureRule = inferCaptureSize(hostClassMap.get(image.path));
+    if (captureRule !== null && image.width !== null) {
+      const tolerance = captureRule * CAPTURE_SIZE_TOLERANCE;
+      if (Math.abs(image.width - captureRule) > tolerance) {
+        issues.push(
+          buildIssue(
+            'PRH-IMG-CAPTURE-SIZE-WRONG',
+            image.path,
+            ` (actual ${image.width}px, expected ${captureRule}px ±${Math.round(tolerance)}px)`,
+          ),
+        );
+      }
+    }
+
+    // 2. DPI minimum. Skip on null (EXIF-stripped).
+    if (image.density !== null && image.density > 0 && image.density < DPI_MIN) {
+      issues.push(
+        buildIssue(
+          'PRH-IMG-DPI-TOO-LOW',
+          image.path,
+          ` (${image.density}dpi < ${DPI_MIN}dpi minimum)`,
+        ),
+      );
+    }
+
+    // 3. sRGB. Skip on null colorSpace.
+    if (image.colorSpace !== null && image.colorSpace.toLowerCase() !== 'srgb') {
+      issues.push(
+        buildIssue(
+          'PRH-IMG-COLORSPACE-NOT-SRGB',
+          image.path,
+          ` (actual: ${image.colorSpace})`,
+        ),
+      );
+    }
+
+    // 4. PNG-expected-JPEG heuristic. Only for JPEGs.
+    if (
+      image.mediaType === 'image/jpeg'
+      && image.width !== null
+      && image.colorCount !== null
+      && image.width <= PNG_EXPECTED_WIDTH_MAX
+      && image.colorCount <= PNG_EXPECTED_COLOR_COUNT_MAX
+    ) {
+      issues.push(
+        buildIssue(
+          'PRH-IMG-PNG-EXPECTED-JPEG',
+          image.path,
+          ` (${image.width}px wide, ${image.colorCount} distinct colours — looks like a line drawing)`,
+        ),
+      );
+    }
+
+    // 5. JPEG quality heuristic. Cover exempt.
+    if (
+      image.mediaType === 'image/jpeg'
+      && !image.isCover
+      && image.width !== null
+      && image.height !== null
+      && image.sizeBytes > 0
+    ) {
+      const pixels = image.width * image.height;
+      if (pixels > 0) {
+        const bpp = image.sizeBytes / pixels;
+        if (bpp > JPEG_QUALITY_BYTES_PER_PIXEL_MAX) {
+          issues.push(
+            buildIssue(
+              'PRH-IMG-JPEG-QUALITY-SUSPECT',
+              image.path,
+              ` (${bpp.toFixed(2)} bytes/pixel > ${JPEG_QUALITY_BYTES_PER_PIXEL_MAX} — quality looks higher than the PRH "8" target)`,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Walk every XHTML file and build a map from image-path → set of
+ * class tokens applied to the `<img>` element that references it.
+ * Multiple `<img>` elements can reference the same image (rare but
+ * possible), so each path can carry several classes.
+ *
+ * Image paths are resolved relative to the XHTML file's directory
+ * because `<img src="...">` is a sibling-relative reference.
+ */
+function buildHostClassMap(
+  xhtmlFiles: PrhXhtmlFile[],
+  images: PrhImageMetadata[],
+): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  const knownPaths = new Set(images.map((i) => i.path));
+
+  for (const file of xhtmlFiles) {
+    const dir = file.path.includes('/')
+      ? file.path.slice(0, file.path.lastIndexOf('/'))
+      : '';
+    // Match <img …> tags; capture the open-tag attribute chunk so we
+    // can read src + class independently. The `[^>]*` is fine here
+    // because <img> tags cannot legitimately contain '>' inside an
+    // attribute value (HTML/XML requires &gt; escaping).
+    for (const m of file.content.matchAll(/<img\b([^>]*)>/gi)) {
+      const attrs = m[1];
+      const srcMatch = attrs.match(/(?:^|\s)src\s*=\s*["']([^"']+)["']/i);
+      if (!srcMatch) continue;
+      const resolved = resolveRelative(dir, srcMatch[1]);
+      if (!knownPaths.has(resolved)) continue;
+      const classMatch = attrs.match(/(?:^|\s)class\s*=\s*["']([^"']+)["']/i);
+      const tokens = classMatch ? classMatch[1].split(/\s+/).filter(Boolean) : [];
+      if (tokens.length === 0) continue;
+      let set = out.get(resolved);
+      if (!set) {
+        set = new Set<string>();
+        out.set(resolved, set);
+      }
+      for (const t of tokens) set.add(t);
+    }
+  }
+  return out;
+}
+
+/**
+ * Pick the canonical capture size for a set of host classes. If
+ * none of the classes maps to a known capture size, returns null
+ * (no enforcement). When multiple classes match, the first match
+ * wins by lookup order — in practice an `<img>` carries at most one
+ * size-class.
+ */
+function inferCaptureSize(classes: Set<string> | undefined): number | null {
+  if (!classes) return null;
+  for (const cls of classes) {
+    if (cls.startsWith(IMAGE_FULL_PREFIX)) return 1900;
+    if (cls in CAPTURE_SIZES) return CAPTURE_SIZES[cls];
+  }
+  return null;
+}
+
+/**
+ * Resolve a relative `src` against the XHTML file's directory.
+ * Mirrors the OPF-relative resolver in run-validators.ts but stays
+ * local so this validator has no orchestrator dependencies.
+ */
+function resolveRelative(dir: string, href: string): string {
+  if (href.startsWith('/')) return href.slice(1);
+  const combined = dir.length > 0 ? `${dir}/${href}` : href;
+  const segments = combined.split('/');
+  const out: string[] = [];
+  for (const seg of segments) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      out.pop();
+      continue;
+    }
+    out.push(seg);
+  }
+  return out.join('/');
+}
+
+function buildIssue(
+  code:
+    | 'PRH-IMG-CAPTURE-SIZE-WRONG'
+    | 'PRH-IMG-DPI-TOO-LOW'
+    | 'PRH-IMG-COLORSPACE-NOT-SRGB'
+    | 'PRH-IMG-PNG-EXPECTED-JPEG'
+    | 'PRH-IMG-JPEG-QUALITY-SUSPECT',
+  location: string,
+  detail = '',
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location}${detail}`,
+    suggestion: suggestionFor(code),
+    location,
+  };
+}
+
+function suggestionFor(code: string): string {
+  switch (code) {
+    case 'PRH-IMG-CAPTURE-SIZE-WRONG':
+      return 'Re-export the image at the canonical capture size for its CSS class (Technical Guide §11). If the class is wrong for the content, change the class instead.';
+    case 'PRH-IMG-DPI-TOO-LOW':
+      return 'Re-export from the original at ≥ 300dpi. Keep the embedded density metadata; some pipelines strip EXIF, which would suppress this finding entirely.';
+    case 'PRH-IMG-COLORSPACE-NOT-SRGB':
+      return 'Convert to sRGB in your image-prep pipeline (ICC profile assignment or colour-space conversion as appropriate).';
+    case 'PRH-IMG-PNG-EXPECTED-JPEG':
+      return 'Re-encode this image as PNG-8 — line drawings, schematics and text-replacement glyphs compress dramatically better with a small palette and avoid JPEG compression artefacts on hard edges.';
+    case 'PRH-IMG-JPEG-QUALITY-SUSPECT':
+      return 'Re-encode at JPEG quality 8 (NOT 9 / 10 / "max"). Cover images are exempt; reduce non-cover quality to keep the EPUB compact.';
+    default:
+      return '';
+  }
+}

--- a/src/services/epub/profiles/prh-uk/validators/types.ts
+++ b/src/services/epub/profiles/prh-uk/validators/types.ts
@@ -99,3 +99,45 @@ export interface PrhFileLayoutInput extends PrhValidatorInput {
    *  becomes required when this flag is set). */
   requiresNcx: boolean;
 }
+
+/**
+ * Pre-computed metadata for one image asset. The orchestrator runs
+ * sharp once per image and passes the resulting metadata to the
+ * validator so the validator stays pure / synchronous / cheap.
+ *
+ * Any field is `null` when sharp couldn't determine it — for
+ * example, sharp returns `density: 0` (mapped here to `null`) when
+ * the source EXIF has been stripped; we do NOT emit
+ * `PRH-IMG-DPI-TOO-LOW` on `null` because stripped EXIF is a common
+ * production-pipeline artefact, not a quality signal.
+ */
+export interface PrhImageMetadata {
+  /** Zip-relative path of the image. */
+  path: string;
+  /** OPF manifest media-type (lowercased). */
+  mediaType: string;
+  /** Image width in pixels. */
+  width: number | null;
+  /** Image height in pixels. */
+  height: number | null;
+  /** Density (DPI) — null when EXIF strips the value; rule
+   *  intentionally skips emission on null to avoid noise on
+   *  EXIF-stripped sources. */
+  density: number | null;
+  /** Color space as reported by sharp ('srgb' / 'rgb16' / 'cmyk' / ...). */
+  colorSpace: string | null;
+  /** Distinct colour count for the PNG-vs-JPEG heuristic; null when
+   *  unavailable (computing it is non-trivial for very large images,
+   *  the orchestrator may decide to skip it). */
+  colorCount: number | null;
+  /** Uncompressed image file size in bytes. */
+  sizeBytes: number;
+  /** True when this image is the manifest cover (properties="cover-image"). */
+  isCover: boolean;
+}
+
+/** Inputs the image-assets validator reads. */
+export interface PrhImageAssetsInput extends PrhPerXhtmlInput {
+  /** Pre-computed metadata for every image asset in the manifest. */
+  images: PrhImageMetadata[];
+}

--- a/tests/unit/services/epub/profiles/prh-uk/validators/image-assets-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/image-assets-validator.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhImageAssets } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/image-assets-validator';
+import type {
+  PrhImageAssetsInput,
+  PrhImageMetadata,
+  PrhXhtmlFile,
+} from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function image(
+  path: string,
+  opts: Partial<PrhImageMetadata> = {},
+): PrhImageMetadata {
+  return {
+    path,
+    mediaType: opts.mediaType ?? 'image/jpeg',
+    width: opts.width ?? 1900,
+    height: opts.height ?? 2400,
+    density: opts.density ?? 300,
+    colorSpace: opts.colorSpace ?? 'srgb',
+    colorCount: opts.colorCount ?? null,
+    sizeBytes: opts.sizeBytes ?? 400_000,
+    isCover: opts.isCover ?? false,
+  };
+}
+
+function xhtmlFile(path: string, body: string): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title></head>
+<body>${body}</body>
+</html>`,
+  };
+}
+
+function input(opts: {
+  images?: PrhImageMetadata[];
+  xhtmlFiles?: PrhXhtmlFile[];
+} = {}): PrhImageAssetsInput {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles: opts.xhtmlFiles ?? [],
+    images: opts.images ?? [],
+  };
+}
+
+describe('validatePrhImageAssets — PRH-IMG-CAPTURE-SIZE-WRONG', () => {
+  it('emits when an image referenced by .portrait_large is not 1900px ±5%', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [image('EPUB/images/diagram.jpg', { width: 1600 })],
+        xhtmlFiles: [
+          xhtmlFile(
+            'EPUB/xhtml/chapter_001.xhtml',
+            '<img class="portrait_large" src="../images/diagram.jpg" alt=""/>',
+          ),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-CAPTURE-SIZE-WRONG')).toBe(true);
+  });
+
+  it('does NOT emit when the width is within the 5% tolerance', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        // 1900px ±95px = 1805..1995
+        images: [image('EPUB/images/diagram.jpg', { width: 1850 })],
+        xhtmlFiles: [
+          xhtmlFile(
+            'EPUB/xhtml/chapter_001.xhtml',
+            '<img class="portrait_large" src="../images/diagram.jpg" alt=""/>',
+          ),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-CAPTURE-SIZE-WRONG')).toBe(false);
+  });
+
+  it('treats image_full* classes as 1900px (prefix match)', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [image('EPUB/images/hero.jpg', { width: 1200 })],
+        xhtmlFiles: [
+          xhtmlFile(
+            'EPUB/xhtml/chapter_001.xhtml',
+            '<img class="image_full_caption_landscape" src="../images/hero.jpg" alt=""/>',
+          ),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-CAPTURE-SIZE-WRONG')).toBe(true);
+  });
+
+  it('does NOT emit when the host class does not map to a canonical capture size', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [image('EPUB/images/diagram.jpg', { width: 500 })],
+        xhtmlFiles: [
+          xhtmlFile(
+            'EPUB/xhtml/chapter_001.xhtml',
+            '<img class="custom_diagram" src="../images/diagram.jpg" alt=""/>',
+          ),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-CAPTURE-SIZE-WRONG')).toBe(false);
+  });
+
+  it('does NOT emit when no <img> in the EPUB references the image', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [image('EPUB/images/orphan.jpg', { width: 500 })],
+        xhtmlFiles: [],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-CAPTURE-SIZE-WRONG')).toBe(false);
+  });
+
+  it('handles space-separated class tokens (.portrait_large among others)', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [image('EPUB/images/diagram.jpg', { width: 500 })],
+        xhtmlFiles: [
+          xhtmlFile(
+            'EPUB/xhtml/chapter_001.xhtml',
+            '<img class="caption_above portrait_large no_indent" src="../images/diagram.jpg" alt=""/>',
+          ),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-CAPTURE-SIZE-WRONG')).toBe(true);
+  });
+});
+
+describe('validatePrhImageAssets — PRH-IMG-DPI-TOO-LOW', () => {
+  it('emits when density is below 300', () => {
+    const issues = validatePrhImageAssets(
+      input({ images: [image('EPUB/images/x.jpg', { density: 200 })] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-DPI-TOO-LOW')).toBe(true);
+  });
+
+  it('does NOT emit when density is exactly 300', () => {
+    const issues = validatePrhImageAssets(
+      input({ images: [image('EPUB/images/x.jpg', { density: 300 })] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-DPI-TOO-LOW')).toBe(false);
+  });
+
+  it('does NOT emit when density is null (EXIF stripped)', () => {
+    const issues = validatePrhImageAssets(
+      input({ images: [image('EPUB/images/x.jpg', { density: null })] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-DPI-TOO-LOW')).toBe(false);
+  });
+});
+
+describe('validatePrhImageAssets — PRH-IMG-COLORSPACE-NOT-SRGB', () => {
+  it('emits when colorSpace is CMYK', () => {
+    const issues = validatePrhImageAssets(
+      input({ images: [image('EPUB/images/x.jpg', { colorSpace: 'cmyk' })] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-COLORSPACE-NOT-SRGB')).toBe(true);
+  });
+
+  it('does NOT emit when colorSpace is srgb (any case)', () => {
+    const issues = validatePrhImageAssets(
+      input({ images: [image('EPUB/images/x.jpg', { colorSpace: 'sRGB' })] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-COLORSPACE-NOT-SRGB')).toBe(false);
+  });
+
+  it('does NOT emit when colorSpace is null', () => {
+    const issues = validatePrhImageAssets(
+      input({ images: [image('EPUB/images/x.jpg', { colorSpace: null })] }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-COLORSPACE-NOT-SRGB')).toBe(false);
+  });
+});
+
+describe('validatePrhImageAssets — PRH-IMG-PNG-EXPECTED-JPEG', () => {
+  it('emits for a small low-colour JPEG (line-drawing heuristic)', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          image('EPUB/images/diagram.jpg', { width: 600, height: 400, colorCount: 32 }),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-PNG-EXPECTED-JPEG')).toBe(true);
+  });
+
+  it('does NOT emit when width > 800 (photo-sized)', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          image('EPUB/images/photo.jpg', { width: 1900, height: 1200, colorCount: 32 }),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-PNG-EXPECTED-JPEG')).toBe(false);
+  });
+
+  it('does NOT emit when colorCount > 256 (full-colour content)', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          image('EPUB/images/thumb.jpg', { width: 600, height: 400, colorCount: 5000 }),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-PNG-EXPECTED-JPEG')).toBe(false);
+  });
+
+  it('does NOT emit for PNGs (rule is JPEG-only)', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          image('EPUB/images/diagram.png', {
+            mediaType: 'image/png',
+            width: 600,
+            height: 400,
+            colorCount: 32,
+          }),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-PNG-EXPECTED-JPEG')).toBe(false);
+  });
+
+  it('does NOT emit when colorCount is null (heuristic skipped)', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          image('EPUB/images/diagram.jpg', {
+            width: 600,
+            height: 400,
+            colorCount: null,
+          }),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-PNG-EXPECTED-JPEG')).toBe(false);
+  });
+});
+
+describe('validatePrhImageAssets — PRH-IMG-JPEG-QUALITY-SUSPECT', () => {
+  it('emits when bytes-per-pixel exceeds 0.5', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          // 1000 * 1000 = 1e6 px, 700KB ≈ 0.7 bytes/px → over threshold
+          image('EPUB/images/photo.jpg', {
+            width: 1000,
+            height: 1000,
+            sizeBytes: 700_000,
+          }),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-JPEG-QUALITY-SUSPECT')).toBe(true);
+  });
+
+  it('does NOT emit at or below 0.5 bytes/pixel', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          // 1000 * 1000 = 1e6 px, 400KB ≈ 0.4 bytes/px → under threshold
+          image('EPUB/images/photo.jpg', {
+            width: 1000,
+            height: 1000,
+            sizeBytes: 400_000,
+          }),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-JPEG-QUALITY-SUSPECT')).toBe(false);
+  });
+
+  it('exempts the cover image', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          image('EPUB/images/cover.jpg', {
+            width: 1000,
+            height: 1000,
+            sizeBytes: 900_000,
+            isCover: true,
+          }),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-JPEG-QUALITY-SUSPECT')).toBe(false);
+  });
+
+  it('does NOT emit for PNGs (rule is JPEG-only)', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          image('EPUB/images/diagram.png', {
+            mediaType: 'image/png',
+            width: 1000,
+            height: 1000,
+            sizeBytes: 900_000,
+          }),
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.code === 'PRH-IMG-JPEG-QUALITY-SUSPECT')).toBe(false);
+  });
+});
+
+describe('validatePrhImageAssets — overall', () => {
+  it('emits zero issues for a conformant image', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          image('EPUB/images/cover.jpg', {
+            width: 1900,
+            height: 2400,
+            density: 300,
+            colorSpace: 'srgb',
+            sizeBytes: 400_000,
+            isCover: true,
+          }),
+        ],
+      }),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('skips non-image manifest entries', () => {
+    const issues = validatePrhImageAssets(
+      input({
+        images: [
+          {
+            path: 'EPUB/styles/basestyles.css',
+            mediaType: 'text/css',
+            width: null,
+            height: null,
+            density: null,
+            colorSpace: null,
+            colorCount: null,
+            sizeBytes: 1000,
+            isCover: false,
+          },
+        ],
+      }),
+    );
+    expect(issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Third PR of P6. Adds a detect-only validator for the PRH image-asset rules in Technical Guide §§11-12 — capture size per CSS class, ≥300dpi, sRGB, PNG-8 for line drawings, JPEG quality cap.

Five new codes, all P3 (advisory — does not block deliverable export):

| Code | Severity | Detects |
|---|---|---|
| \`PRH-IMG-CAPTURE-SIZE-WRONG\` | moderate | Image width does not match the canonical capture size for its CSS class (e.g. \`.portrait_large\` = 1900px ±5%) |
| \`PRH-IMG-DPI-TOO-LOW\` | minor | Embedded density < 300dpi (null densities — EXIF-stripped sources — are deliberately NOT flagged) |
| \`PRH-IMG-COLORSPACE-NOT-SRGB\` | moderate | sharp reports anything other than sRGB |
| \`PRH-IMG-PNG-EXPECTED-JPEG\` | minor | Small low-colour JPEG looks like a line drawing — should be PNG-8 (heuristic: width ≤ 800 AND ≤256 distinct colours) |
| \`PRH-IMG-JPEG-QUALITY-SUSPECT\` | minor | Bytes-per-pixel > 0.5 suggests JPEG quality > 9. Cover image exempt |

Detect-only — auto-resize / re-encode lives in P7 if/when demanded.

### Architecture

The validator is **pure / synchronous**. The orchestrator runs sharp once per manifested image (\`readImageMetadata\`) and passes the resulting \`PrhImageMetadata[]\` to the validator. Per-image sharp failures are caught locally and logged at warn so they never abort the audit.

The PNG-vs-JPEG colour-count probe is **bounded to images ≤ 800px wide** to avoid decoding a 4000px hero illustration just to discard the result at the width gate.

### Capture-size table (hardcoded from Technical Guide §11)

\`\`\`
.cover_image, .image_full*, .portrait_large, .landscape_large   →  1900px
.portrait_medium, .landscape_medium                             →  1600px
.portrait_small, .landscape_small, .plate_image_*               →  1024px
.portrait_xsmall, .landscape_xsmall                             →   500px
\`\`\`

Host-class lookup walks every \`<img>\` element in the XHTML files and builds a path-keyed class map; multiple references to the same image union their classes.

### Conformance report

- \`TIER_CODE_COUNT.P3\` bumped 26 → 31
- \`priorityTierForCode\` maps \`PRH-IMG-*\` → P3

## Test plan
- [x] 23 new unit tests — all 5 rules + edge cases (5% tolerance, EXIF-stripped density, sRGB case-insensitivity, cover-exemption, non-image manifest entries, host-class lookup with space-separated tokens, \`image_full*\` prefix-match)
- [x] Existing 19 conformance-report tests still pass (no behaviour change beyond tier count bump)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean (\`--max-warnings 0\`)
- [ ] Staging smoke: re-audit any PRH-UK book and confirm \`PRH-IMG-*\` codes surface as P3 advisory issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced EPUB image validation: capture-size vs CSS expectations, 300 dpi minimum, sRGB requirement, PNG-expected heuristic for line art, and JPEG-quality suspicion for non-cover images.
* **Reports**
  * Image-related findings are now counted as P3 priority and appear in PRH-UK conformance reports.
* **Tests**
  * Added unit tests covering the new image rules and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/393)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->