### PR TITLE
fix(spike): clamp first heading to H1 (7.4.2 t1 fully cleared)

### DIFF
--- a/spikes/pikepdf-write/write_tagged_pdf.py
+++ b/spikes/pikepdf-write/write_tagged_pdf.py
@@ -183,14 +183,18 @@ def write_tagged_pdf(
                 role = get_pdf_role(zone_type)
 
                 # Build the tag role - headings use H1-H6.
-                # Clamp skipped levels: if we go from H1 → H3 the veraPDF
-                # 7.4.2 check fires because H2 was skipped. Allow ascending
-                # (H3 → H1) freely; only prevent jumps >1 when descending.
+                # Clamp skipped levels (PDF/UA-1 7.4.2): no jump of >1 in
+                # the "descending" direction (increasing level number). The
+                # first heading in a document is also constrained — starting
+                # at H3 means H1 and H2 were "skipped" per veraPDF, so the
+                # `prev > 0` guard from the previous increment is removed.
+                # With prev=0, the first heading is clamped to H1.
+                # Ascending (H3 → H1) always allowed — `level <= prev` path.
                 if zone_type == 'section-header':
                     level = get_heading_level(zone)
                     prev = last_heading_level[0]
-                    if prev > 0 and level > prev + 1:
-                        level = prev + 1      # close the gap
+                    if level > prev + 1:
+                        level = prev + 1      # close the gap (also first heading)
                     last_heading_level[0] = level
                     tag_name = f'/H{level}'
                 else:


### PR DESCRIPTION
Removes the `prev > 0` guard so the **first heading** in a document is also clamped.

**Problem:** Three docs opened with H3/H5 as their first heading. With `prev=0` the old guard skipped clamping, letting H3 through. veraPDF 7.4.2 flags "level 2 skipped" even when there is no prior heading.

**Fix:** `if level > prev + 1: level = prev + 1` — with `prev=0`, first heading is always clamped to H1.

**Result:** `7.4.2 t1` fully gone. **5 → 7 PASS (25% → 35%)**.

Only out-of-scope font clauses remain (`7.21.7`, `7.21.4.2`, `7.10`). All in-scope clauses are now cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed heading hierarchy normalization in tagged PDF document generation. Documents that previously started with lower-level headings (such as H3) are now properly constrained to begin at H1, preventing invalid heading level skips. This improves document structure consistency and ensures better accessibility standards compliance for all PDFs created.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-backend/pull/410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->