### PR TITLE
fix(spike): drain veraPDF stdout via temp file (pipe-buffer deadlock)

### DIFF
--- a/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/RunSpike.java
+++ b/spikes/pdfbox-write/src/main/java/com/ninja/pdfboxspike/RunSpike.java
@@ -159,16 +159,24 @@ public final class RunSpike {
 
     static Validation runVerapdf(File pdf) {
         String bin = System.getenv().getOrDefault("VERAPDF_PATH", "C:/verapdf/verapdf.bat");
-        // veraPDF can take 1–3 minutes on multi-megabyte tagged PDFs (PDFBox
-        // saves richer files than pikepdf, so 60s isn't enough). Override
-        // via VERAPDF_TIMEOUT_SEC for outlier docs.
+        // veraPDF emits ~150-200 KB of XML per doc — far larger than the OS
+        // pipe buffer (~64 KB on Linux). Reading the pipe AFTER waitFor()
+        // deadlocks: veraPDF blocks writing to a full pipe while we block in
+        // waitFor() not draining it. Redirect stdout+stderr to a temp file
+        // so there is no pipe to fill, then read the file once veraPDF exits.
+        // 300s is generous now that the pipe deadlock is fixed — veraPDF
+        // validates these docs in ~10-20s. Override via VERAPDF_TIMEOUT_SEC
+        // if a pathological doc ever needs longer.
         int timeoutSec = Integer.parseInt(
-            System.getenv().getOrDefault("VERAPDF_TIMEOUT_SEC", "600"));
+            System.getenv().getOrDefault("VERAPDF_TIMEOUT_SEC", "300"));
         Validation v = new Validation();
         v.failures = new ArrayList<>();
+        File reportFile = null;
         try {
+            reportFile = File.createTempFile("verapdf-", ".xml");
             ProcessBuilder pb = new ProcessBuilder(bin, "--flavour", "ua1", pdf.getAbsolutePath());
             pb.redirectErrorStream(true);
+            pb.redirectOutput(reportFile);
             Process p = pb.start();
             boolean finished = p.waitFor(timeoutSec, TimeUnit.SECONDS);
             if (!finished) {
@@ -177,7 +185,7 @@ public final class RunSpike {
                 v.failures.add("Validation timed out after " + timeoutSec + "s");
                 return v;
             }
-            String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            String output = Files.readString(reportFile.toPath(), StandardCharsets.UTF_8);
             v.raw = output.length() > 500 ? output.substring(0, 500) : output;
             v.passed = output.contains("isCompliant=\"true\"");
             for (String line : output.split("\n")) {
@@ -192,6 +200,11 @@ public final class RunSpike {
         } catch (Exception e) {
             v.passed = false;
             v.failures.add("Validation error: " + e.getMessage());
+        } finally {
+            if (reportFile != null) {
+                // Best-effort cleanup; a stale temp file shouldn't fail the run.
+                reportFile.delete();
+            }
         }
         return v;
     }


### PR DESCRIPTION
## Summary

The first two PDFBox spike runs reported **17/20 'Validation timed out after 600s'** — which I initially read as "PDFBox produces PDFs veraPDF can't validate." That was wrong. It's a **pipe-buffer deadlock** in `RunSpike.runVerapdf`.

## Root cause

```java
Process p = pb.start();
p.waitFor(timeoutSec, ...);                  // blocks, NOT draining stdout
p.getInputStream().readAllBytes();           // reads only after waitFor returns
```

veraPDF emits ~150–200 KB of XML per document. The Linux pipe buffer is ~64 KB. Once veraPDF fills it, its next `write()` to stdout blocks — and the Java side is parked in `waitFor()` not reading. Classic deadlock; neither side moves until the timeout fires.

The pikepdf spike never hit this because Python's `subprocess.run(capture_output=True)` drains pipes on a reader thread.

## Proof it's the bug, not PDFBox

Running veraPDF **manually** on a PDFBox-written output (with stdout redirected to a file, bypassing the pipe): **12 seconds**, real `isCompliant="false"` verdict. Same doc "timed out at 600s" inside the spike.

## Fix

`ProcessBuilder.redirectOutput(File)` — write veraPDF's stdout+stderr to a temp file, no pipe to fill. Read the file after the process exits; best-effort delete in `finally`.

Also lowered default `VERAPDF_TIMEOUT_SEC` 600 → 300 — the 600s value was only ever compensating for this deadlock.

## Verification

- 2-doc smoke run: **~20 min → 36 s**. Both docs return real veraPDF verdicts (FAIL on clauses 7.18.5 / 7.18.1 — the tab-order/annotation family, same as pikepdf, consistent with both spikes' shared scope limitations).
- Full 20-doc Fargate re-run in progress with the fixed image — real pass rate + CalibrationRun to follow.

## Related

- #389 (PDFBox spike scaffolding), #391 (Dockerfile + PDFBox 3.x API fixes)
- Issue #388 (PDFBox spike tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability and reliability of the PDF validation process
  * Enhanced error handling and recovery during validation operations
  * Updated timeout defaults for validation workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/395)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->