### PR TITLE
fix(spike): add /Contents to Link annotations (7.18.1 t2)

### DIFF
--- a/spikes/pikepdf-write/write_tagged_pdf.py
+++ b/spikes/pikepdf-write/write_tagged_pdf.py
@@ -39,12 +39,31 @@ def write_tagged_pdf(
             for _k in ('/StructParents', '/StructParent'):
                 if _k in _po:
                     del _po[_k]
-            # Strip /StructParent from annotations on this page too.
+            # Process annotations on this page.
             annots = _po.get('/Annots')
             if annots:
                 for ann in annots:
                     if '/StructParent' in ann:
                         del ann['/StructParent']
+                    # PDF/UA-1 7.18.1 t2: every visible Link annotation must
+                    # have either a /Contents key (preferred — on the annotation
+                    # itself) or an /Alt on its enclosing structure element.
+                    # /Contents is simpler: extract the URI/destination from
+                    # the annotation's /A action; fall back to "Link".
+                    if ann.get('/Subtype') == pikepdf.Name('/Link') \
+                            and '/Contents' not in ann:
+                        contents = 'Link'
+                        _a = ann.get('/A')
+                        if _a is not None:
+                            if _a.get('/S') == pikepdf.Name('/URI'):
+                                _uri = _a.get('/URI')
+                                if _uri is not None:
+                                    contents = str(_uri)
+                            elif _a.get('/S') == pikepdf.Name('/GoTo'):
+                                _dest = _a.get('/D')
+                                if _dest is not None:
+                                    contents = f'Link to {_dest}'
+                        ann['/Contents'] = pikepdf.String(contents)
 
         # Set MarkInfo - required for Tagged PDF
         pdf.Root.MarkInfo = pikepdf.Dictionary(Marked=True)


### PR DESCRIPTION
## Summary

Clears **7.18.1 t2** and as a bonus **7.18.5 t2** — total failures drop **9 → 5**.

## Fix

PDF/UA-1 7.18.1 t2: every visible Link annotation must have a `/Contents` key (text description) or `/Alt` on its enclosing structure element. Added a pass over page `/Annots`: for each `/Link` annotation without `/Contents`, set it — extracting the URI from the `/A` action when available, falling back to `"Link"`.

## Result

| Clause | Before | After |
|---|---:|---:|
| 7.18.1 t2 | 2 | **0** ✓ |
| 7.18.5 t2 | 2 | **0** ✓ (incidental) |
| **Remaining total** | **9** | **5** |

Remaining: `7.18.5 t1 (2)`, `7.21.7 t1 (2)`, `7.4.2 t1 (1)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced link annotation handling in tagged PDF output by ensuring links automatically receive proper content labels derived from their associated actions or destinations, improving PDF structure and accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/405)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->