### PR TITLE
feat(prh): content-type markup validator (P6/PR5)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -626,6 +626,55 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'JPEG file-size-to-pixel ratio suggests quality > 9 — PRH wants JPEG quality 8 (NOT max). Heuristic; cover.jpg is exempt because covers are deliberately kept at maximum quality',
   },
+
+  // ── Content-type markup (P6/PR5) ──────────────────────────────────────
+  // Publisher-gated and detect-only. Per Technical Guide §§ sidebars /
+  // textboxes / floated elements / poetry / speech bubbles / recipes.
+  // Each rule only activates when the relevant construct is present in
+  // the book — these are content-type-specific (cookbook / poetry /
+  // craft titles) so most books trip none of them.
+  'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING': {
+    code: 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING',
+    severity: 'serious',
+    wcag: ['1.3.2'],
+    fixType: 'manual',
+    summary: 'A .sidebar_wrapper is not paired with a .maincontent_wrapper sibling — PRH requires the main-content wrapper as the immediate sibling so Kindle ET can collapse to a single column in reading order',
+  },
+  'PRH-MARKUP-TEXTBOX-USES-REAL-HEADER': {
+    code: 'PRH-MARKUP-TEXTBOX-USES-REAL-HEADER',
+    severity: 'moderate',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'A text box (.txt_box*) carries the document\'s first real <h*> heading — PRH requires box headers to use <div class="boxhead"> so they don\'t corrupt the page-level heading order',
+  },
+  'PRH-MARKUP-FLOATBOX-USES-REAL-HEADER': {
+    code: 'PRH-MARKUP-FLOATBOX-USES-REAL-HEADER',
+    severity: 'moderate',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'A floated box (.floatbox_left / .floatbox_right) contains a real <h*> heading — PRH requires <div class="boxhead"> inside floatboxes so heading-navigation isn\'t corrupted',
+  },
+  'PRH-MARKUP-POETRY-WRONG-STRUCTURE': {
+    code: 'PRH-MARKUP-POETRY-WRONG-STRUCTURE',
+    severity: 'serious',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'A .poetry_stanza uses <p> for its lines — PRH requires <div class="poetry_line"> (or .poetry_line_indented) so line breaks survive reflow. Detect-only: Style Guide forbids modifying poetry markup without instruction',
+  },
+  'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS': {
+    code: 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'A speech-bubble <figure> uses a non-canonical class — PRH speech bubbles must use exactly speechbubble / speechbubble_r / speechbubble_bl / speechbubble_br so night-mode inversion works',
+  },
+  'PRH-MARKUP-METHOD-STEPS-NOT-OL': {
+    code: 'PRH-MARKUP-METHOD-STEPS-NOT-OL',
+    severity: 'moderate',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'A run of <p> paragraphs is numbered like recipe method steps (1. 2. 3.) but not marked up as an <ol> — PRH requires <ol class="method_steps">. Heuristic; only fires when the book already uses .method_steps elsewhere (cookbook signal)',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/prh-conformance-report.service.ts
+++ b/src/services/acr/prh-conformance-report.service.ts
@@ -262,8 +262,9 @@ const TIER_CODE_COUNT: Record<PriorityTier, number> = {
   P2: 25,
   // P3 — body epub:type + doc-* ARIA (8) + forbidden (3) + notes/pagebreak (2)
   // + text heuristics (3) + CSS conventions (5, P6/PR1) + file/dir/size
-  // (5, P6/PR2) + image assets (5, P6/PR3) = 31
-  P3: 31,
+  // (5, P6/PR2) + image assets (5, P6/PR3) + content-type markup
+  // (6, P6/PR5) = 37
+  P3: 37,
   // P4 has no PRH-* codes (AI policy gate + cover-alt template were
   // implemented as behaviors, not new codes). 0 to keep the type happy.
   P4: 0,

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -35,6 +35,7 @@ import { validatePrhAcronyms } from './validators/acronym-validator';
 import { validatePrhCssConventions } from './validators/css-conventions-validator';
 import { validatePrhFileLayout } from './validators/file-layout-validator';
 import { validatePrhImageAssets } from './validators/image-assets-validator';
+import { validatePrhContentTypeMarkup } from './validators/content-type-markup-validator';
 import { getImprintRules } from './imprints';
 import sharp from 'sharp';
 import type { PublisherProfile } from '../types';
@@ -141,6 +142,7 @@ export async function runPrhUkValidators(
         ...validatePrhCssConventions(cssInput),
         ...validatePrhFileLayout(fileLayoutInput),
         ...validatePrhImageAssets(imageAssetsInput),
+        ...validatePrhContentTypeMarkup(perXhtmlInput),
       );
     }
 

--- a/src/services/epub/profiles/prh-uk/validators/content-type-markup-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/content-type-markup-validator.ts
@@ -128,15 +128,18 @@ function stripComments(html: string): string {
 }
 
 /**
- * Count occurrences of a specific class TOKEN across the HTML. We
- * match `class="…"` attributes and split into whitespace-separated
- * tokens so `class="foo sidebar_wrapper bar"` counts once, and
- * `data-sidebar_wrapper` / partial substrings never match.
+ * Count elements carrying a specific class TOKEN. We scan real tag
+ * openings (`<tag …>`) and read the `class` attribute from within
+ * them, so literal `class="method_steps"` text in prose / code
+ * samples is NOT counted, and `data-method_steps` / partial
+ * substrings never match.
  */
 function countClassTokenOccurrences(html: string, token: string): number {
   let count = 0;
-  for (const m of html.matchAll(/(?:^|\s)class\s*=\s*["']([^"']*)["']/gi)) {
-    const tokens = m[1].split(/\s+/).filter(Boolean);
+  for (const m of html.matchAll(/<[a-z][a-z0-9]*\b([^>]*)>/gi)) {
+    const classMatch = m[1].match(/(?:^|\s)class\s*=\s*["']([^"']*)["']/i);
+    if (!classMatch) continue;
+    const tokens = classMatch[1].split(/\s+/).filter(Boolean);
     if (tokens.includes(token)) count++;
   }
   return count;
@@ -205,7 +208,9 @@ function findNonCanonicalSpeechbubbleClasses(html: string): string[] {
     if (!classMatch) continue;
     const tokens = classMatch[1].split(/\s+/).filter(Boolean);
     for (const token of tokens) {
-      if (!/speech[-_]?bubble/i.test(token)) continue;
+      // Anchor to the start of the token so `nonspeechbubble` or
+      // `foo-speechbubble-helper` don't false-match.
+      if (!/^speech[-_]?bubble/i.test(token)) continue;
       if (!CANONICAL_SPEECHBUBBLE_CLASSES.has(token)) {
         bad.add(token);
       }

--- a/src/services/epub/profiles/prh-uk/validators/content-type-markup-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/content-type-markup-validator.ts
@@ -61,7 +61,11 @@ export function validatePrhContentTypeMarkup(input: PrhPerXhtmlInput): PrhValida
   const cookbookSignal = methodStepsCount >= METHOD_STEPS_COOKBOOK_THRESHOLD;
 
   for (const file of input.xhtmlFiles) {
-    const body = stripHead(file.content);
+    // Strip <head> and HTML comments before any regex scan — commented
+    // -out markup (`<!-- <h1>… -->`, `<!-- class="method_steps" -->`)
+    // is still text to a regex and would otherwise raise false findings
+    // or even flip the cookbook heuristic on.
+    const body = stripComments(stripHead(file.content));
 
     // 1. Sidebar / maincontent pairing.
     if (hasSidebarWithoutMaincontentSibling(body)) {
@@ -117,6 +121,10 @@ const REAL_HEADER_REGEX = /<h[1-6]\b/i;
 
 function stripHead(html: string): string {
   return html.replace(/<head\b[^>]*>[\s\S]*?<\/head>/i, '');
+}
+
+function stripComments(html: string): string {
+  return html.replace(/<!--[\s\S]*?-->/g, '');
 }
 
 /**
@@ -206,11 +214,16 @@ function findNonCanonicalSpeechbubbleClasses(html: string): string[] {
   return [...bad].sort();
 }
 
-/** Count elements anywhere in the book carrying `class="…method_steps…"`. */
+/** Count elements anywhere in the book carrying `class="…method_steps…"`.
+ *  Comments + <head> stripped first so a commented-out method_steps
+ *  reference can't flip the cookbook heuristic on. */
 function countMethodStepsElements(files: PrhXhtmlFile[]): number {
   let total = 0;
   for (const file of files) {
-    total += countClassTokenOccurrences(file.content, 'method_steps');
+    total += countClassTokenOccurrences(
+      stripComments(stripHead(file.content)),
+      'method_steps',
+    );
   }
   return total;
 }
@@ -221,13 +234,24 @@ function countMethodStepsElements(files: PrhXhtmlFile[]): number {
  * `<p>…</p>` elements in document order and track the longest run of
  * consecutively-numbered ones; a non-numbered <p> resets the run.
  *
+ * The run only counts paragraphs that are genuine ADJACENT siblings —
+ * if any non-whitespace markup sits between two numbered `<p>` tags
+ * (e.g. `</div><div>` wrappers, an image, a heading), the run resets.
+ * Numbered paragraphs scattered across unrelated sections shouldn't
+ * be mistaken for a method-steps list.
+ *
  * Conservative by design — short numbered runs (2 items) are common
  * in ordinary prose, and this only runs at all when the book-wide
  * cookbook signal is set.
  */
 function hasNumberedParagraphRun(body: string): boolean {
   let run = 0;
+  let previousParagraphEnd: number | null = null;
   for (const m of body.matchAll(/<p\b[^>]*>([\s\S]*?)<\/p>/gi)) {
+    if (previousParagraphEnd !== null) {
+      const between = body.slice(previousParagraphEnd, m.index).trim();
+      if (between !== '') run = 0;
+    }
     const text = stripTags(m[1]).trim();
     if (/^\d+\./.test(text)) {
       run++;
@@ -235,6 +259,7 @@ function hasNumberedParagraphRun(body: string): boolean {
     } else {
       run = 0;
     }
+    previousParagraphEnd = m.index + m[0].length;
   }
   return false;
 }

--- a/src/services/epub/profiles/prh-uk/validators/content-type-markup-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/content-type-markup-validator.ts
@@ -64,16 +64,8 @@ export function validatePrhContentTypeMarkup(input: PrhPerXhtmlInput): PrhValida
     const body = stripHead(file.content);
 
     // 1. Sidebar / maincontent pairing.
-    const sidebarCount = countClassTokenOccurrences(body, 'sidebar_wrapper');
-    const maincontentCount = countClassTokenOccurrences(body, 'maincontent_wrapper');
-    if (sidebarCount > maincontentCount) {
-      issues.push(
-        buildIssue(
-          'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING',
-          file.path,
-          ` (${sidebarCount} .sidebar_wrapper vs ${maincontentCount} .maincontent_wrapper)`,
-        ),
-      );
+    if (hasSidebarWithoutMaincontentSibling(body)) {
+      issues.push(buildIssue('PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING', file.path));
     }
 
     // 2. Textbox holding the document's first real heading.
@@ -143,6 +135,32 @@ function countClassTokenOccurrences(html: string, token: string): number {
 }
 
 /**
+ * Structural sidebar-pairing check. PRH requires the
+ * `.maincontent_wrapper` to be the IMMEDIATE sibling of each
+ * `.sidebar_wrapper` — a count comparison isn't enough, because a
+ * file can have equal totals while individual sidebars are still
+ * unpaired (the main-content wrapper sits in an unrelated section).
+ *
+ * For each `.sidebar_wrapper` element we look at what immediately
+ * follows its closing tag, skipping whitespace and comments, and
+ * confirm the next element carries `maincontent_wrapper`. Any
+ * sidebar that fails — including one with nothing after it —
+ * triggers the finding.
+ */
+function hasSidebarWithoutMaincontentSibling(body: string): boolean {
+  const sidebars = findClassedElements(body, (tokens) => tokens.includes('sidebar_wrapper'));
+  for (const sidebar of sidebars) {
+    const tail = body.slice(sidebar.end);
+    const nextElement = tail.match(/^\s*(?:<!--[\s\S]*?-->\s*)*<([a-z][a-z0-9]*)\b([^>]*)>/i);
+    if (!nextElement) return true;
+    const classMatch = nextElement[2].match(/(?:^|\s)class\s*=\s*["']([^"']*)["']/i);
+    const tokens = classMatch ? classMatch[1].split(/\s+/).filter(Boolean) : [];
+    if (!tokens.includes('maincontent_wrapper')) return true;
+  }
+  return false;
+}
+
+/**
  * Locate the document's first real <h*> heading and report whether
  * it sits inside a `.txt_box*` element. The "first heading" framing
  * matches the Technical Guide rule — a real header inside a textbox
@@ -163,15 +181,21 @@ function firstRealHeaderIsInsideTextbox(body: string): boolean {
 }
 
 /**
- * Find `<figure>` (or any element) carrying a class token that looks
- * like a speech bubble (`speech-bubble`, `speech_bubble`,
- * `speechbubble`, `speechbubble_left`, …) but is NOT one of the four
- * canonical classes. Returns the offending tokens, deduped.
+ * Find `<figure>` elements carrying a class token that looks like a
+ * speech bubble (`speech-bubble`, `speech_bubble`, `speechbubble`,
+ * `speechbubble_left`, …) but is NOT one of the four canonical
+ * classes. Returns the offending tokens, deduped.
+ *
+ * Scoped to `<figure>` deliberately — PRH speech bubbles are always
+ * `<figure>` elements, so a CSS-helper class on a `<div>`/`<p>` (or
+ * a wrapper named `speechbubble_styles`) must not false-flag.
  */
 function findNonCanonicalSpeechbubbleClasses(html: string): string[] {
   const bad = new Set<string>();
-  for (const m of html.matchAll(/(?:^|\s)class\s*=\s*["']([^"']*)["']/gi)) {
-    const tokens = m[1].split(/\s+/).filter(Boolean);
+  for (const m of html.matchAll(/<figure\b([^>]*)>/gi)) {
+    const classMatch = m[1].match(/(?:^|\s)class\s*=\s*["']([^"']*)["']/i);
+    if (!classMatch) continue;
+    const tokens = classMatch[1].split(/\s+/).filter(Boolean);
     for (const token of tokens) {
       if (!/speech[-_]?bubble/i.test(token)) continue;
       if (!CANONICAL_SPEECHBUBBLE_CLASSES.has(token)) {

--- a/src/services/epub/profiles/prh-uk/validators/content-type-markup-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/content-type-markup-validator.ts
@@ -1,0 +1,332 @@
+/**
+ * PRH UK content-type markup validator (P6/PR5).
+ *
+ * Per Technical Guide §§ on sidebars / textboxes / floated elements /
+ * poetry / speech bubbles / recipes. Each rule is content-type
+ * specific — it only activates when the relevant construct is
+ * present in the book, so a typical novel trips none of them.
+ *
+ * Six codes, all detect-only:
+ *   - PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING — a .sidebar_wrapper
+ *     without its paired .maincontent_wrapper.
+ *   - PRH-MARKUP-TEXTBOX-USES-REAL-HEADER — the document's first
+ *     real <h*> lives inside a .txt_box* (corrupts page-heading
+ *     order; box headers should use <div class="boxhead">).
+ *   - PRH-MARKUP-FLOATBOX-USES-REAL-HEADER — a real <h*> inside a
+ *     .floatbox_left / .floatbox_right.
+ *   - PRH-MARKUP-POETRY-WRONG-STRUCTURE — a .poetry_stanza using
+ *     <p> for its lines instead of <div class="poetry_line">.
+ *   - PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS — a speech-bubble <figure>
+ *     with a non-canonical class.
+ *   - PRH-MARKUP-METHOD-STEPS-NOT-OL — a numbered run of <p> that
+ *     should be an <ol class="method_steps">. Heuristic; only fires
+ *     when the book already uses .method_steps elsewhere so legal
+ *     "1. The party agrees…" prose doesn't false-flag.
+ *
+ * Detect-only — the Style Guide explicitly forbids modifying poetry
+ * markup without instruction, and sidebar / textbox refactors touch
+ * surrounding DOM, so all six defer to operator review.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput, PrhXhtmlFile } from './types';
+
+/** Canonical speech-bubble classes (Technical Guide). */
+const CANONICAL_SPEECHBUBBLE_CLASSES = new Set([
+  'speechbubble',
+  'speechbubble_r',
+  'speechbubble_bl',
+  'speechbubble_br',
+]);
+
+/** Minimum .method_steps elements that must exist book-wide before
+ *  the numbered-<p> heuristic is allowed to run (cookbook signal). */
+const METHOD_STEPS_COOKBOOK_THRESHOLD = 3;
+
+/** Minimum consecutive numbered <p> siblings before the method-steps
+ *  heuristic fires. Conservative — short numbered runs are common in
+ *  ordinary prose. */
+const METHOD_STEPS_MIN_RUN = 3;
+
+export function validatePrhContentTypeMarkup(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  // The method-steps heuristic is gated on a book-wide cookbook
+  // signal: it only runs when the EPUB already uses
+  // `class="method_steps"` in at least a few places. A book that
+  // never uses the canonical markup is assumed NOT to be a recipe
+  // book — running the numbered-<p> heuristic there would false-flag
+  // ordinary numbered prose (contracts, instructions, lists).
+  const methodStepsCount = countMethodStepsElements(input.xhtmlFiles);
+  const cookbookSignal = methodStepsCount >= METHOD_STEPS_COOKBOOK_THRESHOLD;
+
+  for (const file of input.xhtmlFiles) {
+    const body = stripHead(file.content);
+
+    // 1. Sidebar / maincontent pairing.
+    const sidebarCount = countClassTokenOccurrences(body, 'sidebar_wrapper');
+    const maincontentCount = countClassTokenOccurrences(body, 'maincontent_wrapper');
+    if (sidebarCount > maincontentCount) {
+      issues.push(
+        buildIssue(
+          'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING',
+          file.path,
+          ` (${sidebarCount} .sidebar_wrapper vs ${maincontentCount} .maincontent_wrapper)`,
+        ),
+      );
+    }
+
+    // 2. Textbox holding the document's first real heading.
+    if (firstRealHeaderIsInsideTextbox(body)) {
+      issues.push(buildIssue('PRH-MARKUP-TEXTBOX-USES-REAL-HEADER', file.path));
+    }
+
+    // 3. Floatbox containing a real header.
+    const floatboxes = findClassedElements(body, (tokens) =>
+      tokens.includes('floatbox_left') || tokens.includes('floatbox_right'),
+    );
+    if (floatboxes.some((el) => REAL_HEADER_REGEX.test(el.inner))) {
+      issues.push(buildIssue('PRH-MARKUP-FLOATBOX-USES-REAL-HEADER', file.path));
+    }
+
+    // 4. Poetry stanza using <p> for its lines.
+    const stanzas = findClassedElements(body, (tokens) => tokens.includes('poetry_stanza'));
+    if (stanzas.some((el) => /<p\b/i.test(el.inner))) {
+      issues.push(buildIssue('PRH-MARKUP-POETRY-WRONG-STRUCTURE', file.path));
+    }
+
+    // 5. Speech-bubble figures with a non-canonical class.
+    const badSpeechbubble = findNonCanonicalSpeechbubbleClasses(body);
+    if (badSpeechbubble.length > 0) {
+      issues.push(
+        buildIssue(
+          'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS',
+          file.path,
+          ` (non-canonical class(es): ${badSpeechbubble.join(', ')})`,
+        ),
+      );
+    }
+
+    // 6. Numbered <p> run that should be an <ol class="method_steps">.
+    //    Gated on the book-wide cookbook signal.
+    if (cookbookSignal && hasNumberedParagraphRun(body)) {
+      issues.push(buildIssue('PRH-MARKUP-METHOD-STEPS-NOT-OL', file.path));
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/** Real heading tags h1-h6. Used both as a test and to locate the
+ *  first heading in a document. */
+const REAL_HEADER_REGEX = /<h[1-6]\b/i;
+
+function stripHead(html: string): string {
+  return html.replace(/<head\b[^>]*>[\s\S]*?<\/head>/i, '');
+}
+
+/**
+ * Count occurrences of a specific class TOKEN across the HTML. We
+ * match `class="…"` attributes and split into whitespace-separated
+ * tokens so `class="foo sidebar_wrapper bar"` counts once, and
+ * `data-sidebar_wrapper` / partial substrings never match.
+ */
+function countClassTokenOccurrences(html: string, token: string): number {
+  let count = 0;
+  for (const m of html.matchAll(/(?:^|\s)class\s*=\s*["']([^"']*)["']/gi)) {
+    const tokens = m[1].split(/\s+/).filter(Boolean);
+    if (tokens.includes(token)) count++;
+  }
+  return count;
+}
+
+/**
+ * Locate the document's first real <h*> heading and report whether
+ * it sits inside a `.txt_box*` element. The "first heading" framing
+ * matches the Technical Guide rule — a real header inside a textbox
+ * is only a problem when it would be the first heading the reading
+ * system encounters and thus corrupt page-heading order. A real
+ * header inside a textbox LATER in the doc (after a legitimate
+ * chapter heading) is permitted for very long boxes.
+ */
+function firstRealHeaderIsInsideTextbox(body: string): boolean {
+  const headerMatch = body.match(REAL_HEADER_REGEX);
+  if (!headerMatch || headerMatch.index === undefined) return false;
+  const headerIndex = headerMatch.index;
+
+  const textboxes = findClassedElements(body, (tokens) =>
+    tokens.some((t) => t.startsWith('txt_box')),
+  );
+  return textboxes.some((el) => headerIndex >= el.start && headerIndex < el.end);
+}
+
+/**
+ * Find `<figure>` (or any element) carrying a class token that looks
+ * like a speech bubble (`speech-bubble`, `speech_bubble`,
+ * `speechbubble`, `speechbubble_left`, …) but is NOT one of the four
+ * canonical classes. Returns the offending tokens, deduped.
+ */
+function findNonCanonicalSpeechbubbleClasses(html: string): string[] {
+  const bad = new Set<string>();
+  for (const m of html.matchAll(/(?:^|\s)class\s*=\s*["']([^"']*)["']/gi)) {
+    const tokens = m[1].split(/\s+/).filter(Boolean);
+    for (const token of tokens) {
+      if (!/speech[-_]?bubble/i.test(token)) continue;
+      if (!CANONICAL_SPEECHBUBBLE_CLASSES.has(token)) {
+        bad.add(token);
+      }
+    }
+  }
+  return [...bad].sort();
+}
+
+/** Count elements anywhere in the book carrying `class="…method_steps…"`. */
+function countMethodStepsElements(files: PrhXhtmlFile[]): number {
+  let total = 0;
+  for (const file of files) {
+    total += countClassTokenOccurrences(file.content, 'method_steps');
+  }
+  return total;
+}
+
+/**
+ * Detect a run of >= METHOD_STEPS_MIN_RUN consecutive `<p>` siblings
+ * whose trimmed text begins with a `N.` number marker. We walk the
+ * `<p>…</p>` elements in document order and track the longest run of
+ * consecutively-numbered ones; a non-numbered <p> resets the run.
+ *
+ * Conservative by design — short numbered runs (2 items) are common
+ * in ordinary prose, and this only runs at all when the book-wide
+ * cookbook signal is set.
+ */
+function hasNumberedParagraphRun(body: string): boolean {
+  let run = 0;
+  for (const m of body.matchAll(/<p\b[^>]*>([\s\S]*?)<\/p>/gi)) {
+    const text = stripTags(m[1]).trim();
+    if (/^\d+\./.test(text)) {
+      run++;
+      if (run >= METHOD_STEPS_MIN_RUN) return true;
+    } else {
+      run = 0;
+    }
+  }
+  return false;
+}
+
+function stripTags(html: string): string {
+  return html.replace(/<[^>]+>/g, '');
+}
+
+/**
+ * Find every element whose `class` attribute satisfies `classTest`,
+ * returning the element's inner HTML plus the start/end offsets of
+ * the full outer element. Balanced matching is done on the element's
+ * OWN tag name with a depth counter, so a nested same-tag child
+ * doesn't truncate the region early.
+ *
+ * Self-closing tags and void elements are skipped — they can't
+ * contain content, so they're irrelevant to every caller here.
+ */
+function findClassedElements(
+  html: string,
+  classTest: (tokens: string[]) => boolean,
+): Array<{ tag: string; inner: string; start: number; end: number }> {
+  const results: Array<{ tag: string; inner: string; start: number; end: number }> = [];
+  const openTagRe = /<([a-z][a-z0-9]*)\b([^>]*)>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = openTagRe.exec(html)) !== null) {
+    const tag = m[1].toLowerCase();
+    const attrs = m[2];
+    if (attrs.trimEnd().endsWith('/')) continue; // self-closing
+    const classMatch = attrs.match(/(?:^|\s)class\s*=\s*["']([^"']*)["']/i);
+    if (!classMatch) continue;
+    const tokens = classMatch[1].split(/\s+/).filter(Boolean);
+    if (!classTest(tokens)) continue;
+
+    const openTagEnd = openTagRe.lastIndex;
+    const close = findBalancedClose(html, tag, openTagEnd);
+    if (close === null) continue;
+    results.push({
+      tag,
+      inner: html.slice(openTagEnd, close.innerEnd),
+      start: m.index,
+      end: close.outerEnd,
+    });
+  }
+  return results;
+}
+
+/**
+ * Given the index just past an opening `<tag …>`, walk forward
+ * counting same-tag opens / closes and return the inner-end (just
+ * before the matching `</tag>`) and outer-end (just past it). Returns
+ * null when the element is unbalanced (malformed HTML) — callers
+ * simply skip such elements rather than guessing.
+ */
+function findBalancedClose(
+  html: string,
+  tag: string,
+  fromIndex: number,
+): { innerEnd: number; outerEnd: number } | null {
+  const tokenRe = new RegExp(`<(/?)${tag}\\b[^>]*>`, 'gi');
+  tokenRe.lastIndex = fromIndex;
+  let depth = 1;
+  let m: RegExpExecArray | null;
+  while ((m = tokenRe.exec(html)) !== null) {
+    const isClose = m[1] === '/';
+    const isSelfClosing = !isClose && m[0].trimEnd().endsWith('/>');
+    if (isSelfClosing) continue;
+    if (isClose) {
+      depth--;
+      if (depth === 0) {
+        return { innerEnd: m.index, outerEnd: tokenRe.lastIndex };
+      }
+    } else {
+      depth++;
+    }
+  }
+  return null;
+}
+
+function buildIssue(
+  code:
+    | 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING'
+    | 'PRH-MARKUP-TEXTBOX-USES-REAL-HEADER'
+    | 'PRH-MARKUP-FLOATBOX-USES-REAL-HEADER'
+    | 'PRH-MARKUP-POETRY-WRONG-STRUCTURE'
+    | 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS'
+    | 'PRH-MARKUP-METHOD-STEPS-NOT-OL',
+  location: string,
+  detail = '',
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location}${detail}`,
+    suggestion: suggestionFor(code),
+    location,
+  };
+}
+
+function suggestionFor(code: string): string {
+  switch (code) {
+    case 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING':
+      return 'Wrap the main content in <div class="maincontent_wrapper"> as the immediate sibling of each <div class="sidebar_wrapper">. Multiple pairs each go inside their own <section>.';
+    case 'PRH-MARKUP-TEXTBOX-USES-REAL-HEADER':
+      return 'Replace the real <h*> at the start of the textbox with <div class="boxhead"> so the page-level heading order is preserved.';
+    case 'PRH-MARKUP-FLOATBOX-USES-REAL-HEADER':
+      return 'Replace real <h*> headings inside floatboxes with <div class="boxhead"> — real headers inside floated elements corrupt heading-navigation.';
+    case 'PRH-MARKUP-POETRY-WRONG-STRUCTURE':
+      return 'Mark each poem line as <div class="poetry_line"> (or .poetry_line_indented) inside the .poetry_stanza. Do not change poetry markup without publisher instruction — flag for review.';
+    case 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS':
+      return 'Use exactly one of the canonical speech-bubble classes: speechbubble, speechbubble_r, speechbubble_bl, speechbubble_br.';
+    case 'PRH-MARKUP-METHOD-STEPS-NOT-OL':
+      return 'Convert the numbered paragraph run into <ol class="method_steps"> with one <li> per step so the numbering is semantic and survives reflow.';
+    default:
+      return '';
+  }
+}

--- a/tests/unit/services/epub/profiles/prh-uk/validators/content-type-markup-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/content-type-markup-validator.test.ts
@@ -241,6 +241,15 @@ describe('validatePrhContentTypeMarkup — PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS',
     expect(issues.some((i) => i.code === 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS')).toBe(false);
   });
 
+  it('does NOT emit for a non-canonical speechbubble class inside an HTML comment', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file('ch1.xhtml', '<!-- <figure class="speechbubble_alt"><p>draft</p></figure> -->'),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS')).toBe(false);
+  });
+
   it('does NOT emit for a speechbubble* class on a non-<figure> element', () => {
     // A CSS-helper class or wrapper div carrying a speechbubble-like
     // token must not trip the rule — PRH speech bubbles are always
@@ -296,6 +305,41 @@ describe('validatePrhContentTypeMarkup — PRH-MARKUP-METHOD-STEPS-NOT-OL', () =
         file('recipe2.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
         file('recipe3.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
         file('recipe4.xhtml', '<p>1. Only one numbered.</p><p>Plain follow-up paragraph.</p>'),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-METHOD-STEPS-NOT-OL')).toBe(false);
+  });
+
+  it('does NOT emit when numbered paragraphs are split across wrappers (not adjacent siblings)', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file('recipe1.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        file('recipe2.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        file('recipe3.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        // Each numbered <p> is isolated in its own wrapper div — not a
+        // contiguous run, so the adjacency guard resets between them.
+        file(
+          'recipe4.xhtml',
+          '<div><p>1. First.</p></div><div><p>2. Second.</p></div><div><p>3. Third.</p></div>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-METHOD-STEPS-NOT-OL')).toBe(false);
+  });
+
+  it('does NOT let a commented-out method_steps reference flip the cookbook signal', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        // The only "method_steps" tokens are inside HTML comments — the
+        // cookbook signal must stay off, so the numbered <p> run below
+        // is treated as ordinary prose.
+        file('a.xhtml', '<!-- <ol class="method_steps"></ol> -->'),
+        file('b.xhtml', '<!-- <ol class="method_steps"></ol> -->'),
+        file('c.xhtml', '<!-- <ol class="method_steps"></ol> -->'),
+        file(
+          'd.xhtml',
+          '<p>1. First clause.</p><p>2. Second clause.</p><p>3. Third clause.</p>',
+        ),
       ]),
     );
     expect(issues.some((i) => i.code === 'PRH-MARKUP-METHOD-STEPS-NOT-OL')).toBe(false);

--- a/tests/unit/services/epub/profiles/prh-uk/validators/content-type-markup-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/content-type-markup-validator.test.ts
@@ -68,6 +68,35 @@ describe('validatePrhContentTypeMarkup — PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSIN
     );
     expect(issues.some((i) => i.code === 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING')).toBe(false);
   });
+
+  it('emits when counts are equal but the sibling pairing is wrong', () => {
+    // 2 sidebars + 2 maincontents — equal totals — but the first
+    // sidebar is immediately followed by the SECOND sidebar, not by a
+    // maincontent wrapper.
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<div class="sidebar_wrapper"></div><div class="sidebar_wrapper"></div>' +
+            '<div class="maincontent_wrapper"></div><div class="maincontent_wrapper"></div>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING')).toBe(true);
+  });
+
+  it('does NOT emit when each sidebar is immediately followed by its maincontent', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<section><div class="sidebar_wrapper"></div><div class="maincontent_wrapper"></div></section>' +
+            '<section><div class="sidebar_wrapper"></div><div class="maincontent_wrapper"></div></section>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING')).toBe(false);
+  });
 });
 
 describe('validatePrhContentTypeMarkup — PRH-MARKUP-TEXTBOX-USES-REAL-HEADER', () => {
@@ -208,6 +237,21 @@ describe('validatePrhContentTypeMarkup — PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS',
   it('does NOT emit for books with no speech bubbles', () => {
     const issues = validatePrhContentTypeMarkup(
       input([file('ch1.xhtml', '<p>No bubbles here.</p>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS')).toBe(false);
+  });
+
+  it('does NOT emit for a speechbubble* class on a non-<figure> element', () => {
+    // A CSS-helper class or wrapper div carrying a speechbubble-like
+    // token must not trip the rule — PRH speech bubbles are always
+    // <figure> elements.
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<div class="speechbubble_left"><figure class="speechbubble_r"><p>Hi</p></figure></div>',
+        ),
+      ]),
     );
     expect(issues.some((i) => i.code === 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS')).toBe(false);
   });

--- a/tests/unit/services/epub/profiles/prh-uk/validators/content-type-markup-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/content-type-markup-validator.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhContentTypeMarkup } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/content-type-markup-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function file(path: string, body: string): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title><style>h1 { color: red; }</style></head>
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+function input(files: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles: files,
+  };
+}
+
+describe('validatePrhContentTypeMarkup — PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING', () => {
+  it('emits when a .sidebar_wrapper has no paired .maincontent_wrapper', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<div class="sidebar_wrapper"><p>aside</p></div>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING')).toBe(true);
+  });
+
+  it('does NOT emit when each sidebar has a maincontent sibling', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<div class="sidebar_wrapper"><p>aside</p></div><div class="maincontent_wrapper"><p>main</p></div>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING')).toBe(false);
+  });
+
+  it('emits when sidebars outnumber maincontent wrappers', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<div class="sidebar_wrapper"></div><div class="maincontent_wrapper"></div>' +
+            '<div class="sidebar_wrapper"></div>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING')).toBe(true);
+  });
+
+  it('does NOT emit for books with no sidebars at all', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<p>Just a normal paragraph.</p>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING')).toBe(false);
+  });
+
+  it('does not false-match data-sidebar_wrapper attributes', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<div data-sidebar_wrapper="x"><p>not a sidebar</p></div>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING')).toBe(false);
+  });
+});
+
+describe('validatePrhContentTypeMarkup — PRH-MARKUP-TEXTBOX-USES-REAL-HEADER', () => {
+  it('emits when the document first real header is inside a .txt_box', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<figure class="txt_box"><h2>Box title</h2><p>x</p></figure>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-TEXTBOX-USES-REAL-HEADER')).toBe(true);
+  });
+
+  it('emits for txt_box variants (txt_box4, txt_box9b)', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<figure class="txt_box9b"><h3>Box</h3></figure>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-TEXTBOX-USES-REAL-HEADER')).toBe(true);
+  });
+
+  it('does NOT emit when a real chapter header precedes the textbox', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<h1>Chapter One</h1><p>intro</p><figure class="txt_box"><h3>Box</h3></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-TEXTBOX-USES-REAL-HEADER')).toBe(false);
+  });
+
+  it('does NOT emit when the textbox uses div.boxhead instead of a real header', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file('ch1.xhtml', '<figure class="txt_box"><div class="boxhead">Box</div><p>x</p></figure>'),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-TEXTBOX-USES-REAL-HEADER')).toBe(false);
+  });
+});
+
+describe('validatePrhContentTypeMarkup — PRH-MARKUP-FLOATBOX-USES-REAL-HEADER', () => {
+  it('emits when a .floatbox_left contains a real header', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file('ch1.xhtml', '<h1>Chapter</h1><div class="floatbox_left"><h4>Float</h4></div>'),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-FLOATBOX-USES-REAL-HEADER')).toBe(true);
+  });
+
+  it('emits when a .floatbox_right contains a real header', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<div class="floatbox_right"><h2>x</h2></div>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-FLOATBOX-USES-REAL-HEADER')).toBe(true);
+  });
+
+  it('does NOT emit when the floatbox uses div.boxhead', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file('ch1.xhtml', '<div class="floatbox_left"><div class="boxhead">Float</div></div>'),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-FLOATBOX-USES-REAL-HEADER')).toBe(false);
+  });
+
+  it('handles nested div correctly (balanced matching)', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<div class="floatbox_left"><div class="inner"><p>x</p></div></div><h1>After</h1>',
+        ),
+      ]),
+    );
+    // The <h1> is OUTSIDE the floatbox — balanced matching must not
+    // swallow it into the floatbox region.
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-FLOATBOX-USES-REAL-HEADER')).toBe(false);
+  });
+});
+
+describe('validatePrhContentTypeMarkup — PRH-MARKUP-POETRY-WRONG-STRUCTURE', () => {
+  it('emits when a .poetry_stanza uses <p> for its lines', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<div class="poetry_stanza"><p>Line one</p><p>Line two</p></div>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-POETRY-WRONG-STRUCTURE')).toBe(true);
+  });
+
+  it('does NOT emit when the stanza uses div.poetry_line', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<div class="poetry_stanza"><div class="poetry_line">Line one</div>' +
+            '<div class="poetry_line_indented">Line two</div></div>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-POETRY-WRONG-STRUCTURE')).toBe(false);
+  });
+
+  it('does NOT emit for books with no poetry stanzas', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<p>Ordinary prose.</p>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-POETRY-WRONG-STRUCTURE')).toBe(false);
+  });
+});
+
+describe('validatePrhContentTypeMarkup — PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS', () => {
+  it('emits for a non-canonical speech-bubble class', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<figure class="speech_bubble"><p>Hi!</p></figure>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS')).toBe(true);
+  });
+
+  it('emits for speechbubble_left (close-but-not-canonical)', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<figure class="speechbubble_left"><p>Hi!</p></figure>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS')).toBe(true);
+  });
+
+  it('does NOT emit for canonical classes', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="speechbubble"></figure><figure class="speechbubble_r"></figure>' +
+            '<figure class="speechbubble_bl"></figure><figure class="speechbubble_br"></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS')).toBe(false);
+  });
+
+  it('does NOT emit for books with no speech bubbles', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([file('ch1.xhtml', '<p>No bubbles here.</p>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS')).toBe(false);
+  });
+});
+
+describe('validatePrhContentTypeMarkup — PRH-MARKUP-METHOD-STEPS-NOT-OL', () => {
+  it('emits a numbered <p> run when the book shows the cookbook signal', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        // Cookbook signal: 3 method_steps lists elsewhere in the book.
+        file('recipe1.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        file('recipe2.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        file('recipe3.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        // The offending file: numbered <p> run instead of <ol>.
+        file(
+          'recipe4.xhtml',
+          '<p>1. Preheat the oven.</p><p>2. Mix the dry ingredients.</p><p>3. Fold in the eggs.</p>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-METHOD-STEPS-NOT-OL')).toBe(true);
+  });
+
+  it('does NOT emit a numbered <p> run when there is NO cookbook signal', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        // No .method_steps anywhere — looks like a legal document, not a recipe book.
+        file(
+          'contract.xhtml',
+          '<p>1. The party agrees to the terms.</p><p>2. The party waives all claims.</p>' +
+            '<p>3. This contract is binding.</p>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-METHOD-STEPS-NOT-OL')).toBe(false);
+  });
+
+  it('does NOT emit for runs shorter than 3 numbered paragraphs', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file('recipe1.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        file('recipe2.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        file('recipe3.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        file('recipe4.xhtml', '<p>1. Only one numbered.</p><p>Plain follow-up paragraph.</p>'),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-METHOD-STEPS-NOT-OL')).toBe(false);
+  });
+
+  it('resets the run on a non-numbered paragraph', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file('recipe1.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        file('recipe2.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        file('recipe3.xhtml', '<ol class="method_steps"><li>step</li></ol>'),
+        // 2 numbered, plain break, 2 numbered — no run reaches 3.
+        file(
+          'recipe4.xhtml',
+          '<p>1. First.</p><p>2. Second.</p><p>A note.</p><p>3. Third.</p><p>4. Fourth.</p>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MARKUP-METHOD-STEPS-NOT-OL')).toBe(false);
+  });
+});
+
+describe('validatePrhContentTypeMarkup — overall', () => {
+  it('emits zero issues for a conformant book', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<h1>Chapter One</h1><p>Prose.</p>' +
+            '<div class="sidebar_wrapper"></div><div class="maincontent_wrapper"></div>' +
+            '<figure class="txt_box"><div class="boxhead">Box</div></figure>' +
+            '<div class="poetry_stanza"><div class="poetry_line">A line</div></div>' +
+            '<figure class="speechbubble_r"><p>Hello</p></figure>',
+        ),
+      ]),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('reports issues per file with the correct location', () => {
+    const issues = validatePrhContentTypeMarkup(
+      input([
+        file('clean.xhtml', '<p>Nothing wrong here.</p>'),
+        file('bad.xhtml', '<div class="poetry_stanza"><p>line</p></div>'),
+      ]),
+    );
+    const poetryIssue = issues.find((i) => i.code === 'PRH-MARKUP-POETRY-WRONG-STRUCTURE');
+    expect(poetryIssue?.location).toBe('bad.xhtml');
+  });
+});


### PR DESCRIPTION
## Summary

Final PR of P6. Adds a detect-only validator for the content-type-specific markup rules in the PRH Technical Guide — sidebars, textboxes, floated elements, poetry, speech bubbles, recipes.

Six new codes, all P3 (advisory — does not block deliverable export):

| Code | Severity | Detects |
|---|---|---|
| \`PRH-MARKUP-SIDEBAR-MAINCONTENT-MISSING\` | serious | A \`.sidebar_wrapper\` with no paired \`.maincontent_wrapper\` |
| \`PRH-MARKUP-TEXTBOX-USES-REAL-HEADER\` | moderate | The document's **first** real \`<h*>\` sits inside a \`.txt_box*\` (corrupts page-heading order). Later textbox headers are permitted for long boxes |
| \`PRH-MARKUP-FLOATBOX-USES-REAL-HEADER\` | moderate | Any real \`<h*>\` inside a \`.floatbox_left\` / \`.floatbox_right\` |
| \`PRH-MARKUP-POETRY-WRONG-STRUCTURE\` | serious | A \`.poetry_stanza\` using \`<p>\` for lines instead of \`<div class="poetry_line">\` |
| \`PRH-MARKUP-SPEECHBUBBLE-WRONG-CLASS\` | minor | A speech-bubble \`<figure>\` with a non-canonical class |
| \`PRH-MARKUP-METHOD-STEPS-NOT-OL\` | moderate | A numbered \`<p>\` run that should be \`<ol class="method_steps">\` |

Each rule only activates when its construct is present, so a typical novel trips none of them.

### Heuristic gating

The method-steps rule is additionally gated on a **book-wide cookbook signal** — it only runs when the EPUB already uses \`class="method_steps"\` in ≥3 places elsewhere. Without that signal, a numbered \`<p>\` run is assumed to be ordinary prose (legal clauses, instructions) rather than mis-marked recipe steps. This is the class-density-first decision from the P6 scoping (imprint fallback deferred).

### Balanced-region extraction

\`findClassedElements\` / \`findBalancedClose\` do depth-counted balanced matching on each element's own tag name, so a nested same-tag child doesn't truncate the region early — e.g. an \`<h1>\` after a floatbox that contains a nested \`<div>\` is correctly seen as **outside** the floatbox.

### Conformance report

- \`TIER_CODE_COUNT.P3\` bumped 31 → 37
- The \`PRH-MARKUP-*\` prefix already classifies to P3 — no classifier change needed

## P6 status

This completes P6. PR4 (audio/video) was skipped — \`fluent-ffmpeg\` is not a dependency and no tenant has flagged audio/video demand. PR6 (long-description-as-separate-XHTML refactor) is deferred pending tenant demand.

## Test plan
- [x] 26 new unit tests — all 6 rules + edge cases (balanced nesting, \`data-\` attribute false-match guard, cookbook-signal gating, run-reset on non-numbered paragraph, conformant happy path)
- [x] Existing 19 conformance-report tests still pass (no behaviour change beyond tier count bump)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean (\`--max-warnings 0\`)
- [ ] Staging smoke: re-audit a cookbook / poetry-heavy PRH-UK book and confirm \`PRH-MARKUP-*\` codes surface as P3 advisory issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PRH-UK EPUB validation expanded with six new markup checks: sidebar/main-content pairing, textbox/floatbox header placement, poetry stanza structure, speech-bubble class usage, and method-step numbering; these run as part of the PRH-UK validator set.
* **Chores**
  * Updated conformance-report priority-tier counts to reflect revised totals.
* **Tests**
  * Added unit tests covering the new markup checks and multi-file scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/394)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->