### PR TITLE
docs(pdf): note bookmark issues are non-spatial (no boundingBox)

### DIFF
--- a/src/services/pdf/validators/pdf-bookmark.validator.ts
+++ b/src/services/pdf/validators/pdf-bookmark.validator.ts
@@ -27,6 +27,10 @@ class PdfBookmarkValidator {
   name = 'PdfBookmarkValidator';
   private issueCounter = 0;
 
+  // No boundingBox by design: bookmark issues are non-spatial. They derive from
+  // the document outline (PDFOutlineItem = title + destination page + children),
+  // which points to a page but has no on-page rectangle to highlight.
+
   async validate(parsed: PdfParseResult): Promise<AuditIssue[]> {
     logger.info('[PdfBookmarkValidator] Starting bookmark validation...');
     this.issueCounter = 0;


### PR DESCRIPTION
## What & why
**Prompt 3 of 4** from `pdf-boundingbox-backend-prompts.md` — an investigation, with the expected outcome of "N/A".

Question: do any bookmark issues expose on-page geometry for the frontend highlight overlay?

**Answer: no.** Bookmark issues derive from the document outline (`PDFOutlineItem` = `title` + `destination` page number + `children`). A bookmark points to a *page* but has no on-page rectangle to draw. There is genuinely no per-element coordinate to attach.

## Change
Per the prompt's instruction for this outcome, **no code change** beyond a one-line comment in `pdf-bookmark.validator.ts` recording that bookmark issues are non-spatial by design. No behavioral change, no tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains internal code documentation improvements with no user-facing changes.

* **Chores**
  * Improved internal code comments for clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->