### PR TITLE
feat(prh): audio/video markup validator — 3 markup rules (P6/PR4)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -675,6 +675,34 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'A run of <p> paragraphs is numbered like recipe method steps (1. 2. 3.) but not marked up as an <ol> — PRH requires <ol class="method_steps">. Heuristic; only fires when the book already uses .method_steps elsewhere (cookbook signal)',
   },
+
+  // ── Audio / video markup (P6/PR4) ─────────────────────────────────────
+  // Publisher-gated and detect-only. The MARKUP rules — these three —
+  // are pure XHTML checks. The codec / bitrate / dimensions rules
+  // (PRH-MEDIA-VIDEO-NOT-H264-BASELINE etc.) are deferred to a follow-up
+  // pending a media-inspection decision; they need ffprobe-grade
+  // container parsing that isn't worth building speculatively.
+  'PRH-MEDIA-WRAPPER-MISSING': {
+    code: 'PRH-MEDIA-WRAPPER-MISSING',
+    severity: 'serious',
+    wcag: ['1.3.1'],
+    fixType: 'manual',
+    summary: 'A <video> or <audio> element is not wrapped in <figure class="media_wrapper"> — PRH requires the figure wrapper so media has a consistent structural container and reflows predictably',
+  },
+  'PRH-MEDIA-FALLBACK-TEXT-MISSING': {
+    code: 'PRH-MEDIA-FALLBACK-TEXT-MISSING',
+    severity: 'serious',
+    wcag: ['1.1.1'],
+    fixType: 'manual',
+    summary: 'A <video> or <audio> element has no fallback text for reading systems that cannot play it — PRH requires fallback content describing the media inside the element',
+  },
+  'PRH-MEDIA-INLINE-WIDTH': {
+    code: 'PRH-MEDIA-INLINE-WIDTH',
+    severity: 'minor',
+    wcag: [],
+    fixType: 'manual',
+    summary: 'A <video> or <audio> element sets width via a width attribute or inline style — PRH requires media width to be set in CSS, not on the element',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/prh-conformance-report.service.ts
+++ b/src/services/acr/prh-conformance-report.service.ts
@@ -263,8 +263,8 @@ const TIER_CODE_COUNT: Record<PriorityTier, number> = {
   // P3 — body epub:type + doc-* ARIA (8) + forbidden (3) + notes/pagebreak (2)
   // + text heuristics (3) + CSS conventions (5, P6/PR1) + file/dir/size
   // (5, P6/PR2) + image assets (5, P6/PR3) + content-type markup
-  // (6, P6/PR5) = 37
-  P3: 37,
+  // (6, P6/PR5) + audio/video markup (3, P6/PR4) = 40
+  P3: 40,
   // P4 has no PRH-* codes (AI policy gate + cover-alt template were
   // implemented as behaviors, not new codes). 0 to keep the type happy.
   P4: 0,
@@ -299,6 +299,7 @@ function priorityTierForCode(code: string): PriorityTier | null {
   if (code.startsWith('PRH-FILE-')) return 'P3';
   if (code.startsWith('PRH-DIR-')) return 'P3';
   if (code.startsWith('PRH-IMG-')) return 'P3';
+  if (code.startsWith('PRH-MEDIA-')) return 'P3';
   if (code === 'PRH-BODY-HAS-ARIA') return 'P3';
   if (code === 'PRH-PAGEBREAK-MALFORMED') return 'P3';
   if (code === 'PRH-FOOTNOTE-ID-MISMATCH') return 'P3';

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -36,6 +36,7 @@ import { validatePrhCssConventions } from './validators/css-conventions-validato
 import { validatePrhFileLayout } from './validators/file-layout-validator';
 import { validatePrhImageAssets } from './validators/image-assets-validator';
 import { validatePrhContentTypeMarkup } from './validators/content-type-markup-validator';
+import { validatePrhMediaMarkup } from './validators/media-markup-validator';
 import { getImprintRules } from './imprints';
 import sharp from 'sharp';
 import type { PublisherProfile } from '../types';
@@ -143,6 +144,7 @@ export async function runPrhUkValidators(
         ...validatePrhFileLayout(fileLayoutInput),
         ...validatePrhImageAssets(imageAssetsInput),
         ...validatePrhContentTypeMarkup(perXhtmlInput),
+        ...validatePrhMediaMarkup(perXhtmlInput),
       );
     }
 

--- a/src/services/epub/profiles/prh-uk/validators/media-markup-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/media-markup-validator.ts
@@ -1,0 +1,240 @@
+/**
+ * PRH UK audio/video markup validator (P6/PR4).
+ *
+ * Covers the THREE pure-XHTML-markup rules for embedded media. The
+ * codec / bitrate / dimensions rules (H.264-baseline, video
+ * dimensions, MP3-256k) are deliberately NOT here — they need
+ * ffprobe-grade container parsing, deferred to a follow-up pending a
+ * media-inspection dependency decision when audio/video EPUB demand
+ * materialises.
+ *
+ * Three codes, all detect-only:
+ *   - PRH-MEDIA-WRAPPER-MISSING — a <video>/<audio> not inside a
+ *     <figure class="media_wrapper">.
+ *   - PRH-MEDIA-FALLBACK-TEXT-MISSING — a <video>/<audio> with no
+ *     fallback text for reading systems that can't play the media
+ *     (text content, ignoring <source>/<track> children).
+ *   - PRH-MEDIA-INLINE-WIDTH — a <video>/<audio> setting width via a
+ *     `width` attribute or inline `style`; PRH wants width in CSS.
+ *
+ * Each rule only matters when the book actually embeds media, so a
+ * typical text-only EPUB trips none of them. One issue per (file,
+ * code) with an occurrence count, matching the other PRH validators.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+const MEDIA_TAGS = ['video', 'audio'] as const;
+
+/** Child tags that are NOT fallback text — sources / tracks / captions. */
+const NON_FALLBACK_CHILD_TAGS = new Set(['source', 'track']);
+
+interface MediaElement {
+  tag: 'video' | 'audio';
+  /** Raw attribute chunk of the open tag (everything between the tag name and `>`). */
+  attrs: string;
+  /** Inner HTML between the open and close tag; '' for self-closing. */
+  inner: string;
+  /** Offset of the `<` of the open tag. */
+  start: number;
+}
+
+export function validatePrhMediaMarkup(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  for (const file of input.xhtmlFiles) {
+    const body = stripHead(file.content);
+    const mediaElements = findMediaElements(body);
+    if (mediaElements.length === 0) continue;
+
+    const wrapperSpans = findMediaWrapperSpans(body);
+
+    let wrapperMissing = 0;
+    let fallbackMissing = 0;
+    let inlineWidth = 0;
+
+    for (const el of mediaElements) {
+      if (!isInsideAnySpan(el.start, wrapperSpans)) {
+        wrapperMissing++;
+      }
+      if (!hasFallbackText(el.inner)) {
+        fallbackMissing++;
+      }
+      if (hasInlineWidth(el.attrs)) {
+        inlineWidth++;
+      }
+    }
+
+    if (wrapperMissing > 0) {
+      issues.push(buildIssue('PRH-MEDIA-WRAPPER-MISSING', file.path, ` (${wrapperMissing} element(s))`));
+    }
+    if (fallbackMissing > 0) {
+      issues.push(buildIssue('PRH-MEDIA-FALLBACK-TEXT-MISSING', file.path, ` (${fallbackMissing} element(s))`));
+    }
+    if (inlineWidth > 0) {
+      issues.push(buildIssue('PRH-MEDIA-INLINE-WIDTH', file.path, ` (${inlineWidth} element(s))`));
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function stripHead(html: string): string {
+  return html.replace(/<head\b[^>]*>[\s\S]*?<\/head>/i, '');
+}
+
+/**
+ * Find every `<video>` / `<audio>` element. Handles both the normal
+ * `<video …>…</video>` form (depth-counted balanced close so a nested
+ * same-tag element — rare but legal — doesn't truncate early) and the
+ * self-closing `<video … />` form (inner = '').
+ */
+function findMediaElements(body: string): MediaElement[] {
+  const out: MediaElement[] = [];
+  for (const tag of MEDIA_TAGS) {
+    const openRe = new RegExp(`<${tag}\\b([^>]*)>`, 'gi');
+    let m: RegExpExecArray | null;
+    while ((m = openRe.exec(body)) !== null) {
+      const attrs = m[1];
+      const start = m.index;
+      const openTagEnd = openRe.lastIndex;
+      if (attrs.trimEnd().endsWith('/')) {
+        // Self-closing: no inner content.
+        out.push({ tag, attrs, inner: '', start });
+        continue;
+      }
+      const close = findBalancedClose(body, tag, openTagEnd);
+      const inner = close ? body.slice(openTagEnd, close.innerEnd) : '';
+      out.push({ tag, attrs, inner, start });
+    }
+  }
+  return out;
+}
+
+/**
+ * Find the spans of every `<figure>` element carrying the
+ * `media_wrapper` class token. Returns `{start, end}` offsets so a
+ * media element's position can be tested for containment.
+ */
+function findMediaWrapperSpans(body: string): Array<{ start: number; end: number }> {
+  const spans: Array<{ start: number; end: number }> = [];
+  const openRe = /<figure\b([^>]*)>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = openRe.exec(body)) !== null) {
+    const attrs = m[1];
+    if (attrs.trimEnd().endsWith('/')) continue; // self-closing figure can't wrap anything
+    const classMatch = attrs.match(/(?:^|\s)class\s*=\s*["']([^"']*)["']/i);
+    if (!classMatch) continue;
+    const tokens = classMatch[1].split(/\s+/).filter(Boolean);
+    if (!tokens.includes('media_wrapper')) continue;
+    const close = findBalancedClose(body, 'figure', openRe.lastIndex);
+    if (close) {
+      spans.push({ start: m.index, end: close.outerEnd });
+    }
+  }
+  return spans;
+}
+
+function isInsideAnySpan(
+  pos: number,
+  spans: Array<{ start: number; end: number }>,
+): boolean {
+  return spans.some((s) => pos >= s.start && pos < s.end);
+}
+
+/**
+ * Fallback text = any non-whitespace text content of the media
+ * element once `<source>` / `<track>` children and ALL other tags are
+ * stripped. `<source>`/`<track>` declare the media itself, not a
+ * human-readable fallback, so they don't count.
+ */
+function hasFallbackText(inner: string): boolean {
+  if (inner.trim() === '') return false;
+  // Drop <source>/<track> elements (both void — no closing tag).
+  let stripped = inner;
+  for (const childTag of NON_FALLBACK_CHILD_TAGS) {
+    stripped = stripped.replace(new RegExp(`<${childTag}\\b[^>]*/?>`, 'gi'), '');
+  }
+  // Drop every remaining tag, leaving only text.
+  stripped = stripped.replace(/<[^>]+>/g, '');
+  return stripped.trim().length > 0;
+}
+
+/**
+ * True when the open-tag attributes set width via a `width` attribute
+ * or an inline `style` containing a `width` declaration. The attribute
+ * names are anchored on `(?:^|\s)` so `data-width` / `max-width` inside
+ * a different attribute don't false-match.
+ */
+function hasInlineWidth(attrs: string): boolean {
+  if (/(?:^|\s)width\s*=/i.test(attrs)) return true;
+  const styleMatch = attrs.match(/(?:^|\s)style\s*=\s*["']([^"']*)["']/i);
+  if (styleMatch && /(?:^|;)\s*width\s*:/i.test(styleMatch[1])) return true;
+  return false;
+}
+
+/**
+ * Given the index just past an opening `<tag …>`, walk forward
+ * counting same-tag opens / closes and return the inner-end (just
+ * before the matching `</tag>`) and outer-end (just past it). Returns
+ * null for unbalanced markup — callers skip such elements.
+ */
+function findBalancedClose(
+  html: string,
+  tag: string,
+  fromIndex: number,
+): { innerEnd: number; outerEnd: number } | null {
+  const tokenRe = new RegExp(`<(/?)${tag}\\b[^>]*>`, 'gi');
+  tokenRe.lastIndex = fromIndex;
+  let depth = 1;
+  let m: RegExpExecArray | null;
+  while ((m = tokenRe.exec(html)) !== null) {
+    const isClose = m[1] === '/';
+    const isSelfClosing = !isClose && m[0].trimEnd().endsWith('/>');
+    if (isSelfClosing) continue;
+    if (isClose) {
+      depth--;
+      if (depth === 0) {
+        return { innerEnd: m.index, outerEnd: tokenRe.lastIndex };
+      }
+    } else {
+      depth++;
+    }
+  }
+  return null;
+}
+
+function buildIssue(
+  code:
+    | 'PRH-MEDIA-WRAPPER-MISSING'
+    | 'PRH-MEDIA-FALLBACK-TEXT-MISSING'
+    | 'PRH-MEDIA-INLINE-WIDTH',
+  location: string,
+  detail = '',
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location}${detail}`,
+    suggestion: suggestionFor(code),
+    location,
+  };
+}
+
+function suggestionFor(code: string): string {
+  switch (code) {
+    case 'PRH-MEDIA-WRAPPER-MISSING':
+      return 'Wrap each <video>/<audio> in <figure class="media_wrapper"> so media has a consistent structural container.';
+    case 'PRH-MEDIA-FALLBACK-TEXT-MISSING':
+      return 'Add fallback text inside the <video>/<audio> element describing the media — reading systems that cannot play it show this content instead.';
+    case 'PRH-MEDIA-INLINE-WIDTH':
+      return 'Remove the width attribute / inline style and set media width via a CSS class in your stylesheet.';
+    default:
+      return '';
+  }
+}

--- a/src/services/epub/profiles/prh-uk/validators/media-markup-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/media-markup-validator.ts
@@ -44,7 +44,12 @@ export function validatePrhMediaMarkup(input: PrhPerXhtmlInput): PrhValidatorIss
   const issues: PrhValidatorIssue[] = [];
 
   for (const file of input.xhtmlFiles) {
-    const body = stripHead(file.content);
+    // Strip <head> and HTML comments before scanning — commented-out
+    // media markup (`<!-- <video src="old.mp4"/> -->`) is still text to
+    // a regex and would otherwise raise false advisory failures for
+    // content the reading system ignores. Mirrors the content-type
+    // markup validator.
+    const body = stripComments(stripHead(file.content));
     const mediaElements = findMediaElements(body);
     if (mediaElements.length === 0) continue;
 
@@ -86,6 +91,10 @@ function stripHead(html: string): string {
   return html.replace(/<head\b[^>]*>[\s\S]*?<\/head>/i, '');
 }
 
+function stripComments(html: string): string {
+  return html.replace(/<!--[\s\S]*?-->/g, '');
+}
+
 /**
  * Find every `<video>` / `<audio>` element. Handles both the normal
  * `<video …>…</video>` form (depth-counted balanced close so a nested
@@ -101,14 +110,26 @@ function findMediaElements(body: string): MediaElement[] {
       const attrs = m[1];
       const start = m.index;
       const openTagEnd = openRe.lastIndex;
-      if (attrs.trimEnd().endsWith('/')) {
+      // Self-closing test inspects the full matched tag — `m[0]` ends
+      // with `>` and the preceding `/` is the unambiguous self-closing
+      // signal. Testing `attrs.endsWith('/')` instead would misread an
+      // unquoted attribute value whose last character is `/`.
+      if (m[0].trimEnd().endsWith('/>')) {
         // Self-closing: no inner content.
         out.push({ tag, attrs, inner: '', start });
         continue;
       }
       const close = findBalancedClose(body, tag, openTagEnd);
-      const inner = close ? body.slice(openTagEnd, close.innerEnd) : '';
-      out.push({ tag, attrs, inner, start });
+      // Unbalanced markup (no matching `</tag>`) is malformed —
+      // epubcheck is the right tool to flag it; skip silently here so
+      // we don't emit a false fallback-text-missing on garbage input.
+      if (!close) continue;
+      out.push({
+        tag,
+        attrs,
+        inner: body.slice(openTagEnd, close.innerEnd),
+        start,
+      });
     }
   }
   return out;
@@ -125,7 +146,10 @@ function findMediaWrapperSpans(body: string): Array<{ start: number; end: number
   let m: RegExpExecArray | null;
   while ((m = openRe.exec(body)) !== null) {
     const attrs = m[1];
-    if (attrs.trimEnd().endsWith('/')) continue; // self-closing figure can't wrap anything
+    // Self-closing figure can't wrap anything; check the full matched
+    // tag so unquoted attribute values ending in `/` don't fool the
+    // detection.
+    if (m[0].trimEnd().endsWith('/>')) continue;
     const classMatch = attrs.match(/(?:^|\s)class\s*=\s*["']([^"']*)["']/i);
     if (!classMatch) continue;
     const tokens = classMatch[1].split(/\s+/).filter(Boolean);

--- a/tests/unit/services/epub/profiles/prh-uk/validators/media-markup-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/media-markup-validator.test.ts
@@ -244,4 +244,27 @@ describe('validatePrhMediaMarkup — overall', () => {
     );
     expect(issues).toEqual([]);
   });
+
+  it('ignores commented-out media markup (no false advisory failures)', () => {
+    // A commented-out media element must not raise wrapper/fallback/width
+    // failures — the reading system ignores comments and so should the
+    // validator.
+    const issues = validatePrhMediaMarkup(
+      input([
+        file('ch1.xhtml', '<!-- <video src="old.mp4" width="640">x</video> -->'),
+      ]),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('skips unbalanced media tags rather than emitting false fallback-missing', () => {
+    // A <video> with no matching </video> is malformed — epubcheck flags
+    // it. We must NOT pretend it's a self-closing element and emit a
+    // PRH-MEDIA-FALLBACK-TEXT-MISSING for it.
+    const issues = validatePrhMediaMarkup(
+      input([file('ch1.xhtml', '<video controls src="v.mp4"><p>orphan')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-FALLBACK-TEXT-MISSING')).toBe(false);
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-WRAPPER-MISSING')).toBe(false);
+  });
 });

--- a/tests/unit/services/epub/profiles/prh-uk/validators/media-markup-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/media-markup-validator.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhMediaMarkup } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/media-markup-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function file(path: string, body: string): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title><style>video { width: 100%; }</style></head>
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+function input(files: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles: files,
+  };
+}
+
+describe('validatePrhMediaMarkup — PRH-MEDIA-WRAPPER-MISSING', () => {
+  it('emits when a <video> is not inside a figure.media_wrapper', () => {
+    const issues = validatePrhMediaMarkup(
+      input([file('ch1.xhtml', '<video controls><source src="v.mp4"/>Fallback.</video>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-WRAPPER-MISSING')).toBe(true);
+  });
+
+  it('emits when an <audio> is not inside a figure.media_wrapper', () => {
+    const issues = validatePrhMediaMarkup(
+      input([file('ch1.xhtml', '<audio controls><source src="a.mp3"/>Fallback.</audio>')]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-WRAPPER-MISSING')).toBe(true);
+  });
+
+  it('does NOT emit when the media element IS inside figure.media_wrapper', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><video controls><source src="v.mp4"/>Fallback.</video></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-WRAPPER-MISSING')).toBe(false);
+  });
+
+  it('does NOT emit when figure carries media_wrapper among other class tokens', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="full_bleed media_wrapper centered"><audio controls>Fallback.</audio></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-WRAPPER-MISSING')).toBe(false);
+  });
+
+  it('emits when figure has the wrong class (not media_wrapper)', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file('ch1.xhtml', '<figure class="image_wrapper"><video controls>Fallback.</video></figure>'),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-WRAPPER-MISSING')).toBe(true);
+  });
+
+  it('counts multiple unwrapped media elements in one file', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<video controls>A.</video><audio controls>B.</audio>',
+        ),
+      ]),
+    );
+    const wrapperIssue = issues.find((i) => i.code === 'PRH-MEDIA-WRAPPER-MISSING');
+    expect(wrapperIssue?.message).toMatch(/2 element/);
+  });
+
+  it('does NOT emit for a book with no media elements', () => {
+    const issues = validatePrhMediaMarkup(
+      input([file('ch1.xhtml', '<p>Just prose, no media.</p>')]),
+    );
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('validatePrhMediaMarkup — PRH-MEDIA-FALLBACK-TEXT-MISSING', () => {
+  it('emits when a <video> has only <source> children and no text', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><video controls><source src="v.mp4"/></video></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-FALLBACK-TEXT-MISSING')).toBe(true);
+  });
+
+  it('emits for a self-closing <video/> (no inner content at all)', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file('ch1.xhtml', '<figure class="media_wrapper"><video src="v.mp4" controls/></figure>'),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-FALLBACK-TEXT-MISSING')).toBe(true);
+  });
+
+  it('does NOT emit when the media element has fallback text', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><video controls><source src="v.mp4"/>Your reader cannot play this video.</video></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-FALLBACK-TEXT-MISSING')).toBe(false);
+  });
+
+  it('does NOT emit when fallback text is wrapped in a child element', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><audio controls><source src="a.mp3"/><p>Audio description here.</p></audio></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-FALLBACK-TEXT-MISSING')).toBe(false);
+  });
+
+  it('treats <track> children as non-fallback (still emits when only a track is present)', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><video controls><source src="v.mp4"/><track kind="captions" src="c.vtt"/></video></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-FALLBACK-TEXT-MISSING')).toBe(true);
+  });
+});
+
+describe('validatePrhMediaMarkup — PRH-MEDIA-INLINE-WIDTH', () => {
+  it('emits when a <video> sets a width attribute', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><video controls width="640">Fallback.</video></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-INLINE-WIDTH')).toBe(true);
+  });
+
+  it('emits when a <video> sets width via inline style', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><video controls style="width: 80%;">Fallback.</video></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-INLINE-WIDTH')).toBe(true);
+  });
+
+  it('does NOT emit when width is absent from the element', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><video controls>Fallback.</video></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-INLINE-WIDTH')).toBe(false);
+  });
+
+  it('does NOT false-match a data-width attribute', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><video controls data-width="x">Fallback.</video></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-INLINE-WIDTH')).toBe(false);
+  });
+
+  it('does NOT false-match max-width inside an inline style', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><video controls style="max-width: 100%;">Fallback.</video></figure>',
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-MEDIA-INLINE-WIDTH')).toBe(false);
+  });
+});
+
+describe('validatePrhMediaMarkup — overall', () => {
+  it('emits zero issues for a fully conformant media element', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure class="media_wrapper"><video controls><source src="v.mp4"/>This video shows the assembly process.</video></figure>',
+        ),
+      ]),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('reports issues per file with the correct location', () => {
+    const issues = validatePrhMediaMarkup(
+      input([
+        file('clean.xhtml', '<p>No media here.</p>'),
+        file('bad.xhtml', '<video controls>x</video>'),
+      ]),
+    );
+    const wrapperIssue = issues.find((i) => i.code === 'PRH-MEDIA-WRAPPER-MISSING');
+    expect(wrapperIssue?.location).toBe('bad.xhtml');
+  });
+
+  it('does not scan media tags inside <head> (e.g. selectors in <style>)', () => {
+    // The file() helper puts `video { width: 100% }` in a <style> block;
+    // that must not be parsed as a media element.
+    const issues = validatePrhMediaMarkup(
+      input([file('ch1.xhtml', '<p>Prose only in the body.</p>')]),
+    );
+    expect(issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

P6/PR4 — the audio/video validator, scoped to the **3 pure-XHTML-markup rules**. The 3 codec/bitrate/dimensions rules are deliberately deferred (see below).

Three new codes, all P3 (advisory — does not block deliverable export):

| Code | Severity | Detects |
|---|---|---|
| `PRH-MEDIA-WRAPPER-MISSING` | serious | A `<video>`/`<audio>` not inside `<figure class="media_wrapper">` |
| `PRH-MEDIA-FALLBACK-TEXT-MISSING` | serious | A `<video>`/`<audio>` with no fallback text — `<source>`/`<track>` children declare the media, not a human-readable fallback, so they don't count |
| `PRH-MEDIA-INLINE-WIDTH` | minor | Width set via a `width` attribute or inline `style`; PRH wants width in CSS |

Detect-only. Each rule only matters when the book embeds media, so a typical text-only EPUB trips none of them.

## Why only 3 of 6 rules

The other 3 PRH media rules (`H.264-baseline`, `video-dimensions`, `MP3-256k`) need codec/bitrate/dimensions inspection — the repo has no media-inspection capability. After weighing the options, the decision was to **ship the markup rules now** (pure XHTML parsing, zero dependency risk, real value immediately) and **defer the codec rules** until audio/video EPUB demand materialises — at which point ffprobe (not a shallow pure-JS shim) is the durable choice. The deferred codes will be registered when that follow-up PR builds them.

## Implementation notes

- Reuses the depth-counted balanced-region extraction (`findBalancedClose`) so nested same-tag elements don't truncate early
- Handles self-closing `<video/>` / `<audio/>` forms (no inner → fails the fallback-text rule, correctly)
- Attribute checks anchor on `(?:^|\s)` so `data-width` / `max-width` don't false-match
- `<head>` stripped before scanning so a `video { … }` CSS selector in a `<style>` block isn't parsed as a media element

## Conformance report

- `TIER_CODE_COUNT.P3` bumped 37 → 40
- `priorityTierForCode` maps `PRH-MEDIA-*` → P3

## Test plan
- [x] 20 unit tests — all 3 rules + edge cases (class-token among others, self-closing media, `<track>`-vs-fallback distinction, `data-width`/`max-width` false-match guards, head-scoped `<style>` not parsed as media, conformant happy path)
- [x] Existing 19 conformance-report tests still pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (`--max-warnings 0`)
- [ ] Staging smoke: re-audit a media-bearing PRH-UK EPUB and confirm `PRH-MEDIA-*` codes surface as P3 advisory issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new media issue codes and integrated media-markup validation into the PRH-UK publisher-gated P3 validation set (detects missing media wrapper, missing fallback text, and inline width usage).

* **Tests**
  * Added comprehensive unit tests covering detection, suppression cases, location reporting, and regression scenarios for the new media checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/401)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->