### PR TITLE
fix(spike): clamp heading levels to prevent skipped levels (7.4.2 t1)

### DIFF
--- a/spikes/pikepdf-write/write_tagged_pdf.py
+++ b/spikes/pikepdf-write/write_tagged_pdf.py
@@ -122,6 +122,12 @@ def write_tagged_pdf(
             P=struct_tree_ref,
             K=pikepdf.Array(),
         )
+
+        # PDF/UA-1 7.4.2: heading levels must not skip when going deeper.
+        # Track the last heading level emitted (0 = no heading yet) so we
+        # can clamp each new heading to at most last_heading_level + 1.
+        # Ascending (H3 → H1) is always allowed; only descending skips fail.
+        last_heading_level = [0]   # list to allow mutation inside inner scope
         doc_ref = pdf.make_indirect(doc_elem)
 
         # Group zones by page
@@ -170,9 +176,16 @@ def write_tagged_pdf(
                     or zone.get('type', 'paragraph')
                 role = get_pdf_role(zone_type)
 
-                # Build the tag role - headings use H1-H6
+                # Build the tag role - headings use H1-H6.
+                # Clamp skipped levels: if we go from H1 → H3 the veraPDF
+                # 7.4.2 check fires because H2 was skipped. Allow ascending
+                # (H3 → H1) freely; only prevent jumps >1 when descending.
                 if zone_type == 'section-header':
                     level = get_heading_level(zone)
+                    prev = last_heading_level[0]
+                    if prev > 0 and level > prev + 1:
+                        level = prev + 1      # close the gap
+                    last_heading_level[0] = level
                     tag_name = f'/H{level}'
                 else:
                     tag_name = role


### PR DESCRIPTION
## Summary

Clears **7.4.2 t1** — the last in-scope clause. The untagged corpus doc now **passes veraPDF completely**.

## Fix

Track `last_heading_level` across all pages. When emitting a section-header with `level > last + 1`, clamp it to `last + 1` (closes the gap). Ascending jumps (H3 → H1) remain unrestricted.

## Results

| Input | Failures before | After |
|---|---:|---:|
| Pre-tagged mini-bundle (2 docs) | 3 | **2** (`7.21.7` only — font ToUnicode, out of scope) |
| **Untagged (cmnpbz9vk…)** | 0 | **0, status=PASS, Go/No-Go: GO** ✓ |

## Remaining on pre-tagged

`7.21.7 t1` (font ToUnicode) is a source-PDF issue — fonts in the publisher PDFs lack Unicode mapping. That's a font-repair task orthogonal to the write path and scoped out of #396.

## Full-corpus spike next

With all in-scope clauses cleared, the next step is running the full 20-doc Fargate spike to measure the real corpus-wide pass rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced heading level management in tagged PDFs to prevent skipping intermediate levels, ensuring consistent document structure and improved accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->