### PR TITLE
fix(calibration): correct cursor pagination off-by-one (dropped boundary doc/zone)

### DIFF
--- a/src/routes/calibration.routes.ts
+++ b/src/routes/calibration.routes.ts
@@ -243,8 +243,10 @@ router.get('/runs/:runId/zones', authenticate, async (req: Request, res: Respons
 
     let nextCursor: string | undefined;
     if (zones.length > limit) {
-      const extra = zones.pop()!;
-      nextCursor = extra.id;
+      // Resume AFTER the last returned zone, not the popped look-ahead sentinel
+      // (which the next page's `skip: 1` would drop).
+      zones.pop();
+      nextCursor = zones[zones.length - 1]?.id;
     }
 
     return res.json({ success: true, data: { zones, nextCursor } });
@@ -293,7 +295,9 @@ router.get('/corpus-docs', authenticate, async (req: Request, res: Response) => 
       where,
       take: take + 1,
       ...(cursor && { cursor: { id: cursor }, skip: 1 }),
-      orderBy: { uploadedAt: 'desc' },
+      // id is the unique tiebreaker — without it, cursor paging across docs that
+      // share an uploadedAt (many do) can skip or duplicate rows at boundaries.
+      orderBy: [{ uploadedAt: 'desc' }, { id: 'desc' }],
       include: {
         bootstrapJobs: {
           orderBy: { createdAt: 'desc' },
@@ -313,8 +317,11 @@ router.get('/corpus-docs', authenticate, async (req: Request, res: Response) => 
 
     let nextCursor: string | null = null;
     if (documents.length > take) {
-      const extra = documents.pop()!;
-      nextCursor = extra.id;
+      // Resume AFTER the last returned doc. Using the look-ahead sentinel's id
+      // as the cursor would make the next page's `skip: 1` skip that doc — which
+      // dropped the page-boundary doc entirely (e.g. Acharya at rank 26 of 26).
+      documents.pop();
+      nextCursor = documents[documents.length - 1]?.id ?? null;
     }
 
     // Enrich with annotation progress for docs that have a completed run


### PR DESCRIPTION
## Problem
After PR #419, the Document Queue still showed **25 of 26** corpus docs — **Acharya** (the oldest upload, rank 26) was missing, with the footer "All 25 documents loaded."

Root cause is **not** the page limit — it's an **off-by-one in cursor pagination**, exposed now that the frontend ships real cursor paging (`useInfiniteQuery`, `PAGE_SIZE = 25`).

`/corpus-docs` (and `/runs/:runId/zones`) fetch `take + 1` rows, then:
```ts
const extra = documents.pop()!;   // the (take+1)'th row
nextCursor = extra.id;            // ...used as the cursor
```
The next page does `cursor: { id }, skip: 1` — which **skips that exact row**. So the page-boundary item is popped from page N *and* skipped on page N+1 → never returned. With 26 docs at page size 25: page 1 returns 25 (Acharya popped as cursor), page 2 skips Acharya → empty. Acharya vanishes.

## Fix
- `nextCursor` now points at the **last returned row** (resume strictly after it), for both `/corpus-docs` and `/zones`.
- `/corpus-docs` `orderBy` gains an **`id` tiebreaker** (`[{ uploadedAt: 'desc' }, { id: 'desc' }]`) so paging is stable across the many docs sharing an `uploadedAt`.

## Verification (against staging)
Simulated the corrected paging at size 25:
```
pages: 2, returned: 26, distinct: 26, dupes: 0, corpusTotal: 26,
allReturned: true, acharyaPresent: true   // last item = Acharya
```
- `tsc --noEmit` ✅ · `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination for calibration zones so results no longer include an extra look-ahead item, and the next page cursor now reflects the last item returned.
  * Made calibration corpus document pagination more stable by adding a consistent secondary sort order.
  * Fixed document paging cursor handling so the next page continues from the final returned item, reducing skipped or repeated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->