### PR TITLE
feat(calibration): add reopen endpoint to re-annotate completed documents

### DIFF
--- a/src/controllers/annotation-report.controller.ts
+++ b/src/controllers/annotation-report.controller.ts
@@ -21,7 +21,7 @@ import {
 } from '../services/calibration/corpus-summary.service';
 import { markCompleteBodySchema } from '../schemas/mark-complete.schema';
 import { corpusRangeQuerySchema, resolveCorpusRange } from '../schemas/corpus-summary.schema';
-import prisma from '../lib/prisma';
+import prisma, { Prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 
 function serverError(res: Response, err: unknown, code: string) {
@@ -324,6 +324,65 @@ class AnnotationReportController {
       });
     } catch (err) {
       serverError(res, err, 'MARK_COMPLETE_FAILED');
+    }
+  }
+
+  /**
+   * POST /calibration/runs/:runId/reopen
+   *
+   * Reverses Mark Complete so a completed corpus document can be re-annotated
+   * (e.g. to fix table labels). Clears the run's annotation-completion signals
+   * — `pagesReviewed` and `summary.analysisStatus` — and sets the document's
+   * `statusOverride` to IN_PROGRESS. Operator zones are left untouched, and the
+   * extraction `completedAt` is preserved (this does not re-run extraction).
+   * Returns `documentId` so the FE can navigate straight to the review workspace.
+   */
+  async reopenAnnotation(req: Request, res: Response, _next: NextFunction): Promise<void> {
+    try {
+      const { runId } = req.params;
+
+      const run = await prisma.calibrationRun.findUnique({
+        where: { id: runId },
+        select: { id: true, documentId: true, summary: true },
+      });
+      if (!run) {
+        res.status(404).json({
+          success: false,
+          error: { code: 'NOT_FOUND', message: 'Calibration run not found' },
+        });
+        return;
+      }
+
+      // Drop the analysis-complete marker but keep the rest of the summary.
+      const summary = { ...((run.summary as Record<string, unknown> | null) ?? {}) };
+      delete summary.analysisStatus;
+
+      await prisma.$transaction([
+        prisma.calibrationRun.update({
+          where: { id: runId },
+          data: {
+            pagesReviewed: null,
+            summary: summary as Prisma.InputJsonValue,
+          },
+        }),
+        prisma.corpusDocument.update({
+          where: { id: run.documentId },
+          data: {
+            statusOverride: 'IN_PROGRESS',
+            statusUpdatedAt: new Date(),
+            statusUpdatedBy: req.user?.id ?? null,
+          },
+        }),
+      ]);
+
+      logger.info(`[AnnotationReport] Reopened run ${runId} (doc ${run.documentId}) for re-annotation`);
+
+      res.json({
+        success: true,
+        data: { runId, documentId: run.documentId, status: 'IN_PROGRESS' as const },
+      });
+    } catch (err) {
+      serverError(res, err, 'REOPEN_FAILED');
     }
   }
 

--- a/src/routes/annotation-report.routes.ts
+++ b/src/routes/annotation-report.routes.ts
@@ -37,6 +37,7 @@ router.get('/corpus/analysis-summary', annotationReportController.getCorpusSumma
 
 // Annotation analysis
 router.post('/runs/:runId/complete', annotationReportController.markAnnotationComplete.bind(annotationReportController));
+router.post('/runs/:runId/reopen', annotationReportController.reopenAnnotation.bind(annotationReportController));
 router.get('/runs/:runId/analysis-status', annotationReportController.getAnalysisStatus.bind(annotationReportController));
 router.get('/runs/:runId/analysis', annotationReportController.getAnalysis.bind(annotationReportController));
 


### PR DESCRIPTION
## Why

The zone-detector data audit found `table` is annotated inconsistently (whole table **and** every cell boxed as `table`), which is why the model misses ~89% of tables. Fixing it requires re-annotating ~12 documents that are already marked **Complete** — but the annotation UI hides the "Review" entry once a doc is complete, with no way back in.

This adds the backend half of a **Reopen** action.

## What

`POST /api/v1/calibration/runs/:runId/reopen` — reverses Mark Complete:
- Clears the run's `pagesReviewed` and `summary.analysisStatus`
- Sets the document's `statusOverride = 'IN_PROGRESS'`
- **Preserves all operator zones**; leaves the extraction `completedAt` intact (no re-extraction)
- Returns `{ runId, documentId, status }` so the FE can open the review workspace

Sits next to `markAnnotationComplete` in the same controller/route file.

## Frontend

Paired UI work is specced for the front-end agent (Reopen button in the Document Queue → calls this endpoint → navigates to the review workspace). Backend is independently safe to ship.

## Test
- `npx tsc --noEmit` — clean
- Logic: clears completion signals + flips statusOverride in one transaction; 404 on unknown runId

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to reopen calibration annotation runs. When reopened, a run is reset to in-progress status, allowing reviewers to revisit and modify previous annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->