### PR TITLE
fix(spike): guard against null annotation entries in /Annots array

### DIFF
--- a/spikes/pikepdf-write/write_tagged_pdf.py
+++ b/spikes/pikepdf-write/write_tagged_pdf.py
@@ -40,9 +40,15 @@ def write_tagged_pdf(
                 if _k in _po:
                     del _po[_k]
             # Process annotations on this page.
+            # Guard against null/deleted annotation entries — some PDFs store
+            # null indirect references in the /Annots array which pikepdf
+            # yields as None.  Without the `if ann is not None` check the `in`
+            # operator raises "argument of type 'NoneType' is not iterable".
             annots = _po.get('/Annots')
             if annots:
                 for ann in annots:
+                    if ann is None:
+                        continue
                     if '/StructParent' in ann:
                         del ann['/StructParent']
                     # PDF/UA-1 7.18.1 t2: every visible Link annotation must
@@ -268,6 +274,8 @@ def write_tagged_pdf(
             annots = page_obj.get('/Annots')
             if annots:
                 for ann in annots:
+                    if ann is None:          # null indirect reference
+                        continue
                     if ann.get('/Subtype') != pikepdf.Name('/Link'):
                         continue
                     ann_ref = pdf.make_indirect(ann)


### PR DESCRIPTION
One-line fix: `if ann is None: continue` in both annotation loops. Some PDFs store null indirect references in `/Annots` arrays; pikepdf yields them as `None`, crashing the `in` operator.

**Impact:** Fixes the one `WRITE_FAILED` doc in the 20-doc corpus (`cmnxvsoi2`, Army, Empire and Film). That doc now writes and scores — it fails on 7.1 t3 (residual content-tagging, same as 4 other docs), which is a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of PDF annotation processing to gracefully handle edge cases with null references, preventing potential errors during PDF generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->