### PR TITLE
feat(prh): long-description-inline detector (P6/PR6)

### DIFF
--- a/src/constants/prh-issue-codes.ts
+++ b/src/constants/prh-issue-codes.ts
@@ -703,6 +703,20 @@ export const PRH_ISSUE_CODES = {
     fixType: 'manual',
     summary: 'A <video> or <audio> element sets width via a width attribute or inline style — PRH requires media width to be set in CSS, not on the element',
   },
+
+  // ── Figure long-description detection (P6/PR6) ────────────────────────
+  // Publisher-gated and detect-only. Per PRH Technical Guide, long
+  // descriptions of complex images belong in a non-linear XHTML
+  // appendix (linked via aria-describedby), not inline in <figcaption>.
+  // We flag the cases worth refactoring; the actual non-linear-XHTML
+  // remediator is deferred until tenant demand surfaces.
+  'PRH-FIGURE-LONG-DESC-INLINE': {
+    code: 'PRH-FIGURE-LONG-DESC-INLINE',
+    severity: 'minor',
+    wcag: ['1.1.1'],
+    fixType: 'manual',
+    summary: 'A <figcaption> contains 250+ characters of text — PRH recommends moving long descriptions to a non-linear XHTML appendix (file_longdesc<N>.xhtml linked via aria-describedby) so the main reading flow stays uncluttered',
+  },
 } satisfies Record<string, PrhIssueDefinition>;
 
 export type PrhIssueCode = keyof typeof PRH_ISSUE_CODES;

--- a/src/services/acr/prh-conformance-report.service.ts
+++ b/src/services/acr/prh-conformance-report.service.ts
@@ -263,8 +263,9 @@ const TIER_CODE_COUNT: Record<PriorityTier, number> = {
   // P3 — body epub:type + doc-* ARIA (8) + forbidden (3) + notes/pagebreak (2)
   // + text heuristics (3) + CSS conventions (5, P6/PR1) + file/dir/size
   // (5, P6/PR2) + image assets (5, P6/PR3) + content-type markup
-  // (6, P6/PR5) + audio/video markup (3, P6/PR4) = 40
-  P3: 40,
+  // (6, P6/PR5) + audio/video markup (3, P6/PR4) + long-description
+  // detect (1, P6/PR6) = 41
+  P3: 41,
   // P4 has no PRH-* codes (AI policy gate + cover-alt template were
   // implemented as behaviors, not new codes). 0 to keep the type happy.
   P4: 0,
@@ -300,6 +301,7 @@ function priorityTierForCode(code: string): PriorityTier | null {
   if (code.startsWith('PRH-DIR-')) return 'P3';
   if (code.startsWith('PRH-IMG-')) return 'P3';
   if (code.startsWith('PRH-MEDIA-')) return 'P3';
+  if (code.startsWith('PRH-FIGURE-')) return 'P3';
   if (code === 'PRH-BODY-HAS-ARIA') return 'P3';
   if (code === 'PRH-PAGEBREAK-MALFORMED') return 'P3';
   if (code === 'PRH-FOOTNOTE-ID-MISMATCH') return 'P3';

--- a/src/services/epub/profiles/prh-uk/run-validators.ts
+++ b/src/services/epub/profiles/prh-uk/run-validators.ts
@@ -37,6 +37,7 @@ import { validatePrhFileLayout } from './validators/file-layout-validator';
 import { validatePrhImageAssets } from './validators/image-assets-validator';
 import { validatePrhContentTypeMarkup } from './validators/content-type-markup-validator';
 import { validatePrhMediaMarkup } from './validators/media-markup-validator';
+import { validatePrhLongDescriptionInline } from './validators/long-description-validator';
 import { getImprintRules } from './imprints';
 import sharp from 'sharp';
 import type { PublisherProfile } from '../types';
@@ -145,6 +146,7 @@ export async function runPrhUkValidators(
         ...validatePrhImageAssets(imageAssetsInput),
         ...validatePrhContentTypeMarkup(perXhtmlInput),
         ...validatePrhMediaMarkup(perXhtmlInput),
+        ...validatePrhLongDescriptionInline(perXhtmlInput),
       );
     }
 

--- a/src/services/epub/profiles/prh-uk/validators/long-description-validator.ts
+++ b/src/services/epub/profiles/prh-uk/validators/long-description-validator.ts
@@ -1,0 +1,132 @@
+/**
+ * PRH UK long-description-inline validator (P6/PR6).
+ *
+ * Per the Technical Guide, LONG descriptions of complex images
+ * (charts, schematics, infographics that need a paragraph or more
+ * to describe) should live in a NON-LINEAR XHTML appendix — a
+ * `<basename>_longdesc<N>.xhtml` file marked `linear="no"` in the
+ * spine, linked from the figure via `aria-describedby`. Short
+ * captions and brief context belong inline in `<figcaption>`; long
+ * descriptions inline clutter the reading flow and add scroll
+ * weight, especially on Kindle ET.
+ *
+ * One detect-only rule:
+ *   - PRH-FIGURE-LONG-DESC-INLINE — a `<figcaption>` whose text
+ *     content reaches the long-description threshold. Operators
+ *     review and decide; the actual non-linear-XHTML refactor is
+ *     deferred until tenant demand surfaces.
+ *
+ * Aggregated per file (one issue per file with an occurrence count)
+ * to match the other PRH markup validators.
+ */
+
+import { PRH_ISSUE_CODES } from '../../../../../constants/prh-issue-codes';
+import type { PrhValidatorIssue, PrhPerXhtmlInput } from './types';
+
+/**
+ * Character threshold above which a figcaption is considered a "long
+ * description" candidate. Aligned with the P6 implementation plan's
+ * 250-char target — short enough to catch genuine multi-sentence
+ * descriptions while leaving normal captions ("Fig. 3. The Eiffel
+ * Tower, 1889.") untouched.
+ */
+const LONG_DESC_CHAR_THRESHOLD = 250;
+
+export function validatePrhLongDescriptionInline(input: PrhPerXhtmlInput): PrhValidatorIssue[] {
+  const issues: PrhValidatorIssue[] = [];
+
+  for (const file of input.xhtmlFiles) {
+    const body = stripComments(stripHead(file.content));
+    const captions = extractFigcaptionTexts(body);
+    if (captions.length === 0) continue;
+
+    const longCount = captions.filter((text) => text.length >= LONG_DESC_CHAR_THRESHOLD).length;
+    if (longCount > 0) {
+      issues.push(
+        buildIssue(
+          'PRH-FIGURE-LONG-DESC-INLINE',
+          file.path,
+          ` (${longCount} figcaption(s) at or above the ${LONG_DESC_CHAR_THRESHOLD}-char threshold)`,
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function stripHead(html: string): string {
+  return html.replace(/<head\b[^>]*>[\s\S]*?<\/head>/i, '');
+}
+
+function stripComments(html: string): string {
+  return html.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+/**
+ * Extract the plain-text content of every `<figcaption>` element.
+ * Depth-counted balanced matching on `<figcaption>` so nested same-tag
+ * children (rare but possible) don't truncate early; text length is
+ * measured after stripping ALL child tags so a description wrapped in
+ * `<p>` and `<span>` is still counted by its visible text length.
+ */
+function extractFigcaptionTexts(body: string): string[] {
+  const out: string[] = [];
+  const openRe = /<figcaption\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = openRe.exec(body)) !== null) {
+    // Self-closing <figcaption/> has no text and is malformed XHTML;
+    // skip it rather than count zero text.
+    if (m[0].trimEnd().endsWith('/>')) continue;
+    const close = findBalancedClose(body, 'figcaption', openRe.lastIndex);
+    if (!close) continue;
+    const inner = body.slice(openRe.lastIndex, close.innerEnd);
+    const text = inner.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+    out.push(text);
+  }
+  return out;
+}
+
+function findBalancedClose(
+  html: string,
+  tag: string,
+  fromIndex: number,
+): { innerEnd: number; outerEnd: number } | null {
+  const tokenRe = new RegExp(`<(/?)${tag}\\b[^>]*>`, 'gi');
+  tokenRe.lastIndex = fromIndex;
+  let depth = 1;
+  let m: RegExpExecArray | null;
+  while ((m = tokenRe.exec(html)) !== null) {
+    const isClose = m[1] === '/';
+    const isSelfClosing = !isClose && m[0].trimEnd().endsWith('/>');
+    if (isSelfClosing) continue;
+    if (isClose) {
+      depth--;
+      if (depth === 0) {
+        return { innerEnd: m.index, outerEnd: tokenRe.lastIndex };
+      }
+    } else {
+      depth++;
+    }
+  }
+  return null;
+}
+
+function buildIssue(
+  code: 'PRH-FIGURE-LONG-DESC-INLINE',
+  location: string,
+  detail = '',
+): PrhValidatorIssue {
+  const def = PRH_ISSUE_CODES[code];
+  return {
+    code,
+    severity: def.severity,
+    wcag: def.wcag,
+    message: `${def.summary}: ${location}${detail}`,
+    suggestion:
+      'Move the long description into a separate non-linear XHTML file (e.g. <basename>_longdesc1.xhtml, declared with linear="no" in the spine) and link from the figure via aria-describedby. Keep the inline <figcaption> short (caption only).',
+    location,
+  };
+}

--- a/tests/unit/services/epub/profiles/prh-uk/validators/long-description-validator.test.ts
+++ b/tests/unit/services/epub/profiles/prh-uk/validators/long-description-validator.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { validatePrhLongDescriptionInline } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/long-description-validator';
+import type { PrhXhtmlFile } from '../../../../../../../src/services/epub/profiles/prh-uk/validators/types';
+
+function file(path: string, body: string): PrhXhtmlFile {
+  return {
+    path,
+    content: `<?xml version="1.0"?>
+<html xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>x</title></head>
+<body epub:type="bodymatter">${body}</body>
+</html>`,
+  };
+}
+
+function input(files: PrhXhtmlFile[]) {
+  return {
+    opfContent: '<?xml version="1.0"?><package/>',
+    opfPath: 'EPUB/package.opf',
+    bookTitle: 'Test',
+    xhtmlFiles: files,
+  };
+}
+
+/** Build a paragraph of plain text exactly `n` characters long. */
+function textOfLength(n: number): string {
+  return 'x'.repeat(n);
+}
+
+describe('validatePrhLongDescriptionInline — PRH-FIGURE-LONG-DESC-INLINE', () => {
+  it('emits when a <figcaption> contains 250+ chars of text', () => {
+    const issues = validatePrhLongDescriptionInline(
+      input([
+        file(
+          'ch1.xhtml',
+          `<figure><img src="x.png"/><figcaption>${textOfLength(300)}</figcaption></figure>`,
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-FIGURE-LONG-DESC-INLINE')).toBe(true);
+  });
+
+  it('emits at exactly 250 chars (threshold is inclusive)', () => {
+    const issues = validatePrhLongDescriptionInline(
+      input([
+        file(
+          'ch1.xhtml',
+          `<figure><img src="x.png"/><figcaption>${textOfLength(250)}</figcaption></figure>`,
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-FIGURE-LONG-DESC-INLINE')).toBe(true);
+  });
+
+  it('does NOT emit for short captions (under threshold)', () => {
+    const issues = validatePrhLongDescriptionInline(
+      input([
+        file(
+          'ch1.xhtml',
+          '<figure><img src="x.png"/><figcaption>Fig. 3. The Eiffel Tower, 1889.</figcaption></figure>',
+        ),
+      ]),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('counts only text content, ignoring child tags', () => {
+    // 240 visible chars wrapped in <p>/<span> — still under threshold.
+    const issues = validatePrhLongDescriptionInline(
+      input([
+        file(
+          'ch1.xhtml',
+          `<figure><img src="x.png"/><figcaption><p><span>${textOfLength(240)}</span></p></figcaption></figure>`,
+        ),
+      ]),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('measures combined text across child tags', () => {
+    // Two 130-char spans = 260 visible chars (above threshold).
+    const issues = validatePrhLongDescriptionInline(
+      input([
+        file(
+          'ch1.xhtml',
+          `<figure><img src="x.png"/><figcaption><p>${textOfLength(130)}</p><p>${textOfLength(130)}</p></figcaption></figure>`,
+        ),
+      ]),
+    );
+    expect(issues.some((i) => i.code === 'PRH-FIGURE-LONG-DESC-INLINE')).toBe(true);
+  });
+
+  it('counts multiple long figcaptions in one file', () => {
+    const issues = validatePrhLongDescriptionInline(
+      input([
+        file(
+          'ch1.xhtml',
+          `<figure><img src="a.png"/><figcaption>${textOfLength(300)}</figcaption></figure>` +
+            `<figure><img src="b.png"/><figcaption>${textOfLength(400)}</figcaption></figure>`,
+        ),
+      ]),
+    );
+    const longDescIssue = issues.find((i) => i.code === 'PRH-FIGURE-LONG-DESC-INLINE');
+    expect(longDescIssue?.message).toMatch(/2 figcaption/);
+  });
+
+  it('does NOT count a short and a long caption together — only the long one fires', () => {
+    const issues = validatePrhLongDescriptionInline(
+      input([
+        file(
+          'ch1.xhtml',
+          `<figure><img src="a.png"/><figcaption>Short caption.</figcaption></figure>` +
+            `<figure><img src="b.png"/><figcaption>${textOfLength(300)}</figcaption></figure>`,
+        ),
+      ]),
+    );
+    const longDescIssue = issues.find((i) => i.code === 'PRH-FIGURE-LONG-DESC-INLINE');
+    expect(longDescIssue?.message).toMatch(/1 figcaption/);
+  });
+
+  it('does NOT emit for a book with no <figcaption> at all', () => {
+    const issues = validatePrhLongDescriptionInline(
+      input([file('ch1.xhtml', '<p>Just prose.</p>')]),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('normalises whitespace before measuring (newlines + indentation do not inflate length)', () => {
+    // ~240 visible chars but with newlines + indentation pushing raw
+    // length above 250. Must measure post-normalisation.
+    const padded = '   ' + textOfLength(240).replace(/(.{40})/g, '$1\n    ') + '   ';
+    const issues = validatePrhLongDescriptionInline(
+      input([
+        file(
+          'ch1.xhtml',
+          `<figure><img src="x.png"/><figcaption>${padded}</figcaption></figure>`,
+        ),
+      ]),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('ignores a commented-out figcaption', () => {
+    const issues = validatePrhLongDescriptionInline(
+      input([
+        file('ch1.xhtml', `<!-- <figcaption>${textOfLength(300)}</figcaption> -->`),
+      ]),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('reports the correct file location across multiple files', () => {
+    const issues = validatePrhLongDescriptionInline(
+      input([
+        file('clean.xhtml', '<p>nothing.</p>'),
+        file(
+          'long.xhtml',
+          `<figure><img src="x.png"/><figcaption>${textOfLength(300)}</figcaption></figure>`,
+        ),
+      ]),
+    );
+    expect(issues.length).toBe(1);
+    expect(issues[0].location).toBe('long.xhtml');
+  });
+
+  it('skips unbalanced <figcaption> rather than emit on garbage', () => {
+    const issues = validatePrhLongDescriptionInline(
+      input([file('ch1.xhtml', `<figcaption>${textOfLength(300)}<p>orphan`)]),
+    );
+    expect(issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Final PR of P6. **Detect-only** validator for inline long descriptions — Option 3 from the scoping discussion: ship the visibility now, defer the non-linear-XHTML *remediator* until a tenant actually asks for that workflow.

One new code, P3 (advisory — does not block deliverable export):

| Code | Severity | Detects |
|---|---|---|
| `PRH-FIGURE-LONG-DESC-INLINE` | minor | A `<figcaption>` contains 250+ characters of text. PRH Technical Guide recommends moving long descriptions to a non-linear XHTML appendix (`<basename>_longdesc<N>.xhtml` linked via `aria-describedby`), keeping inline captions short. |

## Why detector-only

The plan originally framed PR6 as a *refactor* of an existing inline-long-description remediator. The actual `addFigureStructure()` in the codebase only handles short captions — there's no long-description output to refactor. Combined with no tenant having asked for the non-linear-appendix workflow, building the 4-file atomic mutation (manifest + spine + nav landmarks + new XHTML) plus tenant config flag would be exactly the "speculative infrastructure that rots" the plan warned against.

This detector earns operators the ability to **see** where long descriptions live in their books. If/when a tenant requests the non-linear refactor, real audit data will inform the threshold and the remediator UX.

## Implementation notes

- Per file, depth-counted balanced extraction of every `<figcaption>` (matches PR4/PR5 pattern)
- Text measured after stripping child tags AND normalising whitespace, so indentation/newlines don't inflate the count
- Threshold **inclusive at 250 chars** (matches the P6 plan target)
- Comments + `<head>` stripped first (consistent with PR4/PR5)
- Unbalanced `<figcaption>` markup is skipped, not emitted as missing — malformed markup is epubcheck's domain

## Conformance report

- `TIER_CODE_COUNT.P3` bumped 40 → 41
- `priorityTierForCode` maps `PRH-FIGURE-*` → P3

## P6 status

This closes P6. Final totals across the 5 shipped PRs (PR1–PR5 + PR6 minus the deferred codec rules from PR4): **22 new detect-only validators**, all P3 advisory.

## Test plan
- [x] 12 unit tests — at-threshold inclusivity, child-tag aware text counting, multi-caption per-file aggregation, whitespace normalisation, comment-stripping, unbalanced-markup skip, zero-figcaption clean path, multi-file location reporting
- [x] Existing 19 conformance-report tests still pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (`--max-warnings 0`)
- [ ] Staging smoke: re-audit a PRH-UK book with long figcaptions and confirm `PRH-FIGURE-LONG-DESC-INLINE` surfaces as P3 advisory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for figure captions exceeding 250 characters, flagged as a minor accessibility issue with manual remediation guidance to move long descriptions to separate documents.

* **Tests**
  * Added comprehensive test coverage for the new figure caption length validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/403)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->