### PR TITLE
feat(spike): strip-then-retag + form XObject recursion (Issue #396)

### DIFF
--- a/spikes/pikepdf-write/content_tagger.py
+++ b/spikes/pikepdf-write/content_tagger.py
@@ -26,12 +26,131 @@ Scope / known limitations (tracked in #396):
     and graphics matrices. It does not advance position within a TJ run
     or account for font glyph widths — fine for ZONE assignment (we only
     need the start point of each show op), not for glyph-precise tagging.
-  - Assumes input pages are NOT already tagged (true for the corpus).
-    Pre-existing marked content would be double-wrapped.
+  - Pre-existing marked content is stripped before retagging; call
+    strip_marked_content() first, or set strip=True in retag_page_content.
+  - Form XObject content is tagged as /Artifact in this increment.
+    Full structure-referenced tagging of form content (needed when forms
+    carry real text) is a future increment.
   - Inline images (BI/ID/EI) are passed through untagged-but-artifacted.
 """
 
 import pikepdf
+
+# ─── Marked-content stripping ────────────────────────────────────────────────
+
+def strip_marked_content(operations):
+    """Remove all existing BMC/BDC/EMC operators from an operation list,
+    keeping every other operator unchanged.
+
+    This is a prerequisite for clean retagging: without stripping, any
+    pre-existing publisher or pdfxt marked-content wrapping causes the new
+    /Span MCID and /Artifact sequences to nest inside it, triggering
+    PDF/UA-1 7.1 test 1/2 ("tagged/artifact content inside artifact/tagged
+    content") failures.
+
+    Depth tracking ensures matched pairs are removed even when nested.
+    Unmatched EMC operators (malformed but possible) are also dropped.
+    """
+    result = []
+    depth = 0
+    for operands, operator in operations:
+        op = str(operator)
+        if op in ('BDC', 'BMC'):
+            depth += 1          # skip opener
+        elif op == 'EMC':
+            if depth > 0:
+                depth -= 1      # skip matched closer
+            # else: unmatched EMC — drop it
+        else:
+            result.append((operands, operator))
+    return result
+
+
+# ─── Form-XObject helper ─────────────────────────────────────────────────────
+
+def retag_form_xobjects(page_resources, processed_forms):
+    """Recursively strip and artifact-wrap content in all form XObjects
+    referenced by `page_resources`.
+
+    Form XObject content runs in the form's own local coordinate space, so
+    we cannot reliably assign its operators to page-level zones. Wrapping
+    everything as /Artifact satisfies PDF/UA-1 clause 7.1 (all content is
+    marked) without needing the full form→structure-tree linkage chain.
+
+    Args:
+        pdf: the pikepdf.Pdf being written.
+        page_resources: the /Resources dict of the page (or of a form XObject
+            being recursed into).
+        processed_forms: a set of object-number ints already handled; prevents
+            double-processing when the same form is Do'd from multiple pages.
+    """
+    xobjs = page_resources.get('/XObject')
+    if not xobjs:
+        return
+    for name in xobjs.keys():
+        xo = xobjs[name]
+        if xo.get('/Subtype') != pikepdf.Name('/Form'):
+            continue
+        obj_num = xo.objgen[0] if xo.is_indirect else None
+        if obj_num is not None and obj_num in processed_forms:
+            continue
+        if obj_num is not None:
+            processed_forms.add(obj_num)
+
+        # Strip existing marked content from the form's stream.
+        try:
+            ops = list(pikepdf.parse_content_stream(xo))
+        except Exception:
+            continue
+        stripped = strip_marked_content(ops)
+
+        # Wrap all drawing operators in the form as /Artifact. Tracks
+        # path state so the whole m…f construction is one BMC…EMC.
+        new_ops = []
+        in_path = False
+
+        for operands, operator in stripped:
+            op = str(operator)
+            if op in _PATH_START_OPS:
+                if not in_path:
+                    new_ops.append((pikepdf.Array([pikepdf.Name('/Artifact')]),
+                                    pikepdf.Operator('BMC')))
+                    in_path = True
+                new_ops.append((operands, operator))
+            elif op in _PATH_CONT_OPS:
+                new_ops.append((operands, operator))
+            elif op in _PATH_PAINT_OPS:
+                new_ops.append((operands, operator))
+                if in_path:
+                    new_ops.append((pikepdf.Array([]), pikepdf.Operator('EMC')))
+                    in_path = False
+            elif op == _SHADING_OP or 'INLINE IMAGE' in op.upper():
+                new_ops.append((pikepdf.Array([pikepdf.Name('/Artifact')]),
+                                pikepdf.Operator('BMC')))
+                new_ops.append((operands, operator))
+                new_ops.append((pikepdf.Array([]), pikepdf.Operator('EMC')))
+            elif op == _XOBJECT_OP:
+                # Nested form — recurse, then artifact-wrap the Do.
+                nested_res = xo.get('/Resources')
+                if nested_res:
+                    retag_form_xobjects(nested_res, processed_forms)
+                new_ops.append((pikepdf.Array([pikepdf.Name('/Artifact')]),
+                                pikepdf.Operator('BMC')))
+                new_ops.append((operands, operator))
+                new_ops.append((pikepdf.Array([]), pikepdf.Operator('EMC')))
+            else:
+                new_ops.append((operands, operator))
+
+        if in_path:  # safety net for malformed streams
+            new_ops.append((pikepdf.Array([]), pikepdf.Operator('EMC')))
+
+        xo.write(pikepdf.unparse_content_stream(new_ops))
+
+        # Recurse into this form's own resources.
+        form_res = xo.get('/Resources')
+        if form_res:
+            retag_form_xobjects(form_res, processed_forms)
+
 
 # Operators that draw text.
 _TEXT_SHOW_OPS = {'Tj', 'TJ', "'", '"'}
@@ -103,15 +222,24 @@ def _find_zone(px, py, zone_boxes):
     return best_idx
 
 
-def retag_page_content(page, page_zones, page_height):
+def retag_page_content(page, page_zones, page_height, processed_forms=None):
     """Rewrite a page's content stream so every text/image drawing
     operator is wrapped in a marked-content sequence.
+
+    Pre-existing marked content (BMC/BDC/EMC) is stripped first so
+    publisher-tagged inputs don't produce nested marked content.  Form
+    XObjects referenced on this page are recursively stripped and
+    artifact-wrapped via retag_form_xobjects() before the page stream
+    itself is rewritten.
 
     Args:
         page: pikepdf page object.
         page_zones: list of zone dicts on this page (artifacts already
             excluded by the caller), in structure order.
         page_height: float, page MediaBox height.
+        processed_forms: optional set of already-handled form XObject
+            object numbers (shared across pages so each form is rewritten
+            exactly once).
 
     Returns:
         (new_operations, assignments) where
@@ -120,7 +248,18 @@ def retag_page_content(page, page_zones, page_height):
           assignments is a list of (mcid:int, zone_index:int) — zone_index
             indexes into page_zones.
     """
-    operations = list(pikepdf.parse_content_stream(page))
+    if processed_forms is None:
+        processed_forms = set()
+
+    # Recurse into form XObjects before processing the page stream so
+    # their content is clean when the page's Do ops execute them.
+    page_resources = page.obj.get('/Resources')
+    if page_resources:
+        retag_form_xobjects(page_resources, processed_forms)
+
+    raw_ops = list(pikepdf.parse_content_stream(page))
+    # Strip pre-existing marked content so we write onto a clean stream.
+    operations = strip_marked_content(raw_ops)
 
     # Precompute each zone's PDF-space box, paired with its index.
     zone_boxes = [
@@ -249,13 +388,30 @@ def retag_page_content(page, page_zones, page_height):
             continue
 
         if op == _XOBJECT_OP:
-            # Image/form XObject — position from CTM origin.
-            dx, dy = _apply(ctm, 0.0, 0.0)
-            zone_idx = _find_zone(dx, dy, zone_boxes)
-            if zone_idx is not None:
-                wrap(operands, operator, zone_idx)
+            # Look up the XObject to distinguish image vs form.
+            # Form XObjects have already been stripped + artifact-wrapped by
+            # retag_form_xobjects(), so the Do itself passes through unwrapped —
+            # the form's content IS marked; wrapping the Do again would nest marks.
+            # Image XObjects are single ops that need an MCID or /Artifact wrap.
+            xo_name = operands[0] if operands else None
+            xo_subtype = None
+            if xo_name and page_resources:
+                xobjs = page_resources.get('/XObject')
+                if xobjs:
+                    xo = xobjs.get(xo_name)
+                    if xo is not None:
+                        xo_subtype = xo.get('/Subtype')
+            if xo_subtype == pikepdf.Name('/Form'):
+                # Form already handled; just emit the Do.
+                new_ops.append((operands, operator))
             else:
-                artifact_wrap(operands, operator)
+                # Image (or unknown) — position from CTM origin.
+                dx, dy = _apply(ctm, 0.0, 0.0)
+                zone_idx = _find_zone(dx, dy, zone_boxes)
+                if zone_idx is not None:
+                    wrap(operands, operator, zone_idx)
+                else:
+                    artifact_wrap(operands, operator)
             continue
 
         # ----- vector paths: bracket the whole construction→paint run -----

--- a/spikes/pikepdf-write/test_content_tagger.py
+++ b/spikes/pikepdf-write/test_content_tagger.py
@@ -8,7 +8,12 @@ it. See content_tagger module docstring for the derivation."""
 
 import unittest
 
-from content_tagger import _mat_mul, _apply, _zone_pdf_box, _find_zone, _IDENTITY
+import pikepdf
+
+from content_tagger import (
+    _mat_mul, _apply, _zone_pdf_box, _find_zone, _IDENTITY,
+    strip_marked_content,
+)
 
 
 class TestMatrixMath(unittest.TestCase):
@@ -97,6 +102,65 @@ class TestFindZone(unittest.TestCase):
 
     def test_empty_zone_list_returns_none(self):
         self.assertIsNone(_find_zone(100.0, 100.0, []))
+
+
+class TestStripMarkedContent(unittest.TestCase):
+    """strip_marked_content must remove all BMC/BDC/EMC pairs while
+    keeping every other operator unchanged, regardless of nesting depth."""
+
+    @staticmethod
+    def _op(name, *args):
+        return (pikepdf.Array(list(args)), pikepdf.Operator(name))
+
+    def _ops(self, *names):
+        return [self._op(n) for n in names]
+
+    def test_empty_list(self):
+        self.assertEqual(strip_marked_content([]), [])
+
+    def test_no_marked_content_passes_through(self):
+        ops = self._ops('BT', 'Tm', 'Tj', 'ET')
+        self.assertEqual(
+            [str(o) for _, o in strip_marked_content(ops)],
+            ['BT', 'Tm', 'Tj', 'ET'],
+        )
+
+    def test_single_bmc_emc_pair_removed(self):
+        ops = self._ops('BMC', 'Tj', 'EMC')
+        result = strip_marked_content(ops)
+        self.assertEqual([str(o) for _, o in result], ['Tj'])
+
+    def test_single_bdc_emc_pair_removed(self):
+        ops = self._ops('BDC', 'Tj', 'EMC')
+        result = strip_marked_content(ops)
+        self.assertEqual([str(o) for _, o in result], ['Tj'])
+
+    def test_nested_marked_content_removed(self):
+        # /Part BDC … /Span BDC … EMC … EMC → inner ops remain
+        ops = self._ops('BDC', 'q', 'BDC', 'Tj', 'EMC', 'Q', 'EMC')
+        result = strip_marked_content(ops)
+        self.assertEqual([str(o) for _, o in result], ['q', 'Tj', 'Q'])
+
+    def test_content_between_pairs_preserved(self):
+        ops = self._ops('BMC', 'f', 'EMC', 'Tm', 'BMC', 'Tj', 'EMC')
+        result = strip_marked_content(ops)
+        self.assertEqual([str(o) for _, o in result], ['f', 'Tm', 'Tj'])
+
+    def test_unmatched_emc_dropped(self):
+        # Malformed but should not crash or leave stray EMC.
+        ops = self._ops('Tj', 'EMC', 'Tj')
+        result = strip_marked_content(ops)
+        self.assertEqual([str(o) for _, o in result], ['Tj', 'Tj'])
+
+    def test_round_trip_idempotent(self):
+        # Stripping an already-stripped stream produces the same result.
+        ops = self._ops('BT', 'Tm', 'Tj', 'ET')
+        once = strip_marked_content(ops)
+        twice = strip_marked_content(once)
+        self.assertEqual(
+            [str(o) for _, o in once],
+            [str(o) for _, o in twice],
+        )
 
 
 if __name__ == '__main__':

--- a/spikes/pikepdf-write/write_tagged_pdf.py
+++ b/spikes/pikepdf-write/write_tagged_pdf.py
@@ -28,6 +28,24 @@ def write_tagged_pdf(
     try:
         pdf = pikepdf.open(input_pdf_path)
 
+        # Strip any pre-existing structure tree so we write onto a clean
+        # canvas regardless of whether the input is publisher-tagged or not.
+        # Without this, new marked-content wrapping nests inside the original
+        # publisher BDC/EMC sequences → PDF/UA-1 7.1 t1/t2 nesting failures.
+        if '/StructTreeRoot' in pdf.Root:
+            del pdf.Root.StructTreeRoot
+        for _page in pdf.pages:
+            _po = _page.obj
+            for _k in ('/StructParents', '/StructParent'):
+                if _k in _po:
+                    del _po[_k]
+            # Strip /StructParent from annotations on this page too.
+            annots = _po.get('/Annots')
+            if annots:
+                for ann in annots:
+                    if '/StructParent' in ann:
+                        del ann['/StructParent']
+
         # Set MarkInfo - required for Tagged PDF
         pdf.Root.MarkInfo = pikepdf.Dictionary(Marked=True)
 
@@ -102,6 +120,9 @@ def write_tagged_pdf(
         parent_tree_nums = pikepdf.Array()
         next_struct_parent = 0
 
+        # Shared set across pages so each form XObject is strip+retag'd once.
+        processed_forms: set = set()
+
         # Process EVERY page, not only pages that have zones. PDF/UA-1 7.1
         # test 3 requires *all* content on *every* page to be marked —
         # a cover image on a zoneless page still has to be artifacted, so
@@ -159,8 +180,10 @@ def write_tagged_pdf(
 
             # 2. Rewrite the page content stream so every drawing op is
             #    inside a marked-content sequence; get MCID→zone mapping.
+            #    processed_forms is shared across pages so each form XObject
+            #    is strip+retag'd exactly once.
             new_ops, assignments = retag_page_content(
-                pdf_page, page_zones, page_height
+                pdf_page, page_zones, page_height, processed_forms
             )
             new_stream = pikepdf.Stream(
                 pdf, pikepdf.unparse_content_stream(new_ops)


### PR DESCRIPTION
## Summary

Makes the pikepdf write path work on **any** input PDF — publisher-tagged or untagged.

## Problem

18/20 corpus input PDFs are publisher-tagged (carry `/StructTreeRoot` + `BDC/BMC/EMC` marked content). Wrapping new `/Span` MCID sequences inside the publisher's existing `/Part`/`/OC` sequences created nested marked content, triggering PDF/UA-1 **7.1 t1/t2** on every pre-tagged doc. The production pipeline receives whatever publishers send — publisher-tagged PDFs are the norm, not the exception.

## Solution: strip then retag

1. **Strip pre-existing structure** — at the top of `write_tagged_pdf()`, delete `/StructTreeRoot` and clear `/StructParents` from all pages, leaving a clean canvas.
2. **Strip existing marked content** — `strip_marked_content()` removes all `BMC`/`BDC`/`EMC` pairs from a content stream before the tagger runs. Depth-tracking removes nested pairs correctly.
3. **Recurse into form XObjects** — `retag_form_xobjects()` strips + artifact-wraps all `/Form` XObjects so their content is marked without nesting. A shared `processed_forms` set prevents re-processing the same form across pages.

## Verification

| Input | 7.1 failures before | 7.1 failures after |
|---|---:|---:|
| Pre-tagged (2 docs from mini-bundle) | 5 (t1×2, t2×2, t3×1) | **0** ✓ |
| Untagged (cmnpbz9vk…, 2541 zones) | 0 | **0** (no regression) ✓ |

Total rule failures on pre-tagged inputs: 15 → **10** (remaining: `7.3`, `7.18.1`, `7.18.5×2`, `7.21.7`, `7.4.2` — other #396 checklist items).

## Tests

38/38 pass (8 new tests on `strip_marked_content` covering empty input, nested pairs, unmatched EMC, idempotency).

## Remaining checklist (Issue #396)

- [x] 7.1 MCID content linkage — PR #399
- [x] Strip-then-retag for pre-tagged inputs — **this PR**
- [ ] 7.3 structure types
- [ ] 7.18.1 Link annotation Alt/Contents
- [ ] 7.18.5 tab order
- [ ] 7.21.7 font ToUnicode (source-PDF font issue, may be out of scope)
- [ ] 7.4.2 heading nesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness when processing PDFs with pre-existing structure markup to prevent tagging conflicts
  * Enhanced form processing to eliminate duplicate processing across pages

* **Tests**
  * Added comprehensive test coverage for markup handling scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/402)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->