### PR TITLE
feat(pdf): emit boundingBox from form & contrast validators

### DIFF
--- a/src/services/audit/base-audit.service.ts
+++ b/src/services/audit/base-audit.service.ts
@@ -62,7 +62,12 @@ export interface AuditIssue {
   /** Testability designation from Matterhorn Protocol 1.1 */
   matterhornHow?: 'M' | 'H' | '--';
   triage?: IssueTriage;
-  /** Bounding box of the flagged element in PDF page coordinates (bottom-left origin). */
+  /**
+   * Bounding box of the flagged element, in unscaled PDF points with a
+   * TOP-LEFT origin (y grows downward) — the same convention produced by the
+   * image/table/link extractors. Validators emitting this must convert any
+   * bottom-left (raw PDF user-space / pdfjs) coordinates before populating it.
+   */
   boundingBox?: { x: number; y: number; width: number; height: number; pageWidth: number; pageHeight: number };
 }
 

--- a/src/services/pdf/validators/pdf-contrast.validator.ts
+++ b/src/services/pdf/validators/pdf-contrast.validator.ts
@@ -168,6 +168,10 @@ export class PdfContrastValidator {
             `Text: "${str.substring(0, 50)}", ` +
             `fg=${this.rgbToHex(textColor)}, bg=${this.rgbToHex(bgColor)}, ratio=${ratio.toFixed(2)}:1`,
           pageNumber: page.pageNumber,
+          // Use UNSCALED PDF-point coords (not the canvas/RENDER_SCALE values above)
+          boundingBox: this.computeTextBoundingBox(
+            pdfX, pdfY, item.width, fontSize, page.width, page.height
+          ),
         });
       }
     }
@@ -221,6 +225,45 @@ export class PdfContrastValidator {
   }
 
   // ─── Public helpers (used by tests and AI analysis) ───────────────────────
+
+  /**
+   * Build a top-left-origin boundingBox (unscaled PDF points) for a text item.
+   *
+   * pdfjs text-item coordinates (transform[4]/[5]) are PDF user space with a
+   * BOTTOM-LEFT origin, where transform[5] is the text baseline. The canonical
+   * boundingBox uses a TOP-LEFT origin matching the text/structure extractors
+   * (text-extractor.service.ts: y = pageHeight - transform[5], height = fontSize).
+   * Deliberately uses PDF points — NOT the canvas/RENDER_SCALE values used for
+   * pixel sampling.
+   *
+   * Returns undefined when the text width or page size is unknown, so the box is
+   * only attached when every value is a real number.
+   */
+  computeTextBoundingBox(
+    pdfX: number,
+    pdfBaselineY: number,
+    itemWidth: number | undefined,
+    fontSize: number,
+    pageWidth: number,
+    pageHeight: number,
+  ): AuditIssue['boundingBox'] | undefined {
+    if (
+      !(typeof itemWidth === 'number' && itemWidth > 0) ||
+      !(fontSize > 0) ||
+      !(pageWidth > 0) ||
+      !(pageHeight > 0)
+    ) {
+      return undefined;
+    }
+    return {
+      x: pdfX,
+      y: pageHeight - pdfBaselineY,
+      width: itemWidth,
+      height: fontSize,
+      pageWidth,
+      pageHeight,
+    };
+  }
 
   calculateContrastRatio(color1: RgbColor, color2: RgbColor): number {
     const l1 = this.getLuminance(color1.r, color1.g, color1.b);

--- a/src/services/pdf/validators/pdf-form.validator.ts
+++ b/src/services/pdf/validators/pdf-form.validator.ts
@@ -31,7 +31,7 @@ class PdfFormValidator {
     for (const page of parsed.pages) {
       totalFields += page.formFields.length;
       for (const field of page.formFields) {
-        const issue = this.checkField(field, page.pageNumber);
+        const issue = this.checkField(field, page.pageNumber, page.width, page.height);
         if (issue) issues.push(issue);
       }
     }
@@ -45,9 +45,15 @@ class PdfFormValidator {
     return issues;
   }
 
-  private checkField(field: PdfFormField, pageNumber: number): AuditIssue | null {
+  private checkField(
+    field: PdfFormField,
+    pageNumber: number,
+    pageWidth: number,
+    pageHeight: number
+  ): AuditIssue | null {
     const label = (field.label ?? '').trim();
     const name = (field.name ?? '').trim();
+    const boundingBox = this.buildBoundingBox(field, pageWidth, pageHeight);
 
     const hasNoLabel = !label;
     const hasGenericLabel = label
@@ -73,6 +79,7 @@ class PdfFormValidator {
           'or set a descriptive field name in the authoring tool.',
         context: `Field name: "${name || '(unnamed)'}", Type: ${field.type}`,
         pageNumber,
+        boundingBox,
       };
     }
 
@@ -92,6 +99,7 @@ class PdfFormValidator {
           'The tooltip provides the accessible name read by screen readers.',
         context: `Field name: "${name}", Type: ${field.type}`,
         pageNumber,
+        boundingBox,
       };
     }
 
@@ -111,10 +119,42 @@ class PdfFormValidator {
           '(e.g., "Enter your full legal name" instead of "Field1").',
         context: `Field name: "${name}", Tooltip: "${label}", Type: ${field.type}`,
         pageNumber,
+        boundingBox,
       };
     }
 
     return null;
+  }
+
+  /**
+   * Build a top-left-origin boundingBox from a form field's position.
+   *
+   * field.position comes from the pdfjs annotation rect [x0,y0,x1,y1], which is
+   * in PDF user space with a BOTTOM-LEFT origin (position.y is the bottom edge).
+   * The canonical boundingBox uses a TOP-LEFT origin, so flip y:
+   *   topLeftY = pageHeight - (position.y + position.height)
+   *
+   * Returns undefined when the field has no real geometry (some widget types
+   * report a zero-area rect) or the page size is unknown — so boundingBox stays
+   * optional and is only attached when all values are real numbers.
+   */
+  private buildBoundingBox(
+    field: PdfFormField,
+    pageWidth: number,
+    pageHeight: number
+  ): AuditIssue['boundingBox'] | undefined {
+    const { x, y, width, height } = field.position;
+    if (!(width > 0) || !(height > 0) || !(pageHeight > 0) || !(pageWidth > 0)) {
+      return undefined;
+    }
+    return {
+      x,
+      y: pageHeight - (y + height),
+      width,
+      height,
+      pageWidth,
+      pageHeight,
+    };
   }
 }
 

--- a/tests/unit/services/pdf/pdf-contrast.boundingbox.test.ts
+++ b/tests/unit/services/pdf/pdf-contrast.boundingbox.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for PDF Contrast Validator boundingBox geometry.
+ *
+ * The full contrast pass renders pages to a canvas (pdfjs + @napi-rs/canvas),
+ * which is not exercisable in a unit test, so the coordinate conversion that
+ * feeds issue.boundingBox is isolated in computeTextBoundingBox() and verified
+ * directly here. The conversion mirrors text-extractor.service.ts so highlights
+ * line up with the alt-text/table/link convention (top-left origin, PDF points).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PdfContrastValidator } from '../../../../src/services/pdf/validators/pdf-contrast.validator';
+
+describe('PdfContrastValidator.computeTextBoundingBox', () => {
+  const validator = new PdfContrastValidator();
+
+  it('converts a pdfjs text item to a top-left-origin PDF-point box', () => {
+    // pdfjs baseline y (transform[5]) is bottom-left origin; flip to top-left.
+    const box = validator.computeTextBoundingBox(100, 700, 80, 12, 612, 792);
+
+    expect(box).toEqual({
+      x: 100,
+      y: 92, // pageHeight - baselineY = 792 - 700
+      width: 80,
+      height: 12, // fontSize
+      pageWidth: 612,
+      pageHeight: 792,
+    });
+  });
+
+  it('uses PDF points, not canvas/RENDER_SCALE values', () => {
+    const box = validator.computeTextBoundingBox(0, 0, 50, 18, 612, 792);
+    expect(box?.width).toBe(50);
+    expect(box?.height).toBe(18);
+  });
+
+  it('returns undefined when the text width is unknown', () => {
+    expect(validator.computeTextBoundingBox(100, 700, undefined, 12, 612, 792)).toBeUndefined();
+  });
+
+  it('returns undefined when the page size is unknown', () => {
+    expect(validator.computeTextBoundingBox(100, 700, 80, 12, 0, 0)).toBeUndefined();
+  });
+});

--- a/tests/unit/services/pdf/pdf-form.validator.test.ts
+++ b/tests/unit/services/pdf/pdf-form.validator.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for PDF Form Field Validator
+ *
+ * Focuses on accessible-label detection and on the boundingBox geometry that
+ * drives issue highlighting in the frontend PDF preview.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { pdfFormValidator } from '../../../../src/services/pdf/validators/pdf-form.validator';
+import { PdfParseResult, PdfFormField } from '../../../../src/services/pdf/pdf-comprehensive-parser.service';
+
+const PAGE_WIDTH = 612;
+const PAGE_HEIGHT = 792;
+
+function makeParsed(formFields: PdfFormField[]): PdfParseResult {
+  return {
+    metadata: {
+      pdfVersion: '1.7',
+      isEncrypted: false,
+      isLinearized: false,
+      isTagged: true,
+      hasOutline: false,
+      hasAcroForm: true,
+      hasXFA: false,
+      pageCount: 1,
+      hasStructureTree: true,
+    },
+    pages: [
+      {
+        pageNumber: 1,
+        width: PAGE_WIDTH,
+        height: PAGE_HEIGHT,
+        rotation: 0,
+        content: [],
+        images: [],
+        links: [],
+        formFields,
+        headings: [],
+        tables: [],
+        lists: [],
+      },
+    ],
+    isTagged: true,
+  } as unknown as PdfParseResult;
+}
+
+function makeField(overrides: Partial<PdfFormField> = {}): PdfFormField {
+  return {
+    name: 'field1', // generic name → triggers FORM-FIELD-NO-LABEL when unlabeled
+    type: 'text',
+    label: '',
+    value: '',
+    required: false,
+    // pdfjs rect convention: bottom-left origin, position.y is the BOTTOM edge
+    position: { x: 100, y: 700, width: 200, height: 20 },
+    ...overrides,
+  };
+}
+
+describe('PdfFormValidator', () => {
+  it('flags an unlabeled, generically-named field', async () => {
+    const issues = await pdfFormValidator.validate(makeParsed([makeField()]));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('FORM-FIELD-NO-LABEL');
+  });
+
+  it('attaches a top-left-origin boundingBox derived from field.position', async () => {
+    const issues = await pdfFormValidator.validate(makeParsed([makeField()]));
+    const box = issues[0].boundingBox;
+
+    expect(box).toBeDefined();
+    // y is flipped from the bottom-left rect: pageHeight - (y + height) = 792 - 720 = 72
+    expect(box).toEqual({
+      x: 100,
+      y: 72,
+      width: 200,
+      height: 20,
+      pageWidth: PAGE_WIDTH,
+      pageHeight: PAGE_HEIGHT,
+    });
+  });
+
+  it('omits boundingBox when the field has a zero-area rect', async () => {
+    const issues = await pdfFormValidator.validate(
+      makeParsed([makeField({ position: { x: 0, y: 0, width: 0, height: 0 } })])
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].boundingBox).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What & why
The frontend PDF preview highlights an audit issue only when it carries `issue.boundingBox`. Today only alt-text/table/link populate it, so most issues never highlight. This PR adds it to the **form** and **contrast** validators using real element geometry — no fabricated coordinates.

**Prompt 1 of 4** from `pdf-boundingbox-backend-prompts.md` (highest coverage, lowest risk).

## Changes
- **`pdf-form.validator`** — `field.position` comes from the pdfjs annotation `rect` (bottom-left origin); converted to the canonical top-left origin via `y = pageHeight - (position.y + position.height)`. Zero-area widget rects are skipped.
- **`pdf-contrast.validator`** — new pure helper `computeTextBoundingBox()` emitting **PDF points** (`y = pageHeight - baselineY`, `height = fontSize`), explicitly NOT the canvas/`RENDER_SCALE` values used for pixel sampling.
- **`base-audit.service`** — corrected the `boundingBox` doc comment: the convention is **top-left origin** (matches the image/table/link extractors); the old "bottom-left" comment was wrong.

## Coordinate convention (verified in code)
All existing extractors flip to top-left origin: `image-extractor.ts:280`, `structure-analyzer.ts:804`, `text-extractor.ts:274`. The new emitters match exactly.

## Tests
- `pdf-form.validator.test.ts` (new) — bottom-left→top-left conversion + zero-area skip.
- `pdf-contrast.boundingbox.test.ts` (new) — PDF-point conversion + undefined fallbacks.
- typecheck + lint clean; full unit suite 1743 passing.

## No frontend changes needed
Once the backend emits `boundingBox`, the existing highlight code uses it. (Note: locally `PdfPreviewPanel.parseIssueLocation()` is still a stub — the real consumer is in frontend PR #281.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audit issues now include precise location information (bounding boxes) for contrast and form field validation, enabling easier issue identification and remediation.

* **Documentation**
  * Clarified coordinate conventions for location data in validation results.

* **Tests**
  * Added comprehensive test coverage for bounding box computation and form field validation enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->