### PR TITLE
feat(zone-extractor): yolo-client + source:'yolo' extraction mode (B2)

### DIFF
--- a/src/services/zone-extractor/types.ts
+++ b/src/services/zone-extractor/types.ts
@@ -23,11 +23,25 @@ export interface DetectedZone {
   bbox: BBox;
   zoneType: CanonicalZoneType;
   confidence: number | null;
-  source: 'docling' | 'pdfxt' | 'operator';
+  source: 'docling' | 'pdfxt' | 'operator' | 'yolo';
   doclingLabel?: string;
 }
 
 export interface DoclingServiceResponse {
+  jobId: string;
+  zones: Array<{
+    page: number;
+    bbox: { x: number; y: number; w: number; h: number };
+    label: string;
+    confidence?: number;
+  }>;
+  processingTimeMs: number;
+}
+
+// The YOLO zone-detector service returns the same wire shape as Docling, so the
+// client mirrors the docling submit-and-poll flow. Labels are already the
+// canonical class names (the model's class list), unlike Docling's raw labels.
+export interface YoloServiceResponse {
   jobId: string;
   zones: Array<{
     page: number;

--- a/src/services/zone-extractor/yolo-client.ts
+++ b/src/services/zone-extractor/yolo-client.ts
@@ -1,0 +1,116 @@
+import { logger } from '../../lib/logger';
+import type { YoloServiceResponse } from './types';
+
+// Client for the YOLOv8 zone-detector service (zone-detector-service/). Mirrors
+// the docling submit-and-poll flow so a long detection doesn't hold a
+// connection open across the NAT idle timeout. Endpoint from YOLO_SERVICE_URL.
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface AsyncJobResponse {
+  asyncJobId: string;
+  status: 'PROCESSING' | 'COMPLETED' | 'FAILED';
+  result?: YoloServiceResponse;
+  error?: string;
+}
+
+async function submitAsyncJob(
+  baseUrl: string,
+  pdfPath: string,
+  jobId: string,
+): Promise<string> {
+  const res = await fetch(`${baseUrl}/detect-async`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ pdfPath, jobId }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    if (res.status >= 500) {
+      throw new Error(`YOLO_SERVICE_ERROR: ${res.status} ${body}`);
+    }
+    throw new Error(`YOLO_CLIENT_ERROR: ${res.status} ${body}`);
+  }
+
+  const { asyncJobId } = (await res.json()) as AsyncJobResponse;
+  return asyncJobId;
+}
+
+export async function detectWithYolo(
+  pdfPath: string,
+  jobId: string,
+): Promise<YoloServiceResponse> {
+  const baseUrl = process.env.YOLO_SERVICE_URL;
+  if (!baseUrl) {
+    throw new Error('YOLO_SERVICE_URL env var is not set');
+  }
+
+  const MAX_RETRIES = 2; // re-submit on container restart (404)
+  const POLL_INTERVAL_MS = 5_000;
+  const MAX_POLL_TIME_MS = 30 * 60 * 1000; // 30 min — GPU inference on a large PDF is minutes, not hours
+  const startTime = Date.now();
+
+  let asyncJobId = await submitAsyncJob(baseUrl, pdfPath, jobId);
+  logger.info(`[YoloClient] Job ${jobId}: async submitted as ${asyncJobId}`);
+  let retryCount = 0;
+
+  while (Date.now() - startTime < MAX_POLL_TIME_MS) {
+    await sleep(POLL_INTERVAL_MS);
+
+    let pollResponse: Response;
+    try {
+      pollResponse = await fetch(`${baseUrl}/jobs/${asyncJobId}`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch {
+      logger.warn(`[YoloClient] Job ${jobId}: poll request failed, retrying...`);
+      continue;
+    }
+
+    if (!pollResponse.ok) {
+      if (pollResponse.status === 404) {
+        // Container likely restarted and lost in-memory job state — re-submit.
+        if (retryCount < MAX_RETRIES) {
+          retryCount++;
+          logger.warn(
+            `[YoloClient] Job ${jobId}: async job ${asyncJobId} returned 404 ` +
+            `(container restart?), re-submitting (attempt ${retryCount + 1}/${MAX_RETRIES + 1})`,
+          );
+          try {
+            asyncJobId = await submitAsyncJob(baseUrl, pdfPath, jobId);
+            logger.info(`[YoloClient] Job ${jobId}: re-submitted as ${asyncJobId}`);
+            continue;
+          } catch (resubmitErr) {
+            throw new Error(`YOLO_SERVICE_ERROR: re-submit after 404 failed: ${resubmitErr}`);
+          }
+        }
+        throw new Error(
+          `YOLO_SERVICE_ERROR: async job not found after ${retryCount} retries (container keeps restarting?)`,
+        );
+      }
+      logger.warn(`[YoloClient] Job ${jobId}: poll returned ${pollResponse.status}, retrying...`);
+      continue;
+    }
+
+    const job = (await pollResponse.json()) as AsyncJobResponse;
+
+    if (job.status === 'COMPLETED' && job.result) {
+      logger.info(
+        `[YoloClient] Job ${jobId}: completed in ${Date.now() - startTime}ms` +
+        (retryCount > 0 ? ` (after ${retryCount} restart retries)` : ''),
+      );
+      return job.result;
+    }
+
+    if (job.status === 'FAILED') {
+      throw new Error(`YOLO_SERVICE_ERROR: ${job.error ?? 'unknown error'}`);
+    }
+    // Still PROCESSING — keep polling.
+  }
+
+  throw new Error(`YOLO_TIMEOUT: exceeded ${MAX_POLL_TIME_MS / 1000}s for jobId ${jobId}`);
+}

--- a/src/services/zone-extractor/yolo-label-mapper.ts
+++ b/src/services/zone-extractor/yolo-label-mapper.ts
@@ -1,0 +1,18 @@
+import type { CanonicalZoneType } from './types';
+
+// The YOLO zone-detector already emits CanonicalZoneType values — its class
+// names ARE the 11 canonical types (training-export CLASS_MAP). This validates
+// the incoming label and passes it through, defaulting anything unexpected to
+// 'paragraph' with a warning — mirroring mapDoclingLabel / mapPdfxtLabel so a
+// drifted label is surfaced rather than silently trusted.
+const CANONICAL: ReadonlySet<string> = new Set<CanonicalZoneType>([
+  'paragraph', 'section-header', 'table', 'figure', 'caption',
+  'footnote', 'header', 'footer', 'list-item', 'toci', 'formula',
+]);
+
+export function mapYoloLabel(label: string): CanonicalZoneType {
+  const key = label.trim().toLowerCase();
+  if (CANONICAL.has(key)) return key as CanonicalZoneType;
+  console.warn(`[YoloMapper] Unknown YOLO label "${label}" — defaulting to paragraph`);
+  return 'paragraph';
+}

--- a/src/services/zone-extractor/zone-extractor.service.ts
+++ b/src/services/zone-extractor/zone-extractor.service.ts
@@ -1,61 +1,81 @@
 import prisma, { Prisma } from '../../lib/prisma';
 import { detectWithDocling } from './docling-client';
+import { detectWithYolo } from './yolo-client';
 import { mapDoclingLabel } from './zone-type-mapper';
+import { mapYoloLabel } from './yolo-label-mapper';
 import type { DetectedZone } from './types';
 import { logger } from '../../lib/logger';
 
+export type ExtractionMode = 'docling' | 'yolo';
+
 /**
- * Detect zones in a PDF using the Docling sidecar and persist them.
+ * Detect zones in a PDF and persist them.
  *
- * @param pdfPath       - S3 path or local path to the PDF
+ * @param pdfPath        - S3 path or local path to the PDF
  * @param bootstrapJobId - ZoneBootstrapJob.id
- * @param tenantId      - Required: Zone.tenantId is NOT NULL
- * @param fileId        - Optional: Zone.fileId (FK → File, nullable for corpus calibration runs)
+ * @param tenantId       - Required: Zone.tenantId is NOT NULL
+ * @param fileId         - Zone.fileId (FK → File, nullable for corpus calibration runs)
+ * @param mode           - 'docling' (default) or 'yolo' (the fine-tuned zone detector)
+ *
+ * Docling stores its raw label + confidence in the docling* columns. The YOLO
+ * detector's labels are already canonical, so it stores its raw label in the
+ * generic `label` column (there are no dedicated yolo* columns yet — a
+ * yoloConfidence column is a planned follow-up).
  */
 export async function detectZones(
   pdfPath: string,
   bootstrapJobId: string,
   tenantId: string,
   fileId: string,
+  mode: ExtractionMode = 'docling',
 ): Promise<DetectedZone[]> {
   logger.info(
-    `[ZoneExtractor] Starting detection for job ${bootstrapJobId}`,
+    `[ZoneExtractor] Starting ${mode} detection for job ${bootstrapJobId}`,
   );
 
-  const response = await detectWithDocling(pdfPath, bootstrapJobId);
+  const response = mode === 'yolo'
+    ? await detectWithYolo(pdfPath, bootstrapJobId)
+    : await detectWithDocling(pdfPath, bootstrapJobId);
 
-  const detectedZones: DetectedZone[] = response.zones.map((zone) => ({
+  const detected = response.zones.map((zone) => ({
     pageNumber: zone.page,
     bbox: zone.bbox,
-    zoneType: mapDoclingLabel(zone.label),
+    rawLabel: zone.label,
+    zoneType: mode === 'yolo' ? mapYoloLabel(zone.label) : mapDoclingLabel(zone.label),
     confidence: zone.confidence ?? null,
-    source: 'docling' as const,
-    doclingLabel: zone.label,
   }));
 
   await prisma.$transaction([
     prisma.zoneBootstrapJob.update({
       where: { id: bootstrapJobId },
-      data: { extractionMode: 'docling' },
+      data: { extractionMode: mode },
     }),
     prisma.zone.createMany({
-      data: detectedZones.map((z) => ({
+      data: detected.map((z) => ({
         bootstrapJobId,
         tenantId,
         fileId,
         pageNumber: z.pageNumber,
         type: z.zoneType,
         bounds: z.bbox as unknown as Prisma.InputJsonValue,
-        source: z.source,
-        doclingLabel: z.doclingLabel,
-        doclingConfidence: z.confidence,
+        source: mode,
+        ...(mode === 'docling'
+          ? { doclingLabel: z.rawLabel, doclingConfidence: z.confidence }
+          : { label: z.rawLabel }),
       })),
     }),
   ]);
 
   logger.info(
-    `[ZoneExtractor] Completed ${detectedZones.length} zones for job ${bootstrapJobId}`,
+    `[ZoneExtractor] Completed ${detected.length} zones for job ${bootstrapJobId} (${mode})`,
   );
 
-  return detectedZones;
+  return detected.map((z) => ({
+    pageNumber: z.pageNumber,
+    bbox: z.bbox,
+    zoneType: z.zoneType,
+    confidence: z.confidence,
+    source: mode,
+    ...(mode === 'docling' ? { doclingLabel: z.rawLabel } : {}),
+  }));
 }

--- a/tests/unit/services/zone-extractor/yolo-client.test.ts
+++ b/tests/unit/services/zone-extractor/yolo-client.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { detectWithYolo } from '../../../../src/services/zone-extractor/yolo-client';
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  process.env.YOLO_SERVICE_URL = 'http://localhost:9999';
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.useRealTimers();
+});
+
+describe('detectWithYolo', () => {
+  it('throws when YOLO_SERVICE_URL is missing', async () => {
+    delete process.env.YOLO_SERVICE_URL;
+    await expect(detectWithYolo('/t.pdf', 'j1')).rejects.toThrow(
+      'YOLO_SERVICE_URL env var is not set',
+    );
+  });
+
+  it('submit 4xx → YOLO_CLIENT_ERROR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('bad request', { status: 422 }),
+    );
+    await expect(detectWithYolo('/t.pdf', 'j1')).rejects.toThrow('YOLO_CLIENT_ERROR');
+  });
+
+  it('submit 5xx → YOLO_SERVICE_ERROR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('boom', { status: 503 }),
+    );
+    await expect(detectWithYolo('/t.pdf', 'j1')).rejects.toThrow('YOLO_SERVICE_ERROR');
+  });
+
+  it('submit + poll → returns the COMPLETED result', async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ asyncJobId: 'a1', status: 'PROCESSING' }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          asyncJobId: 'a1',
+          status: 'COMPLETED',
+          result: {
+            jobId: 'j1',
+            zones: [{ page: 1, bbox: { x: 0, y: 0, w: 10, h: 10 }, label: 'formula', confidence: 0.9 }],
+            processingTimeMs: 42,
+          },
+        }), { status: 200 }),
+      );
+
+    const p = detectWithYolo('/t.pdf', 'j1');
+    await vi.advanceTimersByTimeAsync(5_000); // clear the poll interval
+    const res = await p;
+
+    expect(res.zones).toHaveLength(1);
+    expect(res.zones[0].label).toBe('formula');
+    expect(res.processingTimeMs).toBe(42);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('poll FAILED → YOLO_SERVICE_ERROR with the service message', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ asyncJobId: 'a1', status: 'PROCESSING' }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ asyncJobId: 'a1', status: 'FAILED', error: 'render failed' }), { status: 200 }),
+      );
+
+    const p = detectWithYolo('/t.pdf', 'j1');
+    p.catch(() => {}); // avoid an unhandled rejection while timers advance
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(p).rejects.toThrow('YOLO_SERVICE_ERROR: render failed');
+  });
+});

--- a/tests/unit/services/zone-extractor/yolo-label-mapper.test.ts
+++ b/tests/unit/services/zone-extractor/yolo-label-mapper.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mapYoloLabel } from '../../../../src/services/zone-extractor/yolo-label-mapper';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('mapYoloLabel', () => {
+  it.each([
+    'paragraph', 'section-header', 'table', 'figure', 'caption',
+    'footnote', 'header', 'footer', 'list-item', 'toci', 'formula',
+  ] as const)('passes canonical label "%s" through unchanged', (label) => {
+    expect(mapYoloLabel(label)).toBe(label);
+  });
+
+  it('is case- and whitespace-tolerant', () => {
+    expect(mapYoloLabel('Formula')).toBe('formula');
+    expect(mapYoloLabel('  LIST-ITEM  ')).toBe('list-item');
+    expect(mapYoloLabel('TOCI')).toBe('toci');
+  });
+
+  it('defaults an unknown label to paragraph and warns once', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(mapYoloLabel('doodad')).toBe('paragraph');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('doodad'));
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
Wires the new YOLOv8 zone-detector service (#427) into the Node pipeline — steps 3a + 3b of B2 in `ZONE_DETECTOR_INTEGRATION_DESIGN.md`.

## What's here
- **`yolo-client.ts`** — `detectWithYolo()`, mirrors `detectWithDocling` (submit-and-poll, 404 re-submit on container restart), endpoint from **`YOLO_SERVICE_URL`**. Shorter poll horizon than docling (GPU inference is minutes, not hours).
- **`yolo-label-mapper.ts`** — `mapYoloLabel()`. The detector already emits canonical labels (its class names *are* the 11 `CanonicalZoneType` values), so this validates + passes through, defaulting unknowns to `paragraph` with a warn like the docling/pdfxt mappers.
- **`detectZones()`** gains `mode: 'docling' | 'yolo'` (default `'docling'`, so the single existing caller is unchanged). The yolo branch persists `source:'yolo'`.
- `DetectedZone.source` widened to include `'yolo'`; `YoloServiceResponse` type added.

## Persistence note
Yolo zones store the raw label in the generic `label` column (the label is already canonical, and there are no `yolo*` columns yet). **Yolo confidence is not persisted yet** — a small `yoloConfidence` column is a planned follow-up (grouped with the deliberate step-4 DB/infra changes), so this PR needs no migration.

## Tests
- `yolo-label-mapper`: 11 canonical pass-throughs, case/whitespace tolerance, unknown→paragraph+warn.
- `yolo-client`: env-missing, 4xx→CLIENT_ERROR, 5xx→SERVICE_ERROR, submit+poll happy path, FAILED path (fake timers for the poll interval).
- `tsc --noEmit` + `eslint --max-warnings 0` + full zone-extractor suite (66 tests) green.

## Deliberately NOT here (step 4 — needs a go)
Register v7 `best.pt` to the SSM weights param, and build/push + deploy the ECS GPU service with Cloud Map DNS → `YOLO_SERVICE_URL`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added YOLO-based zone detection as an alternative to the default extraction method.
  - Added asynchronous detection with status polling and timeout handling.
  - Added support for mapping YOLO labels to recognized zone types.
  - Detection results now include the selected extraction source and relevant confidence information.

- **Bug Fixes**
  - Improved handling of temporary service interruptions and failed detection jobs.

- **Tests**
  - Added coverage for successful processing, failures, timeouts, configuration errors, and label mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->