### PR TITLE
feat(pdf): emit boundingBox from structure table issues

### DIFF
--- a/src/services/pdf/validators/pdf-structure.validator.ts
+++ b/src/services/pdf/validators/pdf-structure.validator.ts
@@ -96,11 +96,17 @@ class PDFStructureValidator {
 
     logger.info('[PDFStructureValidator] Running structure validations...');
 
+    // Page-dimension lookup (width/height at scale=1 in PDF points) for
+    // attaching boundingBox to issues whose element carries real geometry.
+    const pageDims = new Map(
+      (parsedPdf.structure.pages ?? []).map(p => [p.pageNumber, { width: p.width, height: p.height }])
+    );
+
     // Validate document structure
     issues.push(...this.validateDocumentStructure(structure, parsedPdf));
 
     // Validate content structure
-    issues.push(...this.validateContentStructure(structure));
+    issues.push(...this.validateContentStructure(structure, pageDims));
 
     // Calculate summary
     const summary = this.calculateSummary(issues);
@@ -387,14 +393,18 @@ class PDFStructureValidator {
    * @param structure - Analyzed document structure
    * @returns Array of issues
    */
-  private validateContentStructure(structure: DocumentStructure): AuditIssue[] {
+  private validateContentStructure(
+    structure: DocumentStructure,
+    pageDims: Map<number, { width: number; height: number }>
+  ): AuditIssue[] {
     const issues: AuditIssue[] = [];
 
-    // Validate lists
+    // Validate lists — ListInfo.position only exposes {x,y} (no width/height),
+    // so list issues intentionally carry no boundingBox (cannot fabricate size).
     issues.push(...this.validateLists(structure.lists, structure.isTaggedPDF));
 
-    // Validate tables
-    issues.push(...this.validateTables(structure.tables));
+    // Validate tables — TableInfo.position has full {x,y,width,height} geometry.
+    issues.push(...this.validateTables(structure.tables, pageDims));
 
     return issues;
   }
@@ -449,10 +459,25 @@ class PDFStructureValidator {
    * @param tables - Table information
    * @returns Array of issues
    */
-  private validateTables(tables: DocumentStructure['tables']): AuditIssue[] {
+  private validateTables(
+    tables: DocumentStructure['tables'],
+    pageDims: Map<number, { width: number; height: number }>
+  ): AuditIssue[] {
     const issues: AuditIssue[] = [];
 
     for (const table of tables) {
+      // TableInfo.position is top-left origin, unscaled PDF points — same
+      // convention as the alt-text/table/link extractors.
+      const pageSize = pageDims.get(table.pageNumber) ?? { width: 0, height: 0 };
+      const boundingBox = {
+        x: table.position.x,
+        y: table.position.y,
+        width: table.position.width,
+        height: table.position.height,
+        pageWidth: pageSize.width,
+        pageHeight: pageSize.height,
+      };
+
       // Check for accessibility issues identified by structure analyzer
       for (const tableIssue of table.issues) {
         issues.push(this.createIssue({
@@ -465,6 +490,7 @@ class PDFStructureValidator {
           suggestion: 'Ensure table has proper structure with Table, TR, TH, and TD tags. Add headers to identify row/column relationships.',
           category: 'tables',
           pageNumber: table.pageNumber,
+          boundingBox,
         }));
       }
 
@@ -494,6 +520,7 @@ class PDFStructureValidator {
           suggestion: 'Add TH (header) tags to identify row and column headers. For complex tables, add a summary describing the table structure.',
           category: 'tables',
           pageNumber: table.pageNumber,
+          boundingBox,
         }));
       }
     }

--- a/src/services/pdf/validators/pdf-supplemental.validator.ts
+++ b/src/services/pdf/validators/pdf-supplemental.validator.ts
@@ -536,6 +536,12 @@ class PdfSupplementalValidator {
     return undefined;
   }
 
+  // NOTE: No boundingBox is emitted by this validator. Every supplemental
+  // condition is sourced from document-level objects with no on-page rectangle —
+  // the catalog (/OCProperties, /Names, /AcroForm), the encryption dictionary,
+  // page /Resources entries, or structure-tree Note nodes (PdfStructureNode has
+  // no geometry). These issues are non-spatial by design; fabricating coordinates
+  // would be incorrect.
   private createIssue(opts: {
     code: string;
     matterhornCheckpoint: string;

--- a/tests/unit/services/pdf/pdf-structure.validator.test.ts
+++ b/tests/unit/services/pdf/pdf-structure.validator.test.ts
@@ -449,6 +449,107 @@ describe('PDFStructureValidator', () => {
     });
   });
 
+  describe('boundingBox coverage', () => {
+    it('attaches a boundingBox to table issues from table.position + page size', async () => {
+      const mockParsedPdf = createMockParsedPdf({ isTagged: true, hasLanguage: true, hasTitle: true });
+      const mockStructure = createMockStructure({
+        isTaggedPDF: true,
+        hasProperHeadingHierarchy: true,
+        hasDocumentLanguage: true,
+        hasLogicalReadingOrder: true,
+        tables: [
+          {
+            id: 'table_p1_0',
+            pageNumber: 1,
+            position: { x: 50, y: 100, width: 500, height: 200 },
+            rowCount: 5,
+            columnCount: 3,
+            hasHeaderRow: false,
+            hasHeaderColumn: false,
+            hasSummary: false,
+            cells: [],
+            issues: ['Table has no header cells (TH). Add row or column headers.'],
+            isAccessible: false,
+          },
+        ],
+      });
+
+      vi.mocked(pdfParserService.parse).mockResolvedValue(mockParsedPdf);
+      vi.mocked(pdfParserService.close).mockResolvedValue(undefined);
+      vi.mocked(structureAnalyzerService.analyzeStructure).mockResolvedValue(mockStructure);
+
+      const result = await pdfStructureValidator.validateFromFile('/path/to/test.pdf');
+
+      const expectedBox = { x: 50, y: 100, width: 500, height: 200, pageWidth: 612, pageHeight: 792 };
+
+      const inaccessible = result.issues.find(i => i.code === 'TABLE-INACCESSIBLE');
+      expect(inaccessible?.boundingBox).toEqual(expectedBox);
+
+      const accessibility = result.issues.find(i => i.code === 'TABLE-ACCESSIBILITY');
+      expect(accessibility?.boundingBox).toEqual(expectedBox);
+    });
+
+    it('does not attach a boundingBox to heading issues (no per-element geometry)', async () => {
+      const mockParsedPdf = createMockParsedPdf({ isTagged: true, hasLanguage: true, hasTitle: true });
+      const mockStructure = createMockStructure({
+        isTaggedPDF: true,
+        hasProperHeadingHierarchy: false,
+        hasDocumentLanguage: true,
+        hasLogicalReadingOrder: true,
+        headingIssues: [
+          {
+            type: 'missing-h1',
+            severity: 'major' as const,
+            description: 'Document has no H1 heading',
+            location: 'Document',
+            wcagCriterion: '1.3.1',
+          },
+        ],
+      });
+
+      vi.mocked(pdfParserService.parse).mockResolvedValue(mockParsedPdf);
+      vi.mocked(pdfParserService.close).mockResolvedValue(undefined);
+      vi.mocked(structureAnalyzerService.analyzeStructure).mockResolvedValue(mockStructure);
+
+      const result = await pdfStructureValidator.validateFromFile('/path/to/test.pdf');
+
+      const heading = result.issues.find(i => i.code === 'MATTERHORN-14-003');
+      expect(heading).toBeDefined();
+      expect(heading?.boundingBox).toBeUndefined();
+    });
+
+    it('does not attach a boundingBox to list issues (ListInfo has no width/height)', async () => {
+      const mockParsedPdf = createMockParsedPdf({ isTagged: true, hasLanguage: true, hasTitle: true });
+      const mockStructure = createMockStructure({
+        isTaggedPDF: true,
+        hasProperHeadingHierarchy: true,
+        hasDocumentLanguage: true,
+        hasLogicalReadingOrder: true,
+        lists: [
+          {
+            id: 'list_p1_0',
+            pageNumber: 1,
+            type: 'unordered',
+            itemCount: 5,
+            items: [],
+            position: { x: 50, y: 100 },
+            isProperlyTagged: false,
+          },
+        ],
+      });
+
+      vi.mocked(pdfParserService.parse).mockResolvedValue(mockParsedPdf);
+      vi.mocked(pdfParserService.close).mockResolvedValue(undefined);
+      vi.mocked(structureAnalyzerService.analyzeStructure).mockResolvedValue(mockStructure);
+
+      const result = await pdfStructureValidator.validateFromFile('/path/to/test.pdf');
+
+      const list = result.issues.find(i => i.code === 'LIST-IMPROPER-MARKUP');
+      expect(list).toBeDefined();
+      expect(list?.boundingBox).toBeUndefined();
+    });
+  });
+
   describe('summary calculation', () => {
     it('should correctly calculate issue summary', async () => {
       const mockParsedPdf = createMockParsedPdf({
@@ -505,6 +606,15 @@ function createMockParsedPdf(options: {
         hasAcroForm: false,
       },
       outline: [],
+      pages: Array.from({ length: 10 }, (_, i) => ({
+        pageNumber: i + 1,
+        width: 612,
+        height: 792,
+        tags: [],
+        images: [],
+        links: [],
+        annotations: [],
+      })),
     },
     pdfLibDoc: {} as ParsedPDF['pdfLibDoc'],
     pdfjsDoc: {} as ParsedPDF['pdfjsDoc'],


### PR DESCRIPTION
## What & why
Continues PDF issue `boundingBox` coverage so the frontend preview can highlight more issue types. **Prompt 2 of 4** from `pdf-boundingbox-backend-prompts.md`. Builds on the convention established in #415 (independent — can merge in any order).

Attaches `boundingBox` **only** where the underlying element already carries real geometry; everything else is explicitly skipped (no fabricated coordinates).

## Coverage report (which codes get a box, which are skipped)
| Issue code | boundingBox? | Reason |
|---|---|---|
| `TABLE-ACCESSIBILITY` | ✅ | `TableInfo.position` has full `{x,y,width,height}` (top-left) |
| `TABLE-INACCESSIBLE` | ✅ | same |
| `LIST-IMPROPER-MARKUP`, `LIST-NOT-TAGGED` | ❌ | `ListInfo.position` exposes only `{x,y}` — no width/height to attach without fabricating |
| heading codes (`MATTERHORN-14-003`, `HEADING-*`) | ❌ | no per-element geometry |
| reading-order codes (`MATTERHORN-12-001`, `READING-ORDER-*`) | ❌ | no per-element geometry |
| document-level codes (`PDF-UNTAGGED`, `WCAG-2.4.2`, etc.) | ❌ | non-spatial |
| **all supplemental codes** | ❌ | sourced from catalog / encryption dict / structure-tree Note nodes — no on-page rectangle (documented in-code) |

## Changes
- **`pdf-structure.validator`** — page-dimension lookup + `boundingBox` on the two table codes from `TableInfo.position`.
- **`pdf-supplemental.validator`** — comment documenting why it emits no `boundingBox`.
- **`pdf-structure.validator.test`** — tables now assert a `boundingBox`; headings and lists assert it stays unset.

## Tests
typecheck + lint clean; structure suite 16 passing; full unit suite 1743 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table validation issues now include bounding box data indicating exact page location within PDF documents for improved issue tracking

* **Tests**
  * Added comprehensive test coverage for table bounding box calculation and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->