### PR TITLE
feat(seam-c): detector zones → /StructTreeRoot (Phase 2a/2b/2c)

### DIFF
--- a/src/services/zone-extractor/seam-c/content-stream.ts
+++ b/src/services/zone-extractor/seam-c/content-stream.ts
@@ -1,0 +1,213 @@
+// Seam C — Phase 2c core: content-stream MCID tagging.
+//
+// Nothing in the codebase writes marked content; this is the inverse of the
+// read-side operator tracker in `tagged-pdf-extractor.ts`. Given a page's decoded
+// content stream and a set of vertical zone BANDS (device space, bottom-left
+// origin), it wraps each text object in `/<Tag> <</MCID n>> BDC … EMC`, assigns a
+// unique MCID per contiguous same-zone run, and reports which MCID belongs to
+// which zone so the caller can point a StructElem's /K at it.
+//
+// Scope (Phase-2 spike — simple, single-column PDFs):
+//   · Assignment is by the text object's baseline Y falling inside a zone band.
+//     Single-column zones stack vertically, so Y alone is robust; X is ignored.
+//   · CTM and text matrices are assumed axis-aligned (no rotation/skew) — the
+//     common case. Rotated pages are out of scope for the spike.
+//   · Only text objects (BT…ET) are tagged. Non-text painting ops are left as-is
+//     (fine for text-first documents); a later pass marks images/paths.
+
+export interface ZoneBand {
+  zoneIndex: number;
+  /** device-space (bottom-left origin) vertical extent; yTop > yBottom. */
+  yTop: number;
+  yBottom: number;
+  /** PDF tag for the BDC (e.g. 'P', 'H1'); artifacts use 'Artifact' with no MCID. */
+  tag: string;
+  isArtifact?: boolean;
+}
+
+export interface McidAssignment {
+  mcid: number;
+  zoneIndex: number;
+}
+
+export interface TagResult {
+  content: string;
+  assignments: McidAssignment[];
+}
+
+interface Token {
+  /** number | string | hex | name | op | arr | dict | comment */
+  t: 'n' | 's' | 'h' | 'name' | 'op' | '[' | ']' | '<<' | '>>' | 'c';
+  v: string;
+  start: number;
+  end: number;
+}
+
+const WS = new Set([' ', '\t', '\r', '\n', '\f', '\0']);
+const DELIM = new Set(['(', ')', '<', '>', '[', ']', '{', '}', '/', '%']);
+const isWs = (c: string): boolean => WS.has(c);
+const isDelimOrWs = (c: string): boolean => c === undefined || WS.has(c) || DELIM.has(c);
+
+/** Tokenize a content stream, preserving each token's source offsets. */
+export function tokenize(s: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  const n = s.length;
+  while (i < n) {
+    const c = s[i];
+    if (isWs(c)) { i++; continue; }
+    const start = i;
+    if (c === '%') {
+      while (i < n && s[i] !== '\n' && s[i] !== '\r') i++;
+      tokens.push({ t: 'c', v: s.slice(start, i), start, end: i });
+    } else if (c === '(') {
+      let depth = 0;
+      do {
+        const ch = s[i];
+        if (ch === '\\') { i += 2; continue; }
+        if (ch === '(') depth++;
+        else if (ch === ')') depth--;
+        i++;
+      } while (i < n && depth > 0);
+      tokens.push({ t: 's', v: s.slice(start, i), start, end: i });
+    } else if (c === '<' && s[i + 1] === '<') {
+      i += 2; tokens.push({ t: '<<', v: '<<', start, end: i });
+    } else if (c === '>' && s[i + 1] === '>') {
+      i += 2; tokens.push({ t: '>>', v: '>>', start, end: i });
+    } else if (c === '<') {
+      i++; while (i < n && s[i] !== '>') i++; i++;
+      tokens.push({ t: 'h', v: s.slice(start, i), start, end: i });
+    } else if (c === '[') {
+      i++; tokens.push({ t: '[', v: '[', start, end: i });
+    } else if (c === ']') {
+      i++; tokens.push({ t: ']', v: ']', start, end: i });
+    } else if (c === '/') {
+      i++; while (i < n && !isDelimOrWs(s[i])) i++;
+      tokens.push({ t: 'name', v: s.slice(start, i), start, end: i });
+    } else if (c === '+' || c === '-' || c === '.' || (c >= '0' && c <= '9')) {
+      i++; while (i < n && !isDelimOrWs(s[i])) i++;
+      const v = s.slice(start, i);
+      tokens.push({ t: /^[+-]?(\d+\.?\d*|\.\d+)$/.test(v) ? 'n' : 'op', v, start, end: i });
+    } else {
+      i++; while (i < n && !isDelimOrWs(s[i])) i++;
+      tokens.push({ t: 'op', v: s.slice(start, i), start, end: i });
+    }
+  }
+  return tokens;
+}
+
+const num = (t: Token | undefined): number => (t && t.t === 'n' ? parseFloat(t.v) : 0);
+
+/**
+ * Tag the text objects of a content stream with MCID marked content.
+ * @param content decoded content stream text
+ * @param bands   device-space vertical zone bands (bottom-left origin)
+ * @param startMcid first MCID to allocate (unique per page)
+ */
+export function tagContentStream(content: string, bands: ZoneBand[], startMcid = 0): TagResult {
+  const tokens = tokenize(content);
+
+  // Walk tokens; for each BT…ET object compute the baseline Y of its first shown
+  // text, and record the object's [start,end] offsets + assigned zone band.
+  interface Unit { start: number; end: number; band: ZoneBand | null; }
+  const units: Unit[] = [];
+
+  // graphics + text state (axis-aligned assumption: track scale d and translate f)
+  let ctm: { d: number; f: number } = { d: 1, f: 0 };
+  const ctmStack: Array<{ d: number; f: number }> = [];
+  let inText = false;
+  let btStart = -1;
+  let tld = 0;               // text leading (TL)
+  let tmF = 0;               // current text matrix f (baseline y, text space)
+  let firstShownY: number | null = null;
+  const operands: Token[] = [];
+
+  const deviceY = (textF: number): number => ctm.d * textF + ctm.f;
+
+  const bandFor = (y: number): ZoneBand | null => {
+    for (const b of bands) if (y <= b.yTop && y >= b.yBottom) return b;
+    return null;
+  };
+
+  for (let k = 0; k < tokens.length; k++) {
+    const tk = tokens[k];
+    if (tk.t !== 'op') { operands.push(tk); continue; }
+    const op = tk.v;
+    switch (op) {
+      case 'q': ctmStack.push({ ...ctm }); break;
+      case 'Q': { const p = ctmStack.pop(); if (p) ctm = { d: p.d, f: p.f }; break; }
+      case 'cm': {
+        // a b c d e f cm — compose (axis-aligned): new d *= d, new f = d*f_old + f
+        const d = num(operands[operands.length - 3]);
+        const f = num(operands[operands.length - 1]);
+        ctm = { d: ctm.d * d, f: ctm.d * f + ctm.f };
+        break;
+      }
+      case 'BT': inText = true; btStart = tk.start; tmF = 0; firstShownY = null; break;
+      case 'TL': tld = num(operands[operands.length - 1]); break;
+      case 'Td': case 'TD': {
+        const ty = num(operands[operands.length - 1]);
+        if (op === 'TD') tld = -ty;
+        tmF += ty;
+        break;
+      }
+      case 'Tm': tmF = num(operands[operands.length - 1]); break;   // a b c d e f
+      case 'T*': tmF -= tld; break;
+      case 'Tj': case 'TJ': case "'": case '"': {
+        if (op === "'" || op === '"') tmF -= tld;   // these move to next line first
+        if (firstShownY === null) firstShownY = deviceY(tmF);
+        break;
+      }
+      case 'ET': {
+        if (inText) {
+          const y = firstShownY;
+          units.push({ start: btStart, end: tk.end, band: y === null ? null : bandFor(y) });
+        }
+        inText = false; btStart = -1;
+        break;
+      }
+      default: break;
+    }
+    operands.length = 0;
+  }
+
+  // Merge consecutive same-zone units → one MCID per run. Build offset insertions.
+  interface Insertion { offset: number; text: string; }
+  const insertions: Insertion[] = [];
+  const assignments: McidAssignment[] = [];
+  let mcid = startMcid;
+  let run: { band: ZoneBand; startOffset: number; endOffset: number } | null = null;
+
+  const closeRun = (): void => {
+    if (!run) return;
+    if (run.band.isArtifact) {
+      insertions.push({ offset: run.startOffset, text: `/Artifact BDC ` });
+    } else {
+      insertions.push({ offset: run.startOffset, text: `/${run.band.tag} <</MCID ${mcid}>> BDC ` });
+      assignments.push({ mcid, zoneIndex: run.band.zoneIndex });
+      mcid++;
+    }
+    insertions.push({ offset: run.endOffset, text: ` EMC ` });
+    run = null;
+  };
+
+  // Text in no zone is still marked /Artifact — untagged content fails PDF/UA.
+  const ARTIFACT: ZoneBand = { zoneIndex: -1, tag: 'Artifact', isArtifact: true, yTop: 0, yBottom: 0 };
+  for (const u of units) {
+    const band = u.band ?? ARTIFACT;
+    if (run && run.band.zoneIndex === band.zoneIndex && !!run.band.isArtifact === !!band.isArtifact) {
+      run.endOffset = u.end;                 // extend current run
+    } else {
+      closeRun();
+      run = { band, startOffset: u.start, endOffset: u.end };
+    }
+  }
+  closeRun();
+
+  // Apply insertions right-to-left so offsets stay valid.
+  insertions.sort((a, b) => b.offset - a.offset);
+  let out = content;
+  for (const ins of insertions) out = out.slice(0, ins.offset) + ins.text + out.slice(ins.offset);
+
+  return { content: out, assignments };
+}

--- a/src/services/zone-extractor/seam-c/hierarchy.ts
+++ b/src/services/zone-extractor/seam-c/hierarchy.ts
@@ -1,0 +1,98 @@
+import type { OrderableZone, OrderedZone } from './reading-order';
+import {
+  canonicalToTag,
+  headingTag,
+  inferHeadingLevels,
+  type PdfTag,
+  type TagMapping,
+} from './canonical-to-tag';
+
+// Seam C — Phase 2a: hierarchy assembly.
+//
+// A detector emits a FLAT reading-ordered list of typed regions. A /StructTreeRoot
+// is a TREE: list items nest under an `L`, TOC entries under a `TOC`, etc. This
+// step groups the flat, tag-resolved sequence into that container forest — still
+// pure data, no PDF writing (that is Phase 2b `buildStructTreeFromZones`).
+//
+// Grouping rules (single detector class per region, so grouping is by adjacency):
+//   · a run of consecutive `list-item`s  → one `L` of `LI`s
+//   · a run of consecutive `TOCI`s       → one `TOC`
+//   · header/footer                       → `Artifact` (kept, but out of the /K flow)
+//   · table                               → `Table` leaf (TR/TH/TD grid needs cell
+//                                            geometry the detector doesn't emit — a
+//                                            later sub-step; see note below)
+//   · everything else                     → a leaf block with its resolved tag
+//
+// Adjacency is a heuristic: two truly separate lists that abut become one `L`. For
+// the simple single-column PDFs Phase 2 targets that is acceptable; a later pass can
+// split on vertical gaps / indentation.
+
+export type StructNode =
+  | { kind: 'block'; tag: PdfTag; zone: OrderableZone }
+  | { kind: 'list'; children: StructNode[] }        // L
+  | { kind: 'listItem'; zone: OrderableZone }        // LI (expands to LI>LBody at write time)
+  | { kind: 'toc'; children: StructNode[] }          // TOC
+  | { kind: 'tocItem'; zone: OrderableZone }          // TOCI
+  | { kind: 'table'; zone: OrderableZone }            // Table (cell grid = later)
+  | { kind: 'artifact'; zone: OrderableZone };        // header/footer — pagination
+
+export interface TaggedZone {
+  zone: OrderableZone;
+  tag: PdfTag;
+  mapping: TagMapping;
+}
+
+/**
+ * Resolve each ordered zone to its PDF tag, inferring heading levels across the
+ * whole document so `section-header` becomes a concrete H1..H6.
+ */
+export function tagOrderedZones(ordered: OrderedZone<OrderableZone>[]): TaggedZone[] {
+  const headers = ordered.filter((o) => o.zone.zoneType === 'section-header').map((o) => o.zone);
+  const levels = inferHeadingLevels(headers);
+  const levelByZone = new Map<OrderableZone, number>();
+  headers.forEach((h, i) => levelByZone.set(h, levels[i]));
+
+  return ordered.map((o) => {
+    const mapping = canonicalToTag(o.zone.zoneType);
+    const tag = mapping.isHeading ? headingTag(levelByZone.get(o.zone) ?? 1) : mapping.tag;
+    return { zone: o.zone, tag, mapping };
+  });
+}
+
+/**
+ * Group a reading-ordered, tag-resolved sequence into the container forest.
+ * Invariant: at most one of the list / TOC runs is open at any time (each item
+ * type only extends its own run), so a single flush() that closes both is safe.
+ */
+export function assembleHierarchy(tagged: TaggedZone[]): StructNode[] {
+  const out: StructNode[] = [];
+  let listRun: StructNode[] = [];
+  let tocRun: StructNode[] = [];
+
+  const flush = (): void => {
+    if (listRun.length) { out.push({ kind: 'list', children: listRun }); listRun = []; }
+    if (tocRun.length) { out.push({ kind: 'toc', children: tocRun }); tocRun = []; }
+  };
+
+  for (const t of tagged) {
+    if (t.mapping.listItem) {
+      if (tocRun.length) flush();           // switching TOC → list
+      listRun.push({ kind: 'listItem', zone: t.zone });
+    } else if (t.tag === 'TOCI') {
+      if (listRun.length) flush();           // switching list → TOC
+      tocRun.push({ kind: 'tocItem', zone: t.zone });
+    } else {
+      flush();                               // any other block closes an open run
+      if (t.mapping.isArtifact) out.push({ kind: 'artifact', zone: t.zone });
+      else if (t.mapping.tableCell) out.push({ kind: 'table', zone: t.zone });
+      else out.push({ kind: 'block', tag: t.tag, zone: t.zone });
+    }
+  }
+  flush();
+  return out;
+}
+
+/** Convenience: reading-ordered `OrderedZone[]` → the container forest. */
+export function assembleFromOrdered(ordered: OrderedZone<OrderableZone>[]): StructNode[] {
+  return assembleHierarchy(tagOrderedZones(ordered));
+}

--- a/src/services/zone-extractor/seam-c/struct-tree-builder.ts
+++ b/src/services/zone-extractor/seam-c/struct-tree-builder.ts
@@ -1,0 +1,208 @@
+import {
+  PDFDocument, PDFName, PDFNumber, PDFRef, PDFArray, PDFDict, PDFRawStream, PDFObject,
+  decodePDFRawStream,
+} from 'pdf-lib';
+import { synthesizeReadingOrder, type OrderableZone } from './reading-order';
+import { tagOrderedZones, assembleHierarchy, type StructNode } from './hierarchy';
+import { tagContentStream, type ZoneBand } from './content-stream';
+
+// Seam C — Phase 2b/2c: build a /StructTreeRoot from detector zones.
+//
+// Given an untagged PDFDocument + its detected zones, this:
+//   1. synthesizes reading order and assembles the container forest (Phase 1/2a),
+//   2. for each page, rewrites the content stream with MCID marked content
+//      (Phase 2c), assigning each zone's text a unique MCID,
+//   3. writes a StructElem tree whose leaves' /K reference those MCIDs, plus
+//      /MarkInfo, /ParentTree and per-page /StructParents.
+//
+// Coordinate reconciliation: detector bbox is top-left {x,y,w,h}; a page's
+// content space is bottom-left, so a zone's device-space band is
+// [H-(y+h), H-y] (yBottom..yTop), H = page height.
+//
+// Scope: the Phase-2 spike targets simple single-column PDFs (see content-stream.ts).
+
+export interface BuildResult {
+  elements: number;
+  mcids: number;
+  pages: number;
+}
+
+/** Decode a page's content stream(s) into a single string. */
+function pageContent(doc: PDFDocument, pageNode: { get(n: PDFName): PDFObject | undefined }): string {
+  const raw = pageNode.get(PDFName.of('Contents'));
+  const resolve = (o: PDFObject | undefined): PDFObject | undefined =>
+    o instanceof PDFRef ? doc.context.lookup(o) : o;
+  const streams: PDFObject[] = [];
+  const c = resolve(raw);
+  if (c instanceof PDFArray) for (let i = 0; i < c.size(); i++) { const s = resolve(c.get(i)); if (s) streams.push(s); }
+  else if (c) streams.push(c);
+
+  const parts: string[] = [];
+  for (const s of streams) {
+    let bytes: Uint8Array | null = null;
+    const anyS = s as unknown as { decode?: () => Uint8Array };
+    if (typeof anyS.decode === 'function') { try { bytes = anyS.decode(); } catch { /* */ } }
+    if (!bytes && s instanceof PDFRawStream) { try { bytes = decodePDFRawStream(s).decode(); } catch { /* */ } }
+    if (bytes) parts.push(Buffer.from(bytes).toString('latin1'));
+  }
+  return parts.join('\n');
+}
+
+export function buildStructTreeFromZones(doc: PDFDocument, zones: OrderableZone[]): BuildResult {
+  if (zones.length === 0) return { elements: 0, mcids: 0, pages: 0 };
+
+  const ordered = synthesizeReadingOrder(zones);
+  const tagged = tagOrderedZones(ordered);
+  const forest = assembleHierarchy(tagged);
+
+  // zone → its resolved tag/mapping and a stable index
+  const zoneMeta = new Map<OrderableZone, { tag: string; isArtifact: boolean; index: number }>();
+  tagged.forEach((t, i) => zoneMeta.set(t.zone, { tag: t.tag, isArtifact: !!t.mapping.isArtifact, index: i }));
+
+  const pages = doc.getPages();
+  const pageByNumber = new Map<number, number>();     // 1-based zone pageNumber → 0-based doc index
+  // detector page numbers are 1-based and align with doc page order
+  pages.forEach((_, i) => pageByNumber.set(i + 1, i));
+
+  // ── 2c: tag each page's content stream, collect zone → { pageIdx, mcids }
+  const zoneMcids = new Map<number, { pageIdx: number; mcids: number[] }>(); // key = zone index
+  const parentTree = new Map<number, PDFRef[]>();     // pageIdx → [elemRef by mcid]
+
+  const zonesByPage = new Map<number, OrderableZone[]>();
+  for (const z of zones) {
+    const arr = zonesByPage.get(z.pageNumber); if (arr) arr.push(z); else zonesByPage.set(z.pageNumber, [z]);
+  }
+
+  for (const [pageNum, pageZones] of zonesByPage) {
+    const pageIdx = pageByNumber.get(pageNum);
+    if (pageIdx === undefined) continue;
+    const page = pages[pageIdx];
+    const H = page.getHeight();
+
+    const bands: ZoneBand[] = pageZones.map((z) => {
+      const m = zoneMeta.get(z)!;
+      return {
+        zoneIndex: m.index,
+        yTop: H - z.bbox.y,
+        yBottom: H - (z.bbox.y + z.bbox.h),
+        tag: m.tag,
+        isArtifact: m.isArtifact,
+      };
+    });
+
+    const content = pageContent(doc, page.node);
+    const { content: tagged2, assignments } = tagContentStream(content, bands, 0);
+
+    // swap the page's content stream
+    const newStream = doc.context.flateStream(Buffer.from(tagged2, 'latin1'));
+    const newRef = doc.context.register(newStream);
+    page.node.set(PDFName.of('Contents'), newRef);
+    page.node.set(PDFName.of('StructParents'), PDFNumber.of(pageIdx));
+
+    for (const a of assignments) {
+      const rec = zoneMcids.get(a.zoneIndex);
+      if (rec) rec.mcids.push(a.mcid);
+      else zoneMcids.set(a.zoneIndex, { pageIdx, mcids: [a.mcid] });
+    }
+    parentTree.set(pageIdx, []);
+  }
+
+  // ── 2b: build the StructElem tree
+  const rootObj = doc.context.obj({ Type: PDFName.of('StructTreeRoot') }) as PDFDict;
+  const rootRef = doc.context.register(rootObj);
+  const docObj = doc.context.obj({ Type: PDFName.of('StructElem'), S: PDFName.of('Document'), P: rootRef }) as PDFDict;
+  const docRef = doc.context.register(docObj);
+  rootObj.set(PDFName.of('K'), doc.context.obj([docRef]));
+
+  let elemCount = 1; // Document
+  let mcidCount = 0;
+
+  const makeElem = (S: string, parentRef: PDFRef): { ref: PDFRef; dict: PDFDict } => {
+    const dict = doc.context.obj({ Type: PDFName.of('StructElem'), S: PDFName.of(S), P: parentRef }) as PDFDict;
+    const ref = doc.context.register(dict);
+    elemCount++;
+    return { ref, dict };
+  };
+
+  // Attach a leaf's MCID(s) as /K and register it in the ParentTree.
+  const bindLeaf = (leafRef: PDFRef, leafDict: PDFDict, zone: OrderableZone): void => {
+    const meta = zoneMeta.get(zone)!;
+    const rec = zoneMcids.get(meta.index);
+    if (!rec || rec.mcids.length === 0) return;
+    const pageRef = pages[rec.pageIdx].ref;
+    leafDict.set(PDFName.of('Pg'), pageRef);
+    leafDict.set(
+      PDFName.of('K'),
+      rec.mcids.length === 1 ? PDFNumber.of(rec.mcids[0]) : doc.context.obj(rec.mcids.map((m) => PDFNumber.of(m))),
+    );
+    const slots = parentTree.get(rec.pageIdx)!;
+    for (const m of rec.mcids) { slots[m] = leafRef; mcidCount++; }
+  };
+
+  const setKids = (dict: PDFDict, childRefs: PDFRef[]): void => {
+    dict.set(PDFName.of('K'), doc.context.obj(childRefs as PDFObject[]));
+  };
+
+  // Recursively realize a forest node under `parentRef`; returns the created ref (or null for artifacts).
+  const build = (node: StructNode, parentRef: PDFRef): PDFRef | null => {
+    switch (node.kind) {
+      case 'artifact':
+        return null; // content already marked /Artifact; not in the /K flow
+      case 'block': {
+        const { ref, dict } = makeElem(node.tag, parentRef);
+        bindLeaf(ref, dict, node.zone);
+        return ref;
+      }
+      case 'table': {
+        // coarse but valid: Table > TR > TD wrapping the region's content
+        const table = makeElem('Table', parentRef);
+        const tr = makeElem('TR', table.ref);
+        const td = makeElem('TD', tr.ref);
+        bindLeaf(td.ref, td.dict, node.zone);
+        setKids(tr.dict, [td.ref]);
+        setKids(table.dict, [tr.ref]);
+        return table.ref;
+      }
+      case 'tocItem': {
+        const { ref, dict } = makeElem('TOCI', parentRef);
+        bindLeaf(ref, dict, node.zone);
+        return ref;
+      }
+      case 'listItem': {
+        const li = makeElem('LI', parentRef);
+        const lbody = makeElem('LBody', li.ref);
+        bindLeaf(lbody.ref, lbody.dict, node.zone);
+        setKids(li.dict, [lbody.ref]);
+        return li.ref;
+      }
+      case 'list': case 'toc': {
+        const container = makeElem(node.kind === 'list' ? 'L' : 'TOC', parentRef);
+        const kids: PDFRef[] = [];
+        for (const child of node.children) { const r = build(child, container.ref); if (r) kids.push(r); }
+        setKids(container.dict, kids);
+        return container.ref;
+      }
+    }
+  };
+
+  const docKids: PDFRef[] = [];
+  for (const node of forest) { const r = build(node, docRef); if (r) docKids.push(r); }
+  setKids(docObj, docKids);
+
+  // ── /ParentTree number tree (flat Nums: [key, [refs...], ...])
+  const nums: PDFObject[] = [];
+  for (const [pageIdx, slots] of [...parentTree.entries()].sort((a, b) => a[0] - b[0])) {
+    const arr = slots.map((r) => (r ?? doc.context.obj({})) as PDFObject); // dense over MCIDs
+    nums.push(PDFNumber.of(pageIdx), doc.context.obj(arr));
+  }
+  const parentTreeObj = doc.context.obj({ Nums: doc.context.obj(nums) });
+  const parentTreeRef = doc.context.register(parentTreeObj);
+  rootObj.set(PDFName.of('ParentTree'), parentTreeRef);
+  rootObj.set(PDFName.of('ParentTreeNextKey'), PDFNumber.of(pages.length));
+
+  // ── catalog: /StructTreeRoot + /MarkInfo <</Marked true>>
+  doc.catalog.set(PDFName.of('StructTreeRoot'), rootRef);
+  doc.catalog.set(PDFName.of('MarkInfo'), doc.context.obj({ Marked: true }));
+
+  return { elements: elemCount, mcids: mcidCount, pages: zonesByPage.size };
+}

--- a/tests/unit/services/zone-extractor/seam-c/content-stream.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/content-stream.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { tokenize, tagContentStream, type ZoneBand } from '../../../../../src/services/zone-extractor/seam-c/content-stream';
+
+// The exact shape pdf-lib emits (verified via PoC): each drawText → q BT … Tm … Tj … ET Q
+const twoLineStream = `q
+BT
+0 0 0 rg
+/F1 12 Tf
+24 TL
+1 0 0 1 50 150 Tm
+<48656C6C6F> Tj
+T*
+ET
+Q
+q
+BT
+0 0 0 rg
+/F1 12 Tf
+24 TL
+1 0 0 1 50 120 Tm
+<5365636F6E64> Tj
+T*
+ET
+Q
+`;
+
+describe('tokenize', () => {
+  it('classifies numbers, names, hex strings and operators with offsets', () => {
+    const toks = tokenize('1 0 0 1 50 150 Tm\n<48> Tj');
+    expect(toks.filter((t) => t.t === 'n').map((t) => t.v)).toEqual(['1', '0', '0', '1', '50', '150']);
+    expect(toks.find((t) => t.t === 'op' && t.v === 'Tm')).toBeTruthy();
+    expect(toks.find((t) => t.t === 'h')?.v).toBe('<48>');
+    const tj = toks.find((t) => t.v === 'Tj')!;
+    expect('1 0 0 1 50 150 Tm\n<48> Tj'.slice(tj.start, tj.end)).toBe('Tj');
+  });
+
+  it('handles string literals with nested parens and escapes', () => {
+    const toks = tokenize('(a\\(b) Tj');
+    expect(toks[0].t).toBe('s');
+    expect(toks[0].v).toBe('(a\\(b)');
+  });
+
+  it('distinguishes negative numbers from operators', () => {
+    const toks = tokenize('-12.5 0 Td');
+    expect(toks[0]).toMatchObject({ t: 'n', v: '-12.5' });
+    expect(toks[2]).toMatchObject({ t: 'op', v: 'Td' });
+  });
+});
+
+describe('tagContentStream', () => {
+  // page height 200; two zones stacked. Line 1 baseline y=150, line 2 y=120.
+  const bands: ZoneBand[] = [
+    { zoneIndex: 0, yTop: 165, yBottom: 140, tag: 'H1' },   // contains y=150
+    { zoneIndex: 1, yTop: 135, yBottom: 100, tag: 'P' },    // contains y=120
+  ];
+
+  it('wraps each text object in its zone tag with a unique MCID', () => {
+    const { content, assignments } = tagContentStream(twoLineStream, bands);
+    expect(content).toContain('/H1 <</MCID 0>> BDC');
+    expect(content).toContain('/P <</MCID 1>> BDC');
+    expect((content.match(/EMC/g) || []).length).toBe(2);
+    expect(assignments).toEqual([
+      { mcid: 0, zoneIndex: 0 },
+      { mcid: 1, zoneIndex: 1 },
+    ]);
+  });
+
+  it('keeps the original text content intact', () => {
+    const { content } = tagContentStream(twoLineStream, bands);
+    expect(content).toContain('<48656C6C6F> Tj');
+    expect(content).toContain('<5365636F6E64> Tj');
+    // BDC precedes the BT it wraps
+    expect(content.indexOf('/H1 <</MCID 0>> BDC')).toBeLessThan(content.indexOf('<48656C6C6F>'));
+  });
+
+  it('merges consecutive same-zone text objects under one MCID', () => {
+    // both lines fall in one wide band
+    const oneBand: ZoneBand[] = [{ zoneIndex: 0, yTop: 165, yBottom: 100, tag: 'P' }];
+    const { content, assignments } = tagContentStream(twoLineStream, oneBand);
+    expect(assignments).toEqual([{ mcid: 0, zoneIndex: 0 }]);
+    expect((content.match(/BDC/g) || []).length).toBe(1);
+    expect((content.match(/EMC/g) || []).length).toBe(1);
+  });
+
+  it('marks text with no matching zone as Artifact (no MCID)', () => {
+    const { content, assignments } = tagContentStream(twoLineStream, [
+      { zoneIndex: 0, yTop: 999, yBottom: 900, tag: 'P' }, // matches neither line
+    ]);
+    expect(assignments).toEqual([]);
+    expect(content).toContain('/Artifact BDC');
+    expect(content).not.toContain('MCID');
+  });
+
+  it('allocates MCIDs from startMcid', () => {
+    const { assignments } = tagContentStream(twoLineStream, bands, 5);
+    expect(assignments.map((a) => a.mcid)).toEqual([5, 6]);
+  });
+
+  it('respects an artifact band (header/footer) with no MCID', () => {
+    const { content, assignments } = tagContentStream(twoLineStream, [
+      { zoneIndex: 0, yTop: 165, yBottom: 140, tag: 'Artifact', isArtifact: true },
+      { zoneIndex: 1, yTop: 135, yBottom: 100, tag: 'P' },
+    ]);
+    expect(content).toContain('/Artifact BDC');
+    expect(content).toContain('/P <</MCID 0>> BDC');
+    expect(assignments).toEqual([{ mcid: 0, zoneIndex: 1 }]);
+  });
+});

--- a/tests/unit/services/zone-extractor/seam-c/hierarchy.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/hierarchy.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assembleHierarchy,
+  tagOrderedZones,
+  assembleFromOrdered,
+  type TaggedZone,
+  type StructNode,
+} from '../../../../../src/services/zone-extractor/seam-c/hierarchy';
+import { canonicalToTag } from '../../../../../src/services/zone-extractor/seam-c/canonical-to-tag';
+import type { OrderableZone, OrderedZone } from '../../../../../src/services/zone-extractor/seam-c/reading-order';
+import type { CanonicalZoneType } from '../../../../../src/services/zone-extractor/types';
+
+const zone = (zoneType: CanonicalZoneType, h = 12): OrderableZone => ({
+  pageNumber: 1,
+  bbox: { x: 0, y: 0, w: 100, h },
+  zoneType,
+});
+
+// Build TaggedZone[] straight from canonical types (heading level not under test here).
+const tag = (zoneType: CanonicalZoneType): TaggedZone => {
+  const z = zone(zoneType);
+  const mapping = canonicalToTag(zoneType);
+  return { zone: z, tag: mapping.tag, mapping };
+};
+
+const kinds = (nodes: StructNode[]): string[] => nodes.map((n) => n.kind);
+
+describe('assembleHierarchy', () => {
+  it('wraps a run of list-items in a single L', () => {
+    const nodes = assembleHierarchy([tag('list-item'), tag('list-item'), tag('list-item')]);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].kind).toBe('list');
+    const list = nodes[0] as Extract<StructNode, { kind: 'list' }>;
+    expect(list.children.map((c) => c.kind)).toEqual(['listItem', 'listItem', 'listItem']);
+  });
+
+  it('splits two list runs separated by a paragraph into two Ls', () => {
+    const nodes = assembleHierarchy([
+      tag('list-item'), tag('list-item'),
+      tag('paragraph'),
+      tag('list-item'), tag('list-item'),
+    ]);
+    expect(kinds(nodes)).toEqual(['list', 'block', 'list']);
+  });
+
+  it('wraps a run of TOCI in a single TOC', () => {
+    const nodes = assembleHierarchy([tag('toci'), tag('toci')]);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].kind).toBe('toc');
+    expect((nodes[0] as Extract<StructNode, { kind: 'toc' }>).children.map((c) => c.kind))
+      .toEqual(['tocItem', 'tocItem']);
+  });
+
+  it('flushes cleanly when switching directly from a list to a TOC', () => {
+    const nodes = assembleHierarchy([tag('list-item'), tag('toci'), tag('list-item')]);
+    expect(kinds(nodes)).toEqual(['list', 'toc', 'list']);
+  });
+
+  it('emits header/footer as Artifact nodes, never inside a list', () => {
+    const nodes = assembleHierarchy([tag('list-item'), tag('header'), tag('list-item')]);
+    expect(kinds(nodes)).toEqual(['list', 'artifact', 'list']);
+    expect((nodes[1] as Extract<StructNode, { kind: 'artifact' }>).zone.zoneType).toBe('header');
+  });
+
+  it('emits table and figure/paragraph/formula as their own leaf nodes', () => {
+    const nodes = assembleHierarchy([tag('table'), tag('figure'), tag('paragraph'), tag('formula')]);
+    expect(kinds(nodes)).toEqual(['table', 'block', 'block', 'block']);
+    const blocks = nodes.filter((n) => n.kind === 'block') as Extract<StructNode, { kind: 'block' }>[];
+    expect(blocks.map((b) => b.tag)).toEqual(['Figure', 'P', 'Formula']);
+  });
+
+  it('closes an open list at end of sequence', () => {
+    const nodes = assembleHierarchy([tag('paragraph'), tag('list-item')]);
+    expect(kinds(nodes)).toEqual(['block', 'list']);
+  });
+
+  it('returns empty for no zones', () => {
+    expect(assembleHierarchy([])).toEqual([]);
+  });
+});
+
+describe('tagOrderedZones', () => {
+  const ord = (zoneType: CanonicalZoneType, h = 12): OrderedZone<OrderableZone> => ({
+    zone: { pageNumber: 1, bbox: { x: 0, y: 0, w: 100, h }, zoneType },
+    readingOrder: 0,
+  });
+
+  it('resolves section-headers to concrete H-levels by height (taller = higher)', () => {
+    const tagged = tagOrderedZones([ord('section-header', 30), ord('section-header', 20), ord('section-header', 12)]);
+    expect(tagged.map((t) => t.tag)).toEqual(['H1', 'H2', 'H3']);
+  });
+
+  it('resolves plain classes via the role map', () => {
+    const tagged = tagOrderedZones([ord('paragraph'), ord('footnote'), ord('formula')]);
+    expect(tagged.map((t) => t.tag)).toEqual(['P', 'Note', 'Formula']);
+  });
+});
+
+describe('assembleFromOrdered', () => {
+  it('chains tag-resolution and grouping end-to-end', () => {
+    const ordered: OrderedZone<OrderableZone>[] = [
+      { zone: zone('section-header', 24), readingOrder: 0 },
+      { zone: zone('list-item'), readingOrder: 1 },
+      { zone: zone('list-item'), readingOrder: 2 },
+      { zone: zone('footer'), readingOrder: 3 },
+    ];
+    const nodes = assembleFromOrdered(ordered);
+    expect(kinds(nodes)).toEqual(['block', 'list', 'artifact']);
+    expect((nodes[0] as Extract<StructNode, { kind: 'block' }>).tag).toBe('H1');
+  });
+});

--- a/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { PDFDocument, StandardFonts, PDFName, PDFDict, PDFBool, PDFRawStream, decodePDFRawStream } from 'pdf-lib';
+import { buildStructTreeFromZones } from '../../../../../src/services/zone-extractor/seam-c/struct-tree-builder';
+import { serializeStructTreeAsync } from '../../../../../src/services/zone-extractor/struct-tree-serializer';
+import type { OrderableZone } from '../../../../../src/services/zone-extractor/seam-c/reading-order';
+import type { CanonicalZoneType } from '../../../../../src/services/zone-extractor/types';
+
+const H = 600;
+// Draw a single-column page; each line's baseline is chosen so its zone band contains it.
+async function makeUntaggedPdf(): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage([450, H]);
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const draw = (text: string, y: number, size = 12): void => page.drawText(text, { x: 50, y, size, font });
+  draw('Chapter One', 560, 18);   // heading
+  draw('First paragraph text.', 520);
+  draw('Second paragraph text.', 490);
+  draw('First list item', 450);
+  draw('Second list item', 430);
+  return doc.save();
+}
+
+const z = (zoneType: CanonicalZoneType, y: number, h: number): OrderableZone => ({
+  pageNumber: 1, bbox: { x: 50, y, w: 400, h }, zoneType,
+});
+
+// zones in top-left convention; device band = [H-(y+h), H-y] must contain each baseline
+const ZONES: OrderableZone[] = [
+  z('section-header', 30, 20),  // band [550,570] ∋ 560
+  z('paragraph', 70, 20),       // band [510,530] ∋ 520
+  z('paragraph', 100, 20),      // band [480,500] ∋ 490
+  z('list-item', 140, 18),      // band [442,460] ∋ 450
+  z('list-item', 160, 18),      // band [422,440] ∋ 430
+];
+
+describe('buildStructTreeFromZones (end-to-end)', () => {
+  it('tags an untagged single-column PDF and the tree round-trips', async () => {
+    const untagged = await makeUntaggedPdf();
+
+    // load as we would a received PDF, then build the tree
+    const doc = await PDFDocument.load(untagged);
+    const result = buildStructTreeFromZones(doc, ZONES);
+    expect(result.pages).toBe(1);
+    expect(result.mcids).toBe(5);       // one MCID per zone
+    const tagged = await doc.save();
+
+    // catalog markers
+    const reloaded = await PDFDocument.load(tagged);
+    const catalog = reloaded.catalog;
+    expect(catalog.get(PDFName.of('StructTreeRoot'))).toBeTruthy();
+    const markInfo = reloaded.context.lookup(catalog.get(PDFName.of('MarkInfo'))) as PDFDict;
+    expect(markInfo.get(PDFName.of('Marked'))).toBe(PDFBool.True);
+
+    // content stream carries MCID marked content
+    const page = reloaded.getPage(0);
+    const streamObj = reloaded.context.lookup(page.node.get(PDFName.of('Contents')));
+    const bytes = streamObj instanceof PDFRawStream
+      ? decodePDFRawStream(streamObj).decode()
+      : (streamObj as unknown as { decode(): Uint8Array }).decode();
+    let cs = '';
+    for (let i = 0; i < bytes.length; i++) cs += String.fromCharCode(bytes[i]);
+    expect(cs).toContain('/H1 <</MCID 0>> BDC');
+    expect(cs).toContain('BDC');
+    expect((cs.match(/EMC/g) || []).length).toBe(5);
+
+    // round-trip the /StructTreeRoot back to a tag tree via the repo's own reader
+    const { tree } = await serializeStructTreeAsync(tagged as unknown as Parameters<typeof serializeStructTreeAsync>[0]);
+    expect(tree).toHaveLength(1);
+    const document = tree[0];
+    expect(document.tag).toBe('Document');
+    const top = (document.children || []).map((c) => c.tag);
+    expect(top).toEqual(['H1', 'P', 'P', 'L']);
+
+    // leaves carry their MCID; the list nests L > LI > LBody
+    const [h1, p1] = document.children!;
+    expect(h1.mcids).toEqual([0]);
+    expect(p1.mcids).toEqual([1]);
+    const list = document.children![3];
+    expect((list.children || []).map((c) => c.tag)).toEqual(['LI', 'LI']);
+    const firstLi = list.children![0];
+    expect((firstLi.children || []).map((c) => c.tag)).toEqual(['LBody']);
+    expect(firstLi.children![0].mcids).toEqual([3]);
+  });
+
+  it('is a no-op for a PDF with no zones', async () => {
+    const doc = await PDFDocument.load(await makeUntaggedPdf());
+    const result = buildStructTreeFromZones(doc, []);
+    expect(result).toEqual({ elements: 0, mcids: 0, pages: 0 });
+    expect(doc.catalog.get(PDFName.of('StructTreeRoot'))).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Seam C — Phase 2 (the tree builder)

Turns an untagged PDF's detector zones into a real, content-bound `/StructTreeRoot` — the thing that lets the existing audit + remediation pipeline treat it as tagged. **Proven end-to-end on simple single-column PDFs, pure-JS, no new dependencies.**

### 2a — hierarchy assembly (`hierarchy.ts`)
Groups the flat reading-ordered, tag-resolved zones into the container forest: consecutive `list-item`s → `L>LI`; consecutive `TOCI` → `TOC`; header/footer → `Artifact`; `table` → `Table` leaf; else a leaf block. Heading levels inferred doc-wide.

### 2c — content-stream MCID tagging (`content-stream.ts`) — the hard core
A tokenizer + axis-aligned CTM/text-matrix interpreter (the inverse of the read-side operator tracker in `tagged-pdf-extractor`). It wraps each text object in `/<Tag> <</MCID n>> BDC … EMC`, assigns **one MCID per contiguous same-zone run** by baseline-Y band, and marks unmatched text `/Artifact` (untagged content fails PDF/UA). The pdf-lib content-stream round-trip (`stream.decode()` → rewrite → `flateStream`) was validated by PoC first.

### 2b — tree writer (`struct-tree-builder.ts`)
`buildStructTreeFromZones(doc, zones)`: synthesizes order + hierarchy, tags each page's content stream (swaps `/Contents`), then writes `/StructTreeRoot → /Document → StructElems` whose **leaf `/K` reference the MCIDs**, plus `/MarkInfo <</Marked true>>`, a `/ParentTree` number tree, and per-page `/StructParents`. Coordinate flip: top-left `{x,y,w,h}` → device band `[H-(y+h), H-y]`.

### End-to-end validation
An untagged single-column PDF, run through the full pipeline, **round-trips through the repo's own `struct-tree-serializer`** as `Document > [H1, P, P, L > [LI>LBody, LI>LBody]]` with correct MCIDs (9 elements), `MarkInfo Marked`, and `BDC/EMC` in the content stream.

### Tests
43 seam-c unit tests (tokenizer, tagger, hierarchy, ordering, tag-map, end-to-end round-trip). `vitest` green; tsc + eslint clean.

### Scope / next
Spike scope is **simple single-column, text-first** PDFs (axis-aligned matrices; images/paths left as-is; `Table` is a coarse one-cell `Table>TR>TD`). Next: robustness on real multi-column / rotated PDFs, then **Phase 3** — wire `buildStructTreeFromZones` into the worker's Adobe-fallback slot (`accessibility.processor.ts:169`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF structure-tree generation from detected content zones, including container hierarchy assembly.
  * Implemented marked-content tagging for text runs using MCIDs, preserving zone-to-tag assignments (including artifact handling for non-zoned content).
  * Added support for section headers mapped to concrete heading levels, and structured grouping of list and TOC items.
* **Tests**
  * Added unit tests for content-stream tokenization/tagging and hierarchy assembly behavior.
  * Added integration tests validating full struct-tree creation and a safe no-op when no zones are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->