### PR TITLE
feat(zone-extractor): Seam A — yolo detection mode + on-demand auto-scale

### DIFF
--- a/src/routes/zone-extractor.routes.ts
+++ b/src/routes/zone-extractor.routes.ts
@@ -9,6 +9,9 @@ const detectBodySchema = z.object({
   pdfPath: z.string().min(1),
   bootstrapJobId: z.string().min(1),
   fileId: z.string().min(1),
+  // Detection source: 'docling' (default) or 'yolo' (the fine-tuned zone
+  // detector). The yolo service is scale-to-zero — bring it up before use.
+  mode: z.enum(['docling', 'yolo']).optional(),
 });
 
 // POST /api/v1/zone-extractor/detect
@@ -26,10 +29,10 @@ router.post('/detect', authenticate, async (req: Request, res: Response) => {
       });
     }
 
-    const { pdfPath, bootstrapJobId, fileId } = parsed.data;
+    const { pdfPath, bootstrapJobId, fileId, mode } = parsed.data;
     const tenantId = req.user!.tenantId;
 
-    const zones = await detectZones(pdfPath, bootstrapJobId, tenantId, fileId);
+    const zones = await detectZones(pdfPath, bootstrapJobId, tenantId, fileId, mode);
     return res.json({ success: true, data: zones });
   } catch (err) {
     const message = (err as Error).message ?? '';
@@ -50,6 +53,25 @@ router.post('/detect', authenticate, async (req: Request, res: Response) => {
       return res.status(422).json({
         success: false,
         error: { code: 'DOCLING_CLIENT_ERROR', details: message },
+      });
+    }
+
+    if (message.includes('YOLO_TIMEOUT')) {
+      return res.status(503).json({
+        success: false,
+        error: { code: 'YOLO_TIMEOUT', message },
+      });
+    }
+    if (message.includes('YOLO_SERVICE_ERROR')) {
+      return res.status(503).json({
+        success: false,
+        error: { code: 'YOLO_UNAVAILABLE', message },
+      });
+    }
+    if (message.includes('YOLO_CLIENT_ERROR')) {
+      return res.status(422).json({
+        success: false,
+        error: { code: 'YOLO_CLIENT_ERROR', details: message },
       });
     }
 

--- a/src/services/zone-extractor/yolo-service-scaler.ts
+++ b/src/services/zone-extractor/yolo-service-scaler.ts
@@ -1,0 +1,106 @@
+import {
+  ECSClient,
+  UpdateServiceCommand,
+  DescribeServicesCommand,
+  ListTasksCommand,
+  DescribeTasksCommand,
+} from '@aws-sdk/client-ecs';
+import { logger } from '../../lib/logger';
+
+// On-demand orchestration for the scale-to-zero YOLO zone-detector service.
+//
+//   ensureYoloServiceUp()   scale the service to 1 (if down) and wait until a
+//                           task is RUNNING + HEALTHY. Idempotent — a no-op when
+//                           already warm. Call before a yolo detection.
+//   touchYoloIdleTimer()    (re)arm an idle countdown; when it elapses with no
+//                           further use, scale the service back to 0. Called
+//                           after each yolo detection, so a BATCH of documents
+//                           keeps the GPU warm and it drops once the batch ends.
+//
+// Requires the backend task role to allow ecs:UpdateService, DescribeServices,
+// ListTasks, DescribeTasks on the cluster/service.
+
+const region = process.env.AWS_REGION ?? 'ap-south-1';
+const ecs = new ECSClient({ region });
+
+const CLUSTER = process.env.YOLO_ECS_CLUSTER ?? 'ninja-cluster';
+const SERVICE = process.env.YOLO_ECS_SERVICE ?? 'ninja-zone-detector-service';
+const READY_TIMEOUT_MS = Number(process.env.YOLO_READY_TIMEOUT_MS ?? 6 * 60 * 1000); // GPU cold start
+const POLL_MS = Number(process.env.YOLO_READY_POLL_MS ?? 10_000);
+const IDLE_MS = Number(process.env.YOLO_IDLE_MS ?? 10 * 60 * 1000);
+
+async function hasHealthyTask(): Promise<boolean> {
+  const list = await ecs.send(new ListTasksCommand({
+    cluster: CLUSTER, serviceName: SERVICE, desiredStatus: 'RUNNING',
+  }));
+  const taskArns = list.taskArns ?? [];
+  if (taskArns.length === 0) return false;
+  const desc = await ecs.send(new DescribeTasksCommand({ cluster: CLUSTER, tasks: taskArns }));
+  return (desc.tasks ?? []).some(
+    (t) => t.lastStatus === 'RUNNING' && t.healthStatus === 'HEALTHY',
+  );
+}
+
+async function getDesiredCount(): Promise<number> {
+  const res = await ecs.send(new DescribeServicesCommand({ cluster: CLUSTER, services: [SERVICE] }));
+  return res.services?.[0]?.desiredCount ?? 0;
+}
+
+async function setDesiredCount(count: number): Promise<void> {
+  await ecs.send(new UpdateServiceCommand({ cluster: CLUSTER, service: SERVICE, desiredCount: count }));
+}
+
+/**
+ * Ensure the yolo service is up with a HEALTHY task. Scales to 1 if needed and
+ * polls until ready (or throws YOLO_SCALE_TIMEOUT). No-op when already warm.
+ */
+export async function ensureYoloServiceUp(): Promise<void> {
+  if (await hasHealthyTask()) return;
+
+  if ((await getDesiredCount()) < 1) {
+    logger.info('[YoloScaler] scaling zone-detector service to 1 (on-demand)');
+    await setDesiredCount(1);
+  }
+
+  const start = Date.now();
+  while (Date.now() - start < READY_TIMEOUT_MS) {
+    await new Promise((r) => setTimeout(r, POLL_MS));
+    if (await hasHealthyTask()) {
+      logger.info(`[YoloScaler] zone-detector healthy in ${Date.now() - start}ms`);
+      return;
+    }
+  }
+  throw new Error(
+    `YOLO_SCALE_TIMEOUT: zone-detector not healthy within ${READY_TIMEOUT_MS / 1000}s`,
+  );
+}
+
+export async function scaleYoloServiceDown(): Promise<void> {
+  logger.info('[YoloScaler] scaling zone-detector service to 0 (idle)');
+  await setDesiredCount(0);
+}
+
+// Debounced idle scale-down. Kept module-level; in a multi-instance backend each
+// instance debounces independently and the scale-down is idempotent (a running
+// detection re-arms via ensureYoloServiceUp on the next call).
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function touchYoloIdleTimer(): void {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(() => {
+    idleTimer = null;
+    scaleYoloServiceDown().catch((e) =>
+      logger.warn(`[YoloScaler] idle scale-down failed: ${(e as Error).message}`),
+    );
+  }, IDLE_MS);
+  // Don't keep the event loop alive just for the idle timer.
+  if (typeof idleTimer === 'object' && idleTimer && 'unref' in idleTimer) {
+    (idleTimer as { unref: () => void }).unref();
+  }
+}
+
+/** Exported for tests — cancel any pending idle timer. */
+export function __clearYoloIdleTimerForTest(): void {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = null;
+}

--- a/src/services/zone-extractor/zone-extractor.service.ts
+++ b/src/services/zone-extractor/zone-extractor.service.ts
@@ -1,6 +1,7 @@
 import prisma, { Prisma } from '../../lib/prisma';
 import { detectWithDocling } from './docling-client';
 import { detectWithYolo } from './yolo-client';
+import { ensureYoloServiceUp, touchYoloIdleTimer } from './yolo-service-scaler';
 import { mapDoclingLabel } from './zone-type-mapper';
 import { mapYoloLabel } from './yolo-label-mapper';
 import type { DetectedZone } from './types';
@@ -32,6 +33,11 @@ export async function detectZones(
   logger.info(
     `[ZoneExtractor] Starting ${mode} detection for job ${bootstrapJobId}`,
   );
+
+  // The yolo service is scale-to-zero — bring it up on demand before calling it.
+  if (mode === 'yolo') {
+    await ensureYoloServiceUp();
+  }
 
   const response = mode === 'yolo'
     ? await detectWithYolo(pdfPath, bootstrapJobId)
@@ -69,6 +75,12 @@ export async function detectZones(
   logger.info(
     `[ZoneExtractor] Completed ${detected.length} zones for job ${bootstrapJobId} (${mode})`,
   );
+
+  // Re-arm the idle countdown so a batch of documents keeps the GPU warm, then
+  // the service scales back to 0 once detection stops.
+  if (mode === 'yolo') {
+    touchYoloIdleTimer();
+  }
 
   return detected.map((z) => ({
     pageNumber: z.pageNumber,

--- a/tests/unit/services/zone-extractor/yolo-service-scaler.test.ts
+++ b/tests/unit/services/zone-extractor/yolo-service-scaler.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// vi.hoisted so sendMock exists before the mocked module loads (the scaler
+// constructs its ECSClient at import time, before a plain `const` would run).
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }));
+
+vi.mock('@aws-sdk/client-ecs', () => {
+  // Everything here is `new`ed by the scaler, so the mocks must be
+  // constructor-compatible (regular functions, not arrows).
+  const MockECSClient = vi.fn();
+  MockECSClient.prototype.send = (...args: unknown[]) => sendMock(...args);
+  const cmd = (type: string) =>
+    vi.fn(function (this: Record<string, unknown>, input: unknown) {
+      this.__type = type;
+      this.input = input;
+    });
+  return {
+    ECSClient: MockECSClient,
+    UpdateServiceCommand: cmd('UpdateService'),
+    DescribeServicesCommand: cmd('DescribeServices'),
+    ListTasksCommand: cmd('ListTasks'),
+    DescribeTasksCommand: cmd('DescribeTasks'),
+  };
+});
+
+vi.mock('../../../../src/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  ensureYoloServiceUp,
+  scaleYoloServiceDown,
+  touchYoloIdleTimer,
+  __clearYoloIdleTimerForTest,
+} from '../../../../src/services/zone-extractor/yolo-service-scaler';
+
+const IDLE_MS = 10 * 60 * 1000;
+const POLL_MS = 10_000;
+
+const updateCalls = () => sendMock.mock.calls.filter((c) => c[0].__type === 'UpdateService');
+
+beforeEach(() => {
+  sendMock.mockReset();
+});
+afterEach(() => {
+  __clearYoloIdleTimerForTest();
+  vi.useRealTimers();
+});
+
+describe('ensureYoloServiceUp', () => {
+  it('is a no-op when a HEALTHY task already exists', async () => {
+    sendMock.mockImplementation((cmd) => {
+      if (cmd.__type === 'ListTasks') return Promise.resolve({ taskArns: ['t1'] });
+      if (cmd.__type === 'DescribeTasks') {
+        return Promise.resolve({ tasks: [{ lastStatus: 'RUNNING', healthStatus: 'HEALTHY' }] });
+      }
+      return Promise.resolve({});
+    });
+
+    await ensureYoloServiceUp();
+    expect(updateCalls()).toHaveLength(0); // never scaled
+  });
+
+  it('scales to 1 when down, then resolves once a task is HEALTHY', async () => {
+    vi.useFakeTimers();
+    let listCall = 0;
+    sendMock.mockImplementation((cmd) => {
+      if (cmd.__type === 'ListTasks') {
+        listCall++;
+        return Promise.resolve({ taskArns: listCall === 1 ? [] : ['t1'] });
+      }
+      if (cmd.__type === 'DescribeTasks') {
+        return Promise.resolve({ tasks: [{ lastStatus: 'RUNNING', healthStatus: 'HEALTHY' }] });
+      }
+      if (cmd.__type === 'DescribeServices') {
+        return Promise.resolve({ services: [{ desiredCount: 0 }] });
+      }
+      return Promise.resolve({});
+    });
+
+    const p = ensureYoloServiceUp();
+    await vi.advanceTimersByTimeAsync(POLL_MS); // let one poll cycle run
+    await p;
+
+    const up = updateCalls();
+    expect(up).toHaveLength(1);
+    expect(up[0][0].input.desiredCount).toBe(1);
+  });
+});
+
+describe('scaleYoloServiceDown', () => {
+  it('sets desiredCount to 0', async () => {
+    sendMock.mockResolvedValue({});
+    await scaleYoloServiceDown();
+    const down = updateCalls();
+    expect(down).toHaveLength(1);
+    expect(down[0][0].input.desiredCount).toBe(0);
+  });
+});
+
+describe('touchYoloIdleTimer', () => {
+  it('scales to 0 after the idle window elapses', async () => {
+    vi.useFakeTimers();
+    sendMock.mockResolvedValue({});
+    touchYoloIdleTimer();
+    await vi.advanceTimersByTimeAsync(IDLE_MS + 100);
+    const down = updateCalls();
+    expect(down).toHaveLength(1);
+    expect(down[0][0].input.desiredCount).toBe(0);
+  });
+
+  it('debounces — a second touch resets the countdown (only one scale-down)', async () => {
+    vi.useFakeTimers();
+    sendMock.mockResolvedValue({});
+    touchYoloIdleTimer();
+    await vi.advanceTimersByTimeAsync(IDLE_MS / 2);
+    touchYoloIdleTimer(); // reset
+    await vi.advanceTimersByTimeAsync(IDLE_MS / 2); // half-way from the reset — not yet
+    expect(updateCalls()).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(IDLE_MS / 2 + 100); // now past the reset window
+    expect(updateCalls()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Completes **Seam A** — the trained detector is now callable through the pipeline, and the scale-to-zero GPU service comes up automatically around each use.

## What's here
- **Route:** `POST /zone-extractor/detect` takes optional `mode: 'docling' | 'yolo'` (default `docling`), with YOLO errors mapped to status codes.
- **`yolo-service-scaler.ts`** (auto-scale orchestration):
  - `ensureYoloServiceUp()` — scales the ECS service to 1 (if down) and polls until a task is `RUNNING`+`HEALTHY`; idempotent when already warm.
  - `touchYoloIdleTimer()` — debounced idle countdown that scales back to 0, so a **batch** of documents keeps the GPU warm and it drops once idle (default 10 min).
  - `scaleYoloServiceDown()`.
- **`detectZones(mode:'yolo')`** calls `ensureYoloServiceUp()` before detecting and `touchYoloIdleTimer()` after — callers never manage the GPU.

## Validated already (this deploy)
The on-demand cycle was exercised end-to-end standing up the service for the Olszewski/Acharya detections: up (~4 min cold start) → detect → scale to 0 → GPU terminated. This PR automates that cycle.

## Tests
Scaler: healthy no-op, scale-up + poll (fake timers), scale-down, idle debounce. `tsc` + `eslint` + full zone-extractor suite (**71**) green.

## Prerequisites (infra — not code)
1. **IAM:** `ninja-backend-task-role` needs `ecs:UpdateService`, `DescribeServices`, `ListTasks`, `DescribeTasks` on the cluster. I couldn't verify (`iam:ListRolePolicies` denied for my user); the scaler surfaces `AccessDenied` clearly if it's missing.
2. **Env:** set `YOLO_SERVICE_URL=http://ninja-zone-detector.ninja.local:8083` on the backend task def (mirrors `DOCLING_SERVICE_URL`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting YOLO or Docling detection modes.
  * YOLO processing now automatically starts the detection service when needed and scales it down after inactivity.
  * Added health checks and readiness polling for reliable YOLO processing.

* **Bug Fixes**
  * Improved error responses for YOLO timeouts, service failures, and client errors.

* **Tests**
  * Added coverage for service startup, shutdown, readiness checks, and idle-time debouncing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->