### PR TITLE
fix(seam-c): /Artifact BMC + guard against already-tagged PDFs (Phase 2 hardening)

### DIFF
--- a/src/services/zone-extractor/seam-c/content-stream.ts
+++ b/src/services/zone-extractor/seam-c/content-stream.ts
@@ -181,7 +181,9 @@ export function tagContentStream(content: string, bands: ZoneBand[], startMcid =
   const closeRun = (): void => {
     if (!run) return;
     if (run.band.isArtifact) {
-      insertions.push({ offset: run.startOffset, text: `/Artifact BDC ` });
+      // BMC (not BDC): a bare tag with no property list. `/Artifact BDC` makes a
+      // validator look up /Artifact in /Properties → "Undefined property" (veraPDF).
+      insertions.push({ offset: run.startOffset, text: `/Artifact BMC ` });
     } else {
       insertions.push({ offset: run.startOffset, text: `/${run.band.tag} <</MCID ${mcid}>> BDC ` });
       assignments.push({ mcid, zoneIndex: run.band.zoneIndex });

--- a/src/services/zone-extractor/seam-c/struct-tree-builder.ts
+++ b/src/services/zone-extractor/seam-c/struct-tree-builder.ts
@@ -51,6 +51,14 @@ function pageContent(doc: PDFDocument, pageNode: { get(n: PDFName): PDFObject | 
 export function buildStructTreeFromZones(doc: PDFDocument, zones: OrderableZone[]): BuildResult {
   if (zones.length === 0) return { elements: 0, mcids: 0, pages: 0 };
 
+  // Seam C only tags GENUINELY untagged PDFs. Running on a doc that already has a
+  // /StructTreeRoot (and existing MCID marked content) would create duplicate /
+  // nested MCIDs and two coexisting structure trees. The worker gates on
+  // `!isTagged`; this is the defensive backstop.
+  if (doc.catalog.get(PDFName.of('StructTreeRoot'))) {
+    throw new Error('SEAM_C_ALREADY_TAGGED: document already has a /StructTreeRoot');
+  }
+
   const ordered = synthesizeReadingOrder(zones);
   const tagged = tagOrderedZones(ordered);
   const forest = assembleHierarchy(tagged);

--- a/tests/unit/services/zone-extractor/seam-c/content-stream.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/content-stream.test.ts
@@ -87,7 +87,7 @@ describe('tagContentStream', () => {
       { zoneIndex: 0, yTop: 999, yBottom: 900, tag: 'P' }, // matches neither line
     ]);
     expect(assignments).toEqual([]);
-    expect(content).toContain('/Artifact BDC');
+    expect(content).toContain('/Artifact BMC');
     expect(content).not.toContain('MCID');
   });
 
@@ -101,7 +101,7 @@ describe('tagContentStream', () => {
       { zoneIndex: 0, yTop: 165, yBottom: 140, tag: 'Artifact', isArtifact: true },
       { zoneIndex: 1, yTop: 135, yBottom: 100, tag: 'P' },
     ]);
-    expect(content).toContain('/Artifact BDC');
+    expect(content).toContain('/Artifact BMC');
     expect(content).toContain('/P <</MCID 0>> BDC');
     expect(assignments).toEqual([{ mcid: 0, zoneIndex: 1 }]);
   });

--- a/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
@@ -82,6 +82,12 @@ describe('buildStructTreeFromZones (end-to-end)', () => {
     expect(firstLi.children![0].mcids).toEqual([3]);
   });
 
+  it('refuses a PDF that already has a /StructTreeRoot (no double-tagging)', async () => {
+    const doc = await PDFDocument.load(await makeUntaggedPdf());
+    buildStructTreeFromZones(doc, ZONES);                 // now tagged
+    expect(() => buildStructTreeFromZones(doc, ZONES)).toThrow(/ALREADY_TAGGED/);
+  });
+
   it('is a no-op for a PDF with no zones', async () => {
     const doc = await PDFDocument.load(await makeUntaggedPdf());
     const result = buildStructTreeFromZones(doc, []);


### PR DESCRIPTION
## Seam C — Phase 2 hardening (veraPDF-driven)

Ran the Phase-2 output through **veraPDF (PDF/UA-1)** on staging. Two findings, both fixed:

### 1. `/Artifact BDC` → `/Artifact BMC`
veraPDF: `SEVERE: Undefined property /Artifact in a content stream`. A bare marked-content tag with **no property list** must use `BMC`, not `BDC` (which expects a property operand and made the validator look up `/Artifact` in `/Properties`). Artifact runs now emit `/Artifact BMC … EMC`.

### 2. Guard against already-tagged PDFs
`buildStructTreeFromZones` now throws `SEAM_C_ALREADY_TAGGED` when the doc already has a `/StructTreeRoot`.

**Why:** the earlier "real PDF" smoke test (JISYS) turned out to be **already fully tagged** — `StructTreeRoot` + `MarkInfo` present, 88 existing MCIDs in the content stream. Tagging it stacked duplicate/nested MCIDs (veraPDF `Duplicate MCID`/`Nested MCID`) and produced two coexisting structure trees. Seam C only ever runs on genuinely untagged PDFs (the worker gates on `!isTagged`); this is the defensive backstop so the two-`/StructTreeRoot` failure mode from the design (§7) can't happen.

### Validation
- The synthetic clean-untagged round-trip still passes (Document > [H1, P, P, L>…]).
- Re-validated on a **genuinely untagged** real PDF (Nikitopoulos — `StructTreeRoot: false, MarkInfo: false`): builds cleanly (1786 elements, 689 MCIDs, 157 pages), guard not triggered.
- 44 seam-c tests (incl. the new guard test). tsc + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF artifact tagging compatibility by using the correct artifact marker format.
  * Prevented processing PDFs that have already been tagged, avoiding duplicate accessibility structure trees and content markers.
* **Tests**
  * Added coverage for already-tagged PDFs and updated artifact-tagging expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->