### PR TITLE
feat(calibration): bulk-reject + draw-zone endpoints for the zone editor

### DIFF
--- a/src/routes/zone-correction.routes.ts
+++ b/src/routes/zone-correction.routes.ts
@@ -143,6 +143,132 @@ router.post('/zones/:zoneId/reject', authenticate, async (req: Request, res: Res
   }
 });
 
+// POST /api/v1/calibration/zones/bulk-reject
+// Reject many zones in one call — either an explicit list (multi-select in the
+// editor) or a filter (e.g. "reject all remaining formula boxes on this page").
+// Unblocks cleaning up dense pages that carry hundreds of per-cell boxes.
+const bulkRejectSchema = z.object({
+  zoneIds: z.array(z.string().min(1)).max(5000).optional(),
+  filter: z.object({
+    calibrationRunId: z.string().min(1),
+    pageNumber: z.number().int().optional(),
+    operatorLabel: z.string().min(1).optional(),
+  }).optional(),
+  correctionReason: z.string().optional(),
+}).refine((d) => (d.zoneIds && d.zoneIds.length > 0) || d.filter, {
+  message: 'Provide a non-empty zoneIds array or a filter',
+});
+
+router.post('/zones/bulk-reject', authenticate, async (req: Request, res: Response) => {
+  try {
+    const operatorId = req.user!.id;
+    const parsed = bulkRejectSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(422).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: 'Request validation failed', details: parsed.error.issues },
+      });
+    }
+    const { zoneIds, filter, correctionReason } = parsed.data;
+
+    // Explicit ids win; otherwise reject all still-active zones matching the filter.
+    const where: Prisma.ZoneWhereInput = zoneIds && zoneIds.length > 0
+      ? { id: { in: zoneIds } }
+      : {
+          calibrationRunId: filter!.calibrationRunId,
+          ...(filter!.pageNumber != null ? { pageNumber: filter!.pageNumber } : {}),
+          ...(filter!.operatorLabel
+            ? { operatorLabel: { equals: filter!.operatorLabel, mode: 'insensitive' } }
+            : {}),
+          decision: { not: 'REJECTED' },
+        };
+
+    const result = await prisma.zone.updateMany({
+      where,
+      data: {
+        isArtefact: true,
+        decision: 'REJECTED',
+        correctionReason: correctionReason ?? null,
+        verifiedAt: new Date(),
+        verifiedBy: operatorId,
+      },
+    });
+
+    return res.json({ success: true, data: { rejectedCount: result.count } });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
+// POST /api/v1/calibration/runs/:runId/zones
+// Create a new operator-drawn zone (e.g. a box around a whole matrix on a page
+// where extraction only produced cell-level boxes). Writes `bounds` — the field
+// the training export reads — so drawn boxes reach training (unlike Correct,
+// which stores operatorBbox that the export ignores).
+const createZoneSchema = z.object({
+  pageNumber: z.number().int().positive(),
+  operatorLabel: z.string().min(1),
+  bounds: z.object({
+    x: z.number(),
+    y: z.number(),
+    w: z.number().positive(),
+    h: z.number().positive(),
+  }),
+  type: z.string().optional(),
+});
+
+router.post('/runs/:runId/zones', authenticate, async (req: Request, res: Response) => {
+  try {
+    const { runId } = req.params;
+    const operatorId = req.user!.id;
+    const tenantId = req.user!.tenantId;
+
+    const parsed = createZoneSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(422).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: 'Request validation failed', details: parsed.error.issues },
+      });
+    }
+    const { pageNumber, operatorLabel, bounds, type } = parsed.data;
+
+    const run = await prisma.calibrationRun.findUnique({ where: { id: runId }, select: { id: true } });
+    if (!run) {
+      return res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Calibration run not found' },
+      });
+    }
+
+    const created = await prisma.zone.create({
+      data: {
+        tenantId,
+        calibrationRunId: runId,
+        pageNumber,
+        type: type ?? operatorLabel,
+        bounds,
+        source: 'operator',
+        reconciliationBucket: 'GREEN',
+        operatorVerified: true,
+        operatorLabel,
+        decision: 'CORRECTED',
+        verifiedAt: new Date(),
+        verifiedBy: operatorId,
+      },
+    });
+
+    return res.status(201).json({ success: true, data: created });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_ERROR', message: (err as Error).message },
+    });
+  }
+});
+
 // POST /api/v1/calibration/runs/:runId/confirm-all-green
 // Approach: updateMany for boolean/datetime fields.
 // operatorLabel is not set per-zone — at display time the frontend

--- a/src/routes/zone-correction.routes.ts
+++ b/src/routes/zone-correction.routes.ts
@@ -162,6 +162,7 @@ const bulkRejectSchema = z.object({
 router.post('/zones/bulk-reject', authenticate, async (req: Request, res: Response) => {
   try {
     const operatorId = req.user!.id;
+    const tenantId = req.user!.tenantId;
     const parsed = bulkRejectSchema.safeParse(req.body);
     if (!parsed.success) {
       return res.status(422).json({
@@ -171,10 +172,13 @@ router.post('/zones/bulk-reject', authenticate, async (req: Request, res: Respon
     }
     const { zoneIds, filter, correctionReason } = parsed.data;
 
-    // Explicit ids win; otherwise reject all still-active zones matching the filter.
+    // Explicit ids win; otherwise reject all still-active zones matching the
+    // filter. Always scope to the caller's tenant so one tenant can't reject
+    // another tenant's zones by id.
     const where: Prisma.ZoneWhereInput = zoneIds && zoneIds.length > 0
-      ? { id: { in: zoneIds } }
+      ? { tenantId, id: { in: zoneIds } }
       : {
+          tenantId,
           calibrationRunId: filter!.calibrationRunId,
           ...(filter!.pageNumber != null ? { pageNumber: filter!.pageNumber } : {}),
           ...(filter!.operatorLabel


### PR DESCRIPTION
## Why
Re-annotating dense math pages (e.g. Olszewski matrix pages carry **300–580 per-cell formula boxes** each) is impractical today: zone actions are **per-zone only** (`/zones/:zoneId/{confirm,correct,reject}`), there's no multi-select/bulk-reject, and no way to **create** a zone. On pages where extraction produced only cell-level boxes, there was **no way to make a whole-matrix box at all**. This is the tooling gap blocking the formula class (the last weak class in the zone detector — v5 table 0.55 but formula ~0).

## What
Two new endpoints in `zone-correction.routes.ts` (already mounted at `/api/v1/calibration`):

### 1. `POST /calibration/zones/bulk-reject`
Reject many zones in one call — covers **multi-select bulk reject** and **"reject all remaining formula on this page."**
```jsonc
// multi-select:
{ "zoneIds": ["z1","z2", ...] }
// or filter (reject all active formula on a page):
{ "filter": { "calibrationRunId": "...", "pageNumber": 279, "operatorLabel": "formula" } }
```
→ `{ success, data: { rejectedCount } }`. Filter mode only touches still-active zones (`decision != REJECTED`); label match is case-insensitive.

### 2. `POST /calibration/runs/:runId/zones` (draw-new-box)
Create an operator-drawn zone:
```jsonc
{ "pageNumber": 279, "operatorLabel": "formula", "bounds": { "x": 60, "y": 200, "w": 340, "h": 120 } }
```
→ `201 { success, data: <zone> }`. Sets `operatorVerified=true, source='operator', decision='CORRECTED'` and **writes `bounds`**.

## Important pipeline note
`Correct` stores the resized box in **`operatorBbox`**, which the **training export does NOT read** (it reads `bounds`). That's why the draw endpoint writes `bounds` — so drawn boxes actually reach training. A recommended follow-up is to make the export/bundle prefer `operatorBbox` when present, so `Correct`-resize also flows through.

## Testing
- `tsc --noEmit` ✅ · `eslint` ✅
- Follows existing per-zone endpoint conventions (auth, `verifiedBy`, decision values, response shape). `bulk-reject` uses `updateMany` like the existing `confirm-all-green`.

## Frontend
Separate frontend work (multi-select rubber-band, draw-box tool, "reject all on page" button) — prompts provided separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to reject multiple calibration zones at once using selected zones or filters.
  * Added support for creating operator-drawn calibration zones with page, label, bounds, and optional type details.
  * Added validation and clear responses for invalid requests, missing calibration runs, and processing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->