### PR TITLE
fix(spike): wire Link annotations into /Link StructElems (7.18.5 t1)

### DIFF
--- a/spikes/pikepdf-write/write_tagged_pdf.py
+++ b/spikes/pikepdf-write/write_tagged_pdf.py
@@ -218,35 +218,65 @@ def write_tagged_pdf(
 
             # 3. Wire each MCID into its zone's /K array, and build the
             #    page's ParentTree row (index = MCID, value = elem ref).
-            #    A page whose content is entirely artifacts produces no
-            #    assignments — it needs no /StructParents and no ParentTree
-            #    row (those exist only for content the structure tree
-            #    actually references).
-            if not assignments:
-                continue
+            #    Only pages that produce MCID assignments need /StructParents.
+            if assignments:
+                max_mcid = -1
+                for mcid, zone_idx in assignments:
+                    if 0 <= zone_idx < len(zone_elems):
+                        zone_elems[zone_idx].K.append(mcid)
+                        max_mcid = max(max_mcid, mcid)
 
-            max_mcid = -1
-            for mcid, zone_idx in assignments:
-                if 0 <= zone_idx < len(zone_elems):
-                    zone_elems[zone_idx].K.append(mcid)
-                    max_mcid = max(max_mcid, mcid)
+                mcid_to_elem = pikepdf.Array()
+                for mcid in range(max_mcid + 1):
+                    mcid_to_elem.append(
+                        zone_elem_refs[0] if zone_elem_refs else doc_ref
+                    )
+                for mcid, zone_idx in assignments:
+                    if 0 <= mcid <= max_mcid and 0 <= zone_idx < len(zone_elem_refs):
+                        mcid_to_elem[mcid] = zone_elem_refs[zone_idx]
 
-            mcid_to_elem = pikepdf.Array()
-            for mcid in range(max_mcid + 1):
-                # Default: point at the first zone elem so the array has no
-                # holes; overwrite with the real owner below.
-                mcid_to_elem.append(
-                    zone_elem_refs[0] if zone_elem_refs else doc_ref
-                )
-            for mcid, zone_idx in assignments:
-                if 0 <= mcid <= max_mcid and 0 <= zone_idx < len(zone_elem_refs):
-                    mcid_to_elem[mcid] = zone_elem_refs[zone_idx]
+                struct_parent_idx = next_struct_parent
+                next_struct_parent += 1
+                page_obj[pikepdf.Name('/StructParents')] = struct_parent_idx
+                parent_tree_nums.append(struct_parent_idx)
+                parent_tree_nums.append(pdf.make_indirect(mcid_to_elem))
 
-            struct_parent_idx = next_struct_parent
-            next_struct_parent += 1
-            page_obj[pikepdf.Name('/StructParents')] = struct_parent_idx
-            parent_tree_nums.append(struct_parent_idx)
-            parent_tree_nums.append(pdf.make_indirect(mcid_to_elem))
+            # 4. Wire Link annotations into the structure tree.
+            #    Processed unconditionally — a page may have Link annotations
+            #    but no operator-verified content zones (e.g. a TOC page where
+            #    text lives in form XObjects). Without this, 7.18.5 t1 fires on
+            #    those pages even if the same page passes the MCID wiring test.
+            #
+            #    PDF/UA-1 7.18.5 t1 (ISO 32000-1 §14.8.4.4.2): each Link
+            #    annotation must be enclosed in a /Link structure element with
+            #    an /OBJR (object reference) in its /K array.  Annotations use
+            #    /StructParent (singular integer) — distinct from page MCIDs
+            #    which use /StructParents (plural, array).
+            annots = page_obj.get('/Annots')
+            if annots:
+                for ann in annots:
+                    if ann.get('/Subtype') != pikepdf.Name('/Link'):
+                        continue
+                    ann_ref = pdf.make_indirect(ann)
+                    objr = pikepdf.Dictionary(
+                        Type=pikepdf.Name('/OBJR'),
+                        Obj=ann_ref,
+                        Pg=page_obj,
+                    )
+                    link_elem = pikepdf.Dictionary(
+                        Type=pikepdf.Name('/StructElem'),
+                        S=pikepdf.Name('/Link'),
+                        P=doc_ref,
+                        Pg=page_obj,
+                        K=pikepdf.Array([pdf.make_indirect(objr)]),
+                    )
+                    link_elem_ref = pdf.make_indirect(link_elem)
+                    doc_elem.K.append(link_elem_ref)
+                    ann_sp_idx = next_struct_parent
+                    next_struct_parent += 1
+                    ann['/StructParent'] = ann_sp_idx
+                    parent_tree_nums.append(ann_sp_idx)
+                    parent_tree_nums.append(link_elem_ref)
 
         # Attach the ParentTree + structure tree to the document.
         struct_tree_root.ParentTree = pdf.make_indirect(


### PR DESCRIPTION
## Summary

Clears **7.18.5 t1** and produces the first corpus doc with **0 PDF/UA-1 rule failures** on the untagged input.

## Fix

PDF/UA-1 7.18.5 t1 (ISO 32000-1 §14.8.4.4.2) requires each Link annotation to be enclosed in a `/Link` structure element with an `/OBJR` object reference in its `/K` array. Annotation→structure linkage uses `/StructParent` (singular integer) mapping to a leaf entry in the ParentTree — distinct from content MCID linkage which uses `/StructParents` (plural, page array).

**Two changes:**
1. For every Link annotation on every page: create a `/Link` StructElem, set `K=[/OBJR {Obj=<ann>, Pg=<page>}]`, assign a `/StructParent` index, add a ParentTree leaf entry.
2. Restructured MCID wiring from `if not assignments: continue` → `if assignments: …` so the annotation wiring always runs — pages with Link annotations but no content zones (TOC pages) were previously skipped.

## Results

| Input | Before | After |
|---|---:|---:|
| Pre-tagged mini-bundle (2 docs) | 5 rule failures | **3** |
| **Untagged (cmnpbz9vk…, 2541 zones)** | 4 | **0** ✓ — first clean pass |

## Remaining on mini-bundle (pre-tagged inputs)
- `7.21.7 t1` (2) — source-PDF font ToUnicode, **out of scope** for the write path
- `7.4.2 t1` (1) — heading nesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Link annotations in tagged PDFs to ensure proper structure tree integration, regardless of content assignment status.
  * Enhanced PDF structure tagging to correctly wire annotations into the document hierarchy while maintaining proper cross-references.
  * Updated page processing logic to handle annotation structure wiring independently of content assignment status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/406)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->