### PR TITLE
feat(spike): pikepdf write path increment 1 — RoleMap, Tabs, measurement

### DIFF
--- a/spikes/pikepdf-write/run_spike.py
+++ b/spikes/pikepdf-write/run_spike.py
@@ -30,14 +30,20 @@ def run_verapdf(pdf_path: str) -> dict:
         output = result.stdout + result.stderr
         # Check isCompliant attribute in veraPDF XML output
         passed = 'isCompliant="true"' in output
-        # Extract only actual failed rule descriptions
-        failures = []
-        for line in output.split('\n'):
-            if 'status="failed"' in line:
-                failures.append(line.strip())
+        # Extract failed rule clauses. Capture ALL of them (not a cap of 10)
+        # so increment-over-increment clause progress on Issue #396 is
+        # measurable — with a 10-line cap you can't tell whether a fix
+        # removed a clause or just pushed it past the cutoff.
+        # Keep only <rule> lines (they carry clause/testNumber); drop the
+        # per-element <check status="failed"> noise.
+        failures = [
+            line.strip()
+            for line in output.split('\n')
+            if 'status="failed"' in line and '<rule ' in line
+        ]
         return {
             'passed':   passed,
-            'failures': failures[:10],  # cap at 10
+            'failures': failures,
             'raw':      output[:500],
         }
     except FileNotFoundError:

--- a/spikes/pikepdf-write/write_tagged_pdf.py
+++ b/spikes/pikepdf-write/write_tagged_pdf.py
@@ -64,15 +64,30 @@ def write_tagged_pdf(
             Type=pikepdf.Name('/StructTreeRoot'),
         )
 
+        # RoleMap (PDF/UA-1 7.3 test 1): map every structure type this
+        # writer emits to its PDF 1.7 standard type. All of these already
+        # ARE standard types, so each maps to itself — but supplying an
+        # explicit RoleMap is the conformant practice and removes any
+        # ambiguity for the validator. Increment-1 of Issue #396.
+        role_map = pikepdf.Dictionary()
+        for _role in ('Document', 'P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
+                      'Table', 'Figure', 'Caption', 'Note'):
+            role_map[pikepdf.Name('/' + _role)] = pikepdf.Name('/' + _role)
+        struct_tree_root.RoleMap = role_map
+
         struct_tree_ref = pdf.make_indirect(struct_tree_root)
 
-        # Create document-level structure element
+        # Create document-level structure element. make_indirect is called
+        # exactly once here — the previous code re-ran it inside the page
+        # loop, risking duplicate indirect objects for the same dict and a
+        # malformed tree. Every StructElem's /P now points at this one ref.
         doc_elem = pikepdf.Dictionary(
             Type=pikepdf.Name('/StructElem'),
             S=pikepdf.Name('/Document'),
             P=struct_tree_ref,
             K=pikepdf.Array(),
         )
+        doc_ref = pdf.make_indirect(doc_elem)
 
         # Group zones by page
         by_page = defaultdict(list)
@@ -91,7 +106,9 @@ def write_tagged_pdf(
                 continue
             page_obj = pdf.pages[page_idx].obj
 
-            doc_ref = pdf.make_indirect(doc_elem)
+            # Tab order must follow structure order (PDF/UA-1 7.18.x).
+            # /Tabs /S declares structure-order tabbing on every page.
+            page_obj[pikepdf.Name('/Tabs')] = pikepdf.Name('/S')
 
             for zone in page_zones:
                 zone_type = zone.get('operatorLabel') \
@@ -126,8 +143,9 @@ def write_tagged_pdf(
                 doc_elem.K.append(pdf.make_indirect(struct_elem))
                 zone_count += 1
 
-        # Attach structure tree to document
-        struct_tree_root.K = pdf.make_indirect(doc_elem)
+        # Attach structure tree to document. Reuse the single doc_ref made
+        # above rather than calling make_indirect again on doc_elem.
+        struct_tree_root.K = doc_ref
         pdf.Root.StructTreeRoot = struct_tree_ref
 
         pdf.save(output_path)


### PR DESCRIPTION
## Summary

First increment toward **Issue #396** (complete the pikepdf Tagged-PDF write path to ≥95% veraPDF PDF/UA-1). Bounded, verifiable changes. **Does not flip the pass rate** — `7.1` (`/MCID` content-stream linkage) gates that, and it's the sprint-sized chunk tracked in #396 — but this fixes a latent bug and makes clause-level progress measurable for the increments that follow.

## Changes

### `write_tagged_pdf.py`
- **Latent bug fix**: `doc_ref = pdf.make_indirect(doc_elem)` was called once *per page* inside the loop, risking duplicate indirect objects for the same dict and a malformed structure tree. Hoisted to a single call; `StructTreeRoot.K` and every `StructElem` `/P` now share one ref.
- **`/RoleMap`** added to `StructTreeRoot` (PDF/UA-1 **7.3**) — maps every emitted structure type to its PDF 1.7 standard type. Cleared 7.3 on part of the 2-doc sample; full resolution tracked in #396.
- **`/Tabs /S`** on every page (PDF/UA-1 **7.18.x** — tab order follows structure order). Partial — `7.18.5` still flags, so the annotation-ordering work in #396 is still required.

### `run_spike.py`
- `run_verapdf` now captures **all** `<rule status="failed">` lines instead of the first 10, and filters to `<rule>` lines only (dropping per-element `<check>` noise). Without this you can't tell whether a fix *removed* a clause or just pushed it past the cutoff — essential for measuring increment-over-increment progress.

## Verification

- `python -m unittest test_zone_to_tags` — 17/17 pass
- 2-doc mini-run produces a clean full clause inventory: `7.1 t3/t6`, `7.18.1 t2`, `7.18.3 t1`, `7.18.5 t1/t2`, `7.21.7 t1`, `7.3 t1`, `7.4.2 t1`
- Pass rate unchanged at 0% — **expected**, `7.1` gates it

## What's next (Issue #396)

The remaining increments, in dependency order:
1. **`/MCID` content-stream linkage** (`7.1`) — the gating ~70%
2. Annotation handling + tab order (`7.18.1`, `7.18.5`)
3. The smaller clauses (`7.18.3`, `7.21.4.2`, `7.21.7`, `7.4.2`) + finish `7.3`
4. Graduate from `spikes/` to a production `src/services/pdf/` writer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation failure reports now display all detected issues without truncation.
  * Enhanced PDF/UA standard compliance and document structure integrity.
  * Refined document structure handling to ensure consistency across generated PDFs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/397)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->