### PR TITLE
fix(zone-extractor): raise yolo scaler ready-timeout to 10min

### DIFF
--- a/src/services/zone-extractor/yolo-service-scaler.ts
+++ b/src/services/zone-extractor/yolo-service-scaler.ts
@@ -25,7 +25,10 @@ const ecs = new ECSClient({ region });
 
 const CLUSTER = process.env.YOLO_ECS_CLUSTER ?? 'ninja-cluster';
 const SERVICE = process.env.YOLO_ECS_SERVICE ?? 'ninja-zone-detector-service';
-const READY_TIMEOUT_MS = Number(process.env.YOLO_READY_TIMEOUT_MS ?? 6 * 60 * 1000); // GPU cold start
+// Cold start = GPU instance provisioning + image pull + model load; observed at
+// ~6-7 min end-to-end, so allow generous headroom (a too-short timeout throws
+// YOLO_SCALE_TIMEOUT while the service is still coming up).
+const READY_TIMEOUT_MS = Number(process.env.YOLO_READY_TIMEOUT_MS ?? 10 * 60 * 1000);
 const POLL_MS = Number(process.env.YOLO_READY_POLL_MS ?? 10_000);
 const IDLE_MS = Number(process.env.YOLO_IDLE_MS ?? 10 * 60 * 1000);
 


### PR DESCRIPTION
The end-to-end `mode:'yolo'` test (run as the backend role, validating the new IAM policy + `YOLO_SERVICE_URL`) passed the full chain, but revealed the GPU **cold start takes ~6-7 min** (instance provision + image pull + model load) — just over the scaler's 6-min `READY_TIMEOUT_MS`. So `ensureYoloServiceUp` would throw `YOLO_SCALE_TIMEOUT` on a cold start while the service was actually coming up (the detect immediately after the timeout succeeded — 6,070 zones on Boyd-Hamill).

Bumps the default to **10 min** (still `YOLO_READY_TIMEOUT_MS`-overridable). One-line change; scaler tests still green (5).