### PR TITLE
fix(calibration): filter runs by type so review loads the CALIBRATION run

### DIFF
--- a/src/routes/calibration.routes.ts
+++ b/src/routes/calibration.routes.ts
@@ -93,6 +93,7 @@ router.post('/run', authenticate, async (req: Request, res: Response) => {
 
 const runsQuerySchema = z.object({
   documentId: z.string().optional(),
+  type: z.string().optional(),
   limit: z.coerce.number().optional(),
   fromDate: z.string().datetime({ offset: true }).optional(),
   toDate: z.string().datetime({ offset: true }).optional(),
@@ -113,12 +114,15 @@ router.get('/runs', authenticate, async (req: Request, res: Response) => {
       });
     }
 
-    const { documentId, limit, fromDate, toDate } = parsed.data;
+    const { documentId, type, limit, fromDate, toDate } = parsed.data;
     const take = Math.min(limit || 20, 100);
 
     const where: Record<string, unknown> = {};
     if (documentId) {
       where.documentId = documentId;
+    }
+    if (type) {
+      where.type = type;
     }
     if (fromDate) {
       where.runDate = { ...((where.runDate as Record<string, unknown>) || {}), gte: new Date(fromDate) };
@@ -132,6 +136,7 @@ router.get('/runs', authenticate, async (req: Request, res: Response) => {
       select: {
         id: true,
         documentId: true,
+        type: true,
         runDate: true,
         completedAt: true,
         durationMs: true,


### PR DESCRIPTION
## Problem
The zone-review workspace opens a document by loading its **latest run** and showing that run's zones. `GET /calibration/runs` orders by `runDate desc` with **no run-type filter**, so a document that was also used in a non-calibration run (e.g. a `PIKE_PDF_SPIKE` run from the May PDF write-spike) returns that spike run first. The spike run has **no operator zones**, so the annotator sees **"No zones on this page"** on every page — even though the real annotations live on the older `CALIBRATION` run.

Verified live: **Acharya** has 5 runs (4 `PIKE_PDF_SPIKE` from May 13–20 + 1 `CALIBRATION`), and its newest run is a spike run with 0 operator zones. Its 229 table zones / 3,570 operator zones sit on the CALIBRATION run `cmnjmhlpd…`.

## Fix
Add an optional `type` filter to `GET /calibration/runs` (and return `type` in the payload) so the frontend can request the latest **CALIBRATION** run specifically. Additive and backwards-compatible — no `type` param means unchanged behavior.

## Testing
- `tsc --noEmit` ✓ · `npm run lint` (`--max-warnings 0`) ✓
- `tests/unit/routes/calibration-routes-ml26.test.ts` — 6/6 pass ✓

## Deploy order
Deploy **before** the frontend PR (s4cindia/ninja-frontend — "load the latest CALIBRATION run in zone review"), which sends `type=CALIBRATION`. Older backend silently ignores the param (zod strips unknown keys), so no breakage if order slips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The calibration runs API now supports filtering results by run type.
  * Each returned run now includes its type in the response.

* **Bug Fixes**
  * Improved query validation to accept the new type filter while keeping existing filters and pagination unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->