### PR TITLE
feat(seam-c): reading-order synthesis + role→tag map (Phase 1)

### DIFF
--- a/src/services/zone-extractor/seam-c/canonical-to-tag.ts
+++ b/src/services/zone-extractor/seam-c/canonical-to-tag.ts
@@ -1,0 +1,111 @@
+import type { BBox, CanonicalZoneType } from '../types';
+
+// Seam C — §3.2 Role → PDF tag mapping (+ heading-level inference).
+//
+// There is no central role→tag map in the codebase today — the write-path emits
+// literal tag strings per call site. This is the one place the 11 detector classes
+// become PDF structure tags.
+//
+// Two classes need more than a static map:
+//   · section-header → the detector has a SINGLE header class; it does not tell
+//     you H1 vs H3. `inferHeadingLevels` derives the level (§3.2).
+//   · table / list-item → the map yields the container role; the child grid
+//     (TR/TH/TD) and list wrapping (L>LI>LBody) are built in hierarchy assembly
+//     (Phase 2), flagged here via `tableCell` / `listItem`.
+//
+// header / footer map to Artifact — pagination furniture, NOT a StructElem, so
+// they never enter the /K reading flow even though they carry a readingOrder.
+
+export type PdfTag =
+  | 'P'
+  | 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6'
+  | 'Table'
+  | 'Figure'
+  | 'Caption'
+  | 'Note'
+  | 'L' | 'LI'
+  | 'TOC' | 'TOCI'
+  | 'Formula'
+  | 'Artifact';
+
+export interface TagMapping {
+  tag: PdfTag;
+  /** section-header — the concrete Hn is resolved by inferHeadingLevels. */
+  isHeading?: boolean;
+  /** header/footer — a pagination Artifact, excluded from the /K structure flow. */
+  isArtifact?: boolean;
+  /** list-item — wrapped under an L (with LBody) during hierarchy assembly. */
+  listItem?: boolean;
+  /** table — expands to TR/TH/TD during hierarchy assembly. */
+  tableCell?: boolean;
+}
+
+const ROLE_MAP: Record<CanonicalZoneType, TagMapping> = {
+  paragraph: { tag: 'P' },
+  // Placeholder level; the real Hn comes from inferHeadingLevels.
+  'section-header': { tag: 'H1', isHeading: true },
+  table: { tag: 'Table', tableCell: true },
+  figure: { tag: 'Figure' },
+  caption: { tag: 'Caption' },
+  footnote: { tag: 'Note' },
+  header: { tag: 'Artifact', isArtifact: true },
+  footer: { tag: 'Artifact', isArtifact: true },
+  'list-item': { tag: 'LI', listItem: true },
+  toci: { tag: 'TOCI' },
+  formula: { tag: 'Formula' },
+};
+
+/** Map a canonical detector class to its PDF structure tag + assembly flags. */
+export function canonicalToTag(zoneType: CanonicalZoneType): TagMapping {
+  return ROLE_MAP[zoneType];
+}
+
+/** Compose the concrete heading tag (H1..H6) from an inferred 1..6 level. */
+export function headingTag(level: number): PdfTag {
+  const clamped = Math.min(6, Math.max(1, Math.round(level)));
+  return (`H${clamped}`) as PdfTag;
+}
+
+export interface HeadingLevelConfig {
+  /**
+   * Relative height drop (fraction of a band's tallest height) that opens the
+   * next heading level. 0.15 ⇒ a header ≥15% shorter than the band top is H(n+1).
+   */
+  tol: number;
+  maxLevel: number;
+}
+
+export const DEFAULT_HEADING_CONFIG: HeadingLevelConfig = { tol: 0.15, maxLevel: 6 };
+
+/**
+ * Infer a heading level (1..6) per section-header zone.
+ *
+ * The detector emits no font size, so bbox HEIGHT is the size proxy: taller
+ * header box ⇒ larger type ⇒ higher level. Distinct heights are clustered into
+ * bands (tallest = H1) with a relative tolerance, capped at `maxLevel`.
+ *
+ * Caveat: a multi-line header inflates height, so this is a heuristic — good
+ * enough for the Phase-0 spike; Phase 1 can refine with real pdfjs font metrics.
+ *
+ * @returns levels aligned to the input order (`levels[i]` for `headers[i]`).
+ */
+export function inferHeadingLevels(
+  headers: Array<{ bbox: BBox }>,
+  config: HeadingLevelConfig = DEFAULT_HEADING_CONFIG,
+): number[] {
+  if (headers.length === 0) return [];
+
+  const uniqueDesc = [...new Set(headers.map((h) => h.bbox.h))].sort((a, b) => b - a);
+  const heightToLevel = new Map<number, number>();
+  let level = 1;
+  let bandTop = uniqueDesc[0];
+  for (const h of uniqueDesc) {
+    if (bandTop - h > config.tol * bandTop) {
+      level = Math.min(level + 1, config.maxLevel);
+      bandTop = h;
+    }
+    heightToLevel.set(h, level);
+  }
+
+  return headers.map((h) => heightToLevel.get(h.bbox.h) as number);
+}

--- a/src/services/zone-extractor/seam-c/reading-order.ts
+++ b/src/services/zone-extractor/seam-c/reading-order.ts
@@ -1,0 +1,152 @@
+import type { BBox, CanonicalZoneType } from '../types';
+
+// Seam C — §3.1 Reading-order synthesis (the highest-risk core).
+//
+// A layout detector emits UNORDERED rectangles. A /StructTreeRoot needs an
+// ordered /K sequence. The YOLO→Zone path leaves `readingOrder` null, so before
+// any tree can be built we must synthesize a column-aware, top-to-bottom order
+// over `bounds`.
+//
+// Coordinate convention (matches DetectedZone.bbox): PDF points, TOP-LEFT origin,
+// {x, y, w, h}. So smaller `y` is higher on the page and comes first.
+//
+// Algorithm (band + column, an XY-cut approximation robust to the common cases):
+//   1. Group zones by page; pages ascend.
+//   2. Within a page, walk zones top-to-bottom. A "full-width" zone (title, wide
+//      table/figure spanning the text block) acts as a BAND SEPARATOR: it flushes
+//      the accumulated column zones above it, emits in place, and starts a new band.
+//   3. Each band's column zones are clustered by horizontal (x-interval) overlap,
+//      columns ordered left-to-right, and each column ordered top-to-bottom.
+//   4. readingOrder is assigned globally, page-major.
+//
+// This is a Phase-1 prototype: correct on 1-col, n-col, and full-width-spanner
+// layouts (the shapes the Phase-0 spike checks). It does NOT yet handle wrapped
+// text flow around floats or rotated pages — Phase 2 refines against real MCIDs.
+
+export interface OrderableZone {
+  pageNumber: number;
+  /** PDF points, top-left origin. */
+  bbox: BBox;
+  zoneType: CanonicalZoneType;
+}
+
+export interface OrderedZone<T extends OrderableZone> {
+  zone: T;
+  /** Global 0-based reading index, page-major. */
+  readingOrder: number;
+}
+
+export interface OrderConfig {
+  /** width ≥ fullWidthFrac × pageWidth ⇒ full-width band separator. */
+  fullWidthFrac: number;
+  /** min x-interval overlap (points) to group two zones into one column. */
+  columnOverlapTol: number;
+}
+
+export const DEFAULT_ORDER_CONFIG: OrderConfig = {
+  fullWidthFrac: 0.65,
+  columnOverlapTol: 12,
+};
+
+const byTopThenLeft = (a: OrderableZone, b: OrderableZone): number =>
+  a.bbox.y - b.bbox.y || a.bbox.x - b.bbox.x;
+
+/**
+ * Assign a column-aware, top-to-bottom reading order across all pages.
+ * Returns the zones paired with a global page-major readingOrder index.
+ */
+export function synthesizeReadingOrder<T extends OrderableZone>(
+  zones: T[],
+  config: OrderConfig = DEFAULT_ORDER_CONFIG,
+): OrderedZone<T>[] {
+  const byPage = new Map<number, T[]>();
+  for (const z of zones) {
+    const list = byPage.get(z.pageNumber);
+    if (list) list.push(z);
+    else byPage.set(z.pageNumber, [z]);
+  }
+
+  const pages = [...byPage.keys()].sort((a, b) => a - b);
+  const result: OrderedZone<T>[] = [];
+  let order = 0;
+  for (const page of pages) {
+    for (const zone of orderPage(byPage.get(page) as T[], config)) {
+      result.push({ zone, readingOrder: order++ });
+    }
+  }
+  return result;
+}
+
+function orderPage<T extends OrderableZone>(zones: T[], config: OrderConfig): T[] {
+  if (zones.length <= 1) return zones;
+
+  const pageLeft = Math.min(...zones.map((z) => z.bbox.x));
+  const pageRight = Math.max(...zones.map((z) => z.bbox.x + z.bbox.w));
+  const pageWidth = pageRight - pageLeft || 1;
+  const isFullWidth = (z: T): boolean => z.bbox.w >= config.fullWidthFrac * pageWidth;
+
+  const sorted = [...zones].sort(byTopThenLeft);
+  const out: T[] = [];
+  let band: T[] = [];
+  const flush = (): void => {
+    if (band.length) {
+      out.push(...orderColumns(band, config));
+      band = [];
+    }
+  };
+
+  for (const z of sorted) {
+    if (isFullWidth(z)) {
+      flush();
+      out.push(z);
+    } else {
+      band.push(z);
+    }
+  }
+  flush();
+  return out;
+}
+
+interface Column<T> {
+  minX: number;
+  maxX: number;
+  zones: T[];
+}
+
+function orderColumns<T extends OrderableZone>(zones: T[], config: OrderConfig): T[] {
+  if (zones.length <= 1) return zones;
+  const columns = clusterColumns(zones, config.columnOverlapTol);
+  columns.sort((a, b) => a.minX - b.minX);
+  return columns.flatMap((c) => c.zones.sort(byTopThenLeft));
+}
+
+/**
+ * Greedy x-interval clustering: each zone joins the existing column it overlaps
+ * most (beyond `tol`), else opens a new column. Vertically-stacked zones share an
+ * x-range and cluster together; side-by-side columns don't overlap and separate.
+ */
+function clusterColumns<T extends OrderableZone>(zones: T[], tol: number): Column<T>[] {
+  const sorted = [...zones].sort((a, b) => a.bbox.x - b.bbox.x);
+  const columns: Column<T>[] = [];
+  for (const z of sorted) {
+    const zL = z.bbox.x;
+    const zR = z.bbox.x + z.bbox.w;
+    let best: Column<T> | null = null;
+    let bestOverlap = tol;
+    for (const c of columns) {
+      const overlap = Math.min(zR, c.maxX) - Math.max(zL, c.minX);
+      if (overlap > bestOverlap) {
+        bestOverlap = overlap;
+        best = c;
+      }
+    }
+    if (best) {
+      best.minX = Math.min(best.minX, zL);
+      best.maxX = Math.max(best.maxX, zR);
+      best.zones.push(z);
+    } else {
+      columns.push({ minX: zL, maxX: zR, zones: [z] });
+    }
+  }
+  return columns;
+}

--- a/tests/unit/services/zone-extractor/seam-c/canonical-to-tag.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/canonical-to-tag.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalToTag,
+  headingTag,
+  inferHeadingLevels,
+} from '../../../../../src/services/zone-extractor/seam-c/canonical-to-tag';
+import type { CanonicalZoneType } from '../../../../../src/services/zone-extractor/types';
+
+describe('canonicalToTag', () => {
+  it('maps the plain block roles to their PDF tags', () => {
+    expect(canonicalToTag('paragraph').tag).toBe('P');
+    expect(canonicalToTag('figure').tag).toBe('Figure');
+    expect(canonicalToTag('caption').tag).toBe('Caption');
+    expect(canonicalToTag('footnote').tag).toBe('Note');
+    expect(canonicalToTag('toci').tag).toBe('TOCI');
+    expect(canonicalToTag('formula').tag).toBe('Formula');
+  });
+
+  it('flags section-header as a heading (level resolved separately)', () => {
+    const m = canonicalToTag('section-header');
+    expect(m.isHeading).toBe(true);
+    expect(m.tag).toMatch(/^H[1-6]$/);
+  });
+
+  it('maps header and footer to a pagination Artifact, out of the /K flow', () => {
+    for (const t of ['header', 'footer'] as CanonicalZoneType[]) {
+      const m = canonicalToTag(t);
+      expect(m.tag).toBe('Artifact');
+      expect(m.isArtifact).toBe(true);
+    }
+  });
+
+  it('flags list-item and table for hierarchy assembly', () => {
+    expect(canonicalToTag('list-item')).toMatchObject({ tag: 'LI', listItem: true });
+    expect(canonicalToTag('table')).toMatchObject({ tag: 'Table', tableCell: true });
+  });
+
+  it('covers every canonical class (no undefined mapping)', () => {
+    const all: CanonicalZoneType[] = [
+      'paragraph', 'section-header', 'table', 'figure', 'caption',
+      'footnote', 'header', 'footer', 'list-item', 'toci', 'formula',
+    ];
+    for (const t of all) expect(canonicalToTag(t)?.tag).toBeTruthy();
+  });
+});
+
+describe('headingTag', () => {
+  it('composes H1..H6 from a level', () => {
+    expect(headingTag(1)).toBe('H1');
+    expect(headingTag(6)).toBe('H6');
+  });
+  it('clamps out-of-range levels into 1..6', () => {
+    expect(headingTag(0)).toBe('H1');
+    expect(headingTag(9)).toBe('H6');
+    expect(headingTag(2.4)).toBe('H2');
+  });
+});
+
+describe('inferHeadingLevels', () => {
+  it('returns empty for no headers', () => {
+    expect(inferHeadingLevels([])).toEqual([]);
+  });
+
+  it('assigns H1 to a lone header', () => {
+    expect(inferHeadingLevels([{ bbox: { x: 0, y: 0, w: 100, h: 24 } }])).toEqual([1]);
+  });
+
+  it('ranks taller headers as higher levels (bigger = H1)', () => {
+    const levels = inferHeadingLevels([
+      { bbox: { x: 0, y: 0, w: 100, h: 30 } },
+      { bbox: { x: 0, y: 0, w: 100, h: 20 } },
+      { bbox: { x: 0, y: 0, w: 100, h: 12 } },
+    ]);
+    expect(levels).toEqual([1, 2, 3]);
+  });
+
+  it('preserves input order when heights are scrambled', () => {
+    const levels = inferHeadingLevels([
+      { bbox: { x: 0, y: 0, w: 100, h: 12 } }, // smallest
+      { bbox: { x: 0, y: 0, w: 100, h: 30 } }, // largest
+      { bbox: { x: 0, y: 0, w: 100, h: 20 } }, // middle
+    ]);
+    expect(levels).toEqual([3, 1, 2]);
+  });
+
+  it('groups near-equal heights into one level', () => {
+    expect(
+      inferHeadingLevels([
+        { bbox: { x: 0, y: 0, w: 100, h: 24 } },
+        { bbox: { x: 0, y: 0, w: 100, h: 24 } },
+      ]),
+    ).toEqual([1, 1]);
+  });
+
+  it('caps deep hierarchies at H6', () => {
+    const heights = [60, 50, 40, 30, 20, 15, 10, 5];
+    const levels = inferHeadingLevels(heights.map((h) => ({ bbox: { x: 0, y: 0, w: 100, h } })));
+    expect(levels).toEqual([1, 2, 3, 4, 5, 6, 6, 6]);
+  });
+});

--- a/tests/unit/services/zone-extractor/seam-c/reading-order.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/reading-order.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  synthesizeReadingOrder,
+  type OrderableZone,
+} from '../../../../../src/services/zone-extractor/seam-c/reading-order';
+import type { CanonicalZoneType } from '../../../../../src/services/zone-extractor/types';
+
+// bbox is PDF points, top-left origin: {x, y, w, h}. Smaller y = higher on page.
+const z = (
+  pageNumber: number,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  zoneType: CanonicalZoneType = 'paragraph',
+): OrderableZone => ({ pageNumber, bbox: { x, y, w, h }, zoneType });
+
+// Convenience: run the synthesizer and return the zones in reading order.
+const order = (zones: OrderableZone[]): OrderableZone[] =>
+  synthesizeReadingOrder(zones).map((o) => o.zone);
+
+describe('synthesizeReadingOrder', () => {
+  it('returns empty for no zones', () => {
+    expect(synthesizeReadingOrder([])).toEqual([]);
+  });
+
+  it('orders a single-column page top-to-bottom regardless of input order', () => {
+    const a = z(1, 50, 300, 400, 40); // bottom
+    const b = z(1, 50, 100, 400, 40); // top
+    const c = z(1, 50, 200, 400, 40); // middle
+    expect(order([a, b, c])).toEqual([b, c, a]);
+  });
+
+  it('orders a two-column page left-column-first, each column top-to-bottom', () => {
+    const l1 = z(1, 50, 100, 200, 40);
+    const l2 = z(1, 50, 200, 200, 40);
+    const r1 = z(1, 320, 100, 200, 40);
+    const r2 = z(1, 320, 200, 200, 40);
+    // Feed in a scrambled order to prove ordering isn't input-dependent.
+    expect(order([r2, l1, r1, l2])).toEqual([l1, l2, r1, r2]);
+  });
+
+  it('emits a full-width header before the columns beneath it', () => {
+    const header = z(1, 50, 40, 470, 30, 'section-header'); // spans both columns
+    const l1 = z(1, 50, 100, 200, 40);
+    const r1 = z(1, 320, 100, 200, 40);
+    expect(order([l1, r1, header])).toEqual([header, l1, r1]);
+  });
+
+  it('emits a full-width footer after the columns above it', () => {
+    const l1 = z(1, 50, 100, 200, 40);
+    const r1 = z(1, 320, 100, 200, 40);
+    const footer = z(1, 50, 700, 470, 30, 'footer');
+    expect(order([footer, r1, l1])).toEqual([l1, r1, footer]);
+  });
+
+  it('splits bands at a full-width divider (col → wide table → col)', () => {
+    const l1 = z(1, 50, 100, 200, 40);
+    const r1 = z(1, 320, 100, 200, 40);
+    const table = z(1, 50, 250, 470, 80, 'table'); // full-width spanner
+    const l2 = z(1, 50, 380, 200, 40);
+    const r2 = z(1, 320, 380, 200, 40);
+    expect(order([r2, l1, table, r1, l2])).toEqual([l1, r1, table, l2, r2]);
+  });
+
+  it('orders page-major across pages, ascending page number', () => {
+    const p2 = z(2, 50, 100, 400, 40);
+    const p1 = z(1, 50, 100, 400, 40);
+    const result = synthesizeReadingOrder([p2, p1]);
+    expect(result.map((o) => o.zone)).toEqual([p1, p2]);
+    expect(result.map((o) => o.readingOrder)).toEqual([0, 1]);
+  });
+
+  it('assigns a contiguous global readingOrder index', () => {
+    const zones = [
+      z(1, 50, 200, 400, 40),
+      z(1, 50, 100, 400, 40),
+      z(2, 50, 100, 400, 40),
+    ];
+    const result = synthesizeReadingOrder(zones);
+    expect(result.map((o) => o.readingOrder)).toEqual([0, 1, 2]);
+  });
+});


### PR DESCRIPTION
## Seam C — Phase 1 (order + map)

Per `SEAM_C_REMEDIATION_INTEGRATION_DESIGN.md` §9, Phase 1 is the **pure logic** that the Phase-0 tag-quality spike runs against real detected zones — no PDF writing yet. It proves the two build cores are correct in isolation:

### §3.1 Reading-order synthesis *(the highest-risk core)*
`synthesizeReadingOrder()` — column-aware, top-to-bottom order over detector bboxes (PDF points, top-left origin). Band + column XY-cut:
- a **full-width** zone (title / wide table / figure) acts as a **band separator**;
- each band's zones cluster into **columns** by x-interval overlap, columns run **left-to-right**, each column **top-to-bottom**.

Fills the exact gap §3.1 names: the YOLO→Zone path leaves `readingOrder` null.

### §3.2 Role → PDF tag map (+ heading levels)
- `canonicalToTag()` — the first central role→tag map for the 11 classes (`header`/`footer`→`Artifact` out of the /K flow; `list-item`/`table` flagged for Phase-2 hierarchy assembly).
- `inferHeadingLevels()` — bbox-height proxy → `H1..H6` (the detector has a single `section-header` class and emits no font size). Caveat documented; refinable with pdfjs font metrics.

### Tests
21 unit tests on zone fixtures: 1-col, n-col, full-width spanners, band splits, page-major indexing, heading-level clustering + H6 cap. `npx vitest run` green; tsc + eslint clean.

### Not in this PR (later phases)
Hierarchy assembly (L>LI, Table>TR>TD), `buildStructTreeFromZones` + MCID binding + coord reconciliation (Phase 2), worker seam (Phase 3). This PR is intentionally logic-only so the Phase-0 spike can exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added intelligent reading-order sequencing across pages, columns, bands, headers, footers, and tables.
  - Added PDF structure tagging for content such as paragraphs, figures, captions, footnotes, lists, tables, and artifacts.
  - Added automatic heading-level detection with support for levels H1–H6.

- **Tests**
  - Added coverage for tagging, heading detection, and multi-column reading-order scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->