### PR TITLE
fix(calibration): show all corpus docs in queue + ignore non-calibration runs

### DIFF
--- a/src/routes/calibration.routes.ts
+++ b/src/routes/calibration.routes.ts
@@ -257,7 +257,11 @@ router.get('/runs/:runId/zones', authenticate, async (req: Request, res: Respons
 });
 
 const corpusDocsQuerySchema = z.object({
-  limit: z.coerce.number().default(20),
+  // The Bootstrap Console Document Queue has no pagination control and sends no
+  // limit, so the default must cover the whole corpus or older docs (oldest
+  // uploadedAt) silently fall off page 1 and become unreachable. Default to the
+  // 100 cap; revisit (add real pagination) if the corpus grows past ~100.
+  limit: z.coerce.number().default(100),
   cursor: z.string().optional(),
   publisher: z.string().optional(),
   contentType: z.string().optional(),
@@ -296,6 +300,11 @@ router.get('/corpus-docs', authenticate, async (req: Request, res: Response) => 
           take: 1,
         },
         calibrationRuns: {
+          // Only the real annotation run drives the queue row (status, Review/
+          // Reopen target, polling). Without this, a later non-calibration run
+          // (e.g. PIKE_PDF_SPIKE) becomes calibrationRuns[0] and shadows the
+          // CALIBRATION run, breaking the row — as it did for Acharya.
+          where: { type: 'CALIBRATION' },
           orderBy: { runDate: 'desc' },
           take: 1,
         },


### PR DESCRIPTION
## Problem
The Bootstrap Console **Document Queue** doesn't show all corpus documents — Acharya (and any other old upload) is missing, and there's **no pagination control** on the page to reach it.

Two root causes in `GET /api/v1/calibration/corpus-docs`:
1. **Page limit hides old uploads.** The queue sends no `limit`, so the backend default (**20**) applies, ordered by `uploadedAt DESC`. With 26 corpus docs, the 6 oldest fall onto an unreachable page 2. Acharya is the single oldest upload (2026-04-04) → rank **26 of 26** → invisible.
2. **Non-calibration runs shadow the row.** The query included the latest run of **any** type. Acharya has 5 later `PIKE_PDF_SPIKE` runs (font-repair spike), so `calibrationRuns[0]` became a spike run instead of its `CALIBRATION` run — which the frontend uses for status, polling, and the Review/Reopen target.

## Fix
- `corpusDocsQuerySchema.limit` default **20 → 100** (the `take` already caps at 100; covers the whole corpus, no frontend change needed since the queue sends no limit).
- `/corpus-docs` include now filters `calibrationRuns` to `where: { type: 'CALIBRATION' }`.

## Why backend-only
The frontend hook `useCorpusDocumentsWithPolling()` is called with no params and only accepts `{publisher, contentType}` — it never sends `limit`. So raising the backend default fixes visibility without touching the frontend.

## Testing
- `tsc --noEmit` ✅ · `eslint src/routes/calibration.routes.ts` ✅
- Verified against staging: 26 docs total; with limit 100 all return on one page; Acharya's `calibrationRuns[0]` becomes its CALIBRATION run.

## Follow-up (not in this PR)
Add a real pagination/“load more” control in the frontend if the corpus grows past ~100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calibration document listing so the default result count is higher, reducing the chance of incomplete results when pagination isn’t available.
  * Corrected calibration progress display by ensuring only calibration-related runs are used for progress calculations, preventing unrelated run data from affecting status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->