### PR TITLE
build(training-export): bake run_export.py into the image

### DIFF
--- a/training-export-service/Dockerfile
+++ b/training-export-service/Dockerfile
@@ -9,10 +9,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY export.py main.py ./
+COPY export.py main.py run_export.py ./
 
 RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser \
-    && chown -R appuser:appuser /app
+    && mkdir -p /work \
+    && chown -R appuser:appuser /app /work
 
 EXPOSE 8082
 


### PR DESCRIPTION
## What
Adds `run_export.py` (the batch export entrypoint) to the `ninja-training-export` image and creates the `/work` scratch dir it uses.

## Why
The batch export tasks run `python run_export.py`, but that file was never `COPY`'d into the image — so one-shot export runs had to pull the export code from S3 at runtime (`combined_export_run*.py`) via a command override. That override is fragile and drifts from the repo: the live `:latest` image predates the table-cell merge, so **every** export currently *must* override or it silently regresses.

Baking `run_export.py` in (alongside the current `export.py`, which now carries the table-cell merge + pinned page-split) lets a rebuilt image run the batch export directly:
```
python run_export.py   # BUNDLE_S3_URI=... OUTPUT_S3_PREFIX=... EXPORT_ID=... TABLE_NORMALIZE=1
```
No S3-script override, no stale-image drift.

## Notes
- The default `CMD` is unchanged (the `uvicorn main:app` HTTP service); the batch export is still a command override — it just no longer needs to fetch code.
- The image is built + pushed manually (no CI workflow for it); rebuilding as part of this change so `:latest` matches the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the training export container setup by ensuring required scripts are available at runtime.
  * Added a writable workspace directory for export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->