### PR TITLE
fix(calibration): strip NUL/control bytes from zone content before DB write

### DIFF
--- a/src/services/calibration/calibration.service.ts
+++ b/src/services/calibration/calibration.service.ts
@@ -6,6 +6,7 @@ import { extractZonesFromTaggedPdf, type TaggedPdfExtractionStats } from '../zon
 import { matchZones, type SourceZone } from './zone-matcher';
 import { summariseCalibrationRun } from './calibration-summary';
 import { logger } from '../../lib/logger';
+import { stripPgUnsafeChars } from '../../utils/pg-text';
 
 export interface CalibrationRunResult {
   calibrationRunId: string;
@@ -196,7 +197,9 @@ export async function runCalibration(
           doclingLabel: m.doclingZone?.label ?? null,
           doclingConfidence: m.doclingZone?.confidence ?? null,
           pdfxtLabel: m.pdfxtZone?.label ?? null,
-          content: zone.content ?? null,
+          // Defense-in-depth: strip NUL / C0 control chars so a single bad glyph
+          // can't abort the whole createMany transaction (Postgres rejects 0x00).
+          content: stripPgUnsafeChars(zone.content),
         };
       }),
     }),

--- a/src/services/zone-extractor/tagged-pdf-extractor.ts
+++ b/src/services/zone-extractor/tagged-pdf-extractor.ts
@@ -6,6 +6,7 @@ import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { s3Client } from '../s3.service';
 import type { CanonicalZoneType, BBox } from './types';
 import { logger } from '../../lib/logger';
+import { stripPgUnsafeChars } from '../../utils/pg-text';
 import type { Readable } from 'stream';
 
 // Ensure pdfjs worker is configured (same pattern as pdf-parser.service.ts)
@@ -886,7 +887,9 @@ function emitBlockZone(
         const parts = textMap.get(id);
         if (parts) textParts.push(parts.join(''));
       }
-      const joined = textParts.join(' ').trim();
+      // Strip NUL / C0 control chars: pdfjs emits U+0000 for unmapped glyphs
+      // (common in STEM/CID fonts), which PostgreSQL rejects in text columns.
+      const joined = stripPgUnsafeChars(textParts.join(' ').trim());
       if (joined) content = joined;
     }
 

--- a/src/services/zone-extractor/zone-type-mapper.ts
+++ b/src/services/zone-extractor/zone-type-mapper.ts
@@ -14,6 +14,7 @@ const DOCLING_LABEL_MAP: Record<string, CanonicalZoneType> = {
   'formula':         'paragraph',
   'code':            'paragraph',
   'reference':       'paragraph',
+  'document_index':  'paragraph',
   // Docling v1 labels (PascalCase with dashes) — keep for compatibility
   'Text':           'paragraph',
   'Section-Header': 'section-header',

--- a/src/utils/pg-text.ts
+++ b/src/utils/pg-text.ts
@@ -1,0 +1,33 @@
+/**
+ * Strip bytes that PostgreSQL refuses to store in text/varchar columns.
+ *
+ * PostgreSQL text columns are UTF-8 and reject the NUL byte (code point 0)
+ * with `invalid byte sequence for encoding "UTF8": 0x00`, which aborts the
+ * whole surrounding transaction. PDF text extraction (especially via pdfjs on
+ * STEM/CID-font PDFs) can emit NUL and other C0 control characters when a
+ * glyph has no real Unicode mapping — e.g. math symbols in pdfxt-tagged PDFs.
+ *
+ * This removes every C0 control character (code points 0-31) and DEL (127)
+ * except the ones that are legal and meaningful in stored text:
+ * tab (9), line feed (10) and carriage return (13). Returns null for
+ * empty/nullish input so the result can be assigned directly to a nullable
+ * column.
+ */
+export function stripPgUnsafeChars(value: string): string;
+export function stripPgUnsafeChars(value: null | undefined): null;
+export function stripPgUnsafeChars(value: string | null | undefined): string | null;
+export function stripPgUnsafeChars(
+  value: string | null | undefined,
+): string | null {
+  if (value == null) return null;
+
+  let cleaned = '';
+  for (const ch of value) {
+    const code = ch.codePointAt(0)!;
+    const isAllowedControl = code === 9 || code === 10 || code === 13;
+    if ((code < 32 && !isAllowedControl) || code === 127) continue;
+    cleaned += ch;
+  }
+
+  return cleaned.length > 0 ? cleaned : null;
+}

--- a/tests/unit/utils/pg-text.test.ts
+++ b/tests/unit/utils/pg-text.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { stripPgUnsafeChars } from '../../../src/utils/pg-text';
+
+const NUL = String.fromCharCode(0);
+
+describe('stripPgUnsafeChars', () => {
+  it('removes the NUL byte that aborts Postgres text writes', () => {
+    expect(stripPgUnsafeChars(`x${NUL}y`)).toBe('xy');
+  });
+
+  it('strips a NUL embedded in extracted math text (Nikitopoulos repro)', () => {
+    const input = `\\theta ${NUL}= \\frac{1}{2}`;
+    const out = stripPgUnsafeChars(input);
+    expect(out).not.toBeNull();
+    expect(out!.indexOf(NUL)).toBe(-1);
+    expect(out).toBe('\\theta = \\frac{1}{2}');
+  });
+
+  it('removes other C0 control characters and DEL', () => {
+    const input = [0, 1, 8, 11, 12, 14, 31, 127].map((c) => String.fromCharCode(c)).join('A');
+    const out = stripPgUnsafeChars(input);
+    expect(out).toBe('AAAAAAA');
+  });
+
+  it('preserves tab, newline and carriage return', () => {
+    expect(stripPgUnsafeChars('a\tb\nc\rd')).toBe('a\tb\nc\rd');
+  });
+
+  it('preserves normal unicode (math symbols, accents)', () => {
+    expect(stripPgUnsafeChars('∑ α≤β — café')).toBe('∑ α≤β — café');
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(stripPgUnsafeChars(null)).toBeNull();
+    expect(stripPgUnsafeChars(undefined)).toBeNull();
+  });
+
+  it('returns null when the string is empty after stripping', () => {
+    expect(stripPgUnsafeChars(NUL + NUL)).toBeNull();
+    expect(stripPgUnsafeChars('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

"Run Zone extraction" failed **repeatedly and deterministically** for `Math_Nikitopoulos_PDF.pdf` (one of the five STEM titles queued for Phase-2 annotation).

Root cause (confirmed against live staging logs, run `cmpvv7ksg…`):

```
prisma:error invalid byte sequence for encoding "UTF8": 0x00
Invalid prisma.zone.createMany() invocation in calibration.service.js:185:31
```

Both extractors *succeeded* (tagged-PDF: 1,749 zones; Docling: 80 s). The job died on the **database write**: the pdfxt-tagged text contained **7 NUL (`U+0000`) characters on pages 27/100/126/129** — math glyphs with no Unicode mapping, which pdfjs surfaces as `U+0000`. PostgreSQL rejects `0x00` in `text` columns, aborting the whole `createMany` transaction, so **no zones persist** and the run fails every retry.

The PDF itself is fine — it parses cleanly in pikepdf, pdfplumber and pypdfium2. A structurally similar title (`Math_Weir`, fonts with complete ToUnicode maps) had **0 NUL bytes** and ran end-to-end successfully — confirming the failure is content-specific, not complexity- or size-driven.

⚠️ This affects **any** STEM/CID-font PDF whose tagged text contains unmapped glyphs, so the remaining Phase-2 titles are at risk.

## Fix

- **`src/utils/pg-text.ts`** *(new)* — shared `stripPgUnsafeChars()`: removes C0 control chars (keeps `\t \n \r`), returns `null` when empty.
- **`tagged-pdf-extractor.ts`** — sanitize `content` **at the source** (protects every caller).
- **`calibration.service.ts`** — sanitize `content` **at the DB boundary** (defense-in-depth on the exact failing line).
- **`zone-type-mapper.ts`** — map Docling's `document_index` label (was logging "Unknown label" repeatedly and silently falling back to paragraph).
- **`tests/unit/utils/pg-text.test.ts`** *(new)* — 7 cases incl. a Nikitopoulos-style NUL repro.

## Impact / rollout

- Fix is at **extraction time**; the failed run persisted nothing, so **no data migration** is needed. After deploy, the operator simply re-runs **Run Zone extraction** on Nikitopoulos.
- Only side effect: the 7 unmapped glyphs (4 pages) lose those characters from the zone **text** string; bounding boxes and zone types are unaffected.
- Lives in the **ninja-backend** service only; the Docling GPU service is unaffected.

## Verification

- `npx tsc --noEmit` — exit 0
- `vitest run` (sanitizer + mapper) — 25/25 pass
- `eslint --max-warnings 0` on all changed files — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed database transaction failures that occurred when processing document content containing incompatible characters. Text content is now sanitized before database persistence.
  * Extended document label recognition to handle additional Docling label types.

* **Tests**
  * Added comprehensive unit test coverage for text sanitization functionality, including validation of character filtering and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->