### PR TITLE
feat(seam-c): Seam C as the default PDF tagger (Phase 3)

### DIFF
--- a/src/config/ai.config.ts
+++ b/src/config/ai.config.ts
@@ -4,6 +4,12 @@ export const aiConfig = {
     clientSecret: process.env.ADOBE_PDF_SERVICES_CLIENT_SECRET || '',
     enabled: !!process.env.ADOBE_PDF_SERVICES_CLIENT_ID,
   },
+  // Seam C — the in-house detector-driven tagger. DEFAULT tagger for untagged PDFs
+  // (Adobe is the fallback). Enabled whenever the YOLO detector is reachable, unless
+  // explicitly turned off with SEAM_C_ENABLED=false.
+  seamC: {
+    enabled: process.env.SEAM_C_ENABLED !== 'false' && !!process.env.YOLO_SERVICE_URL,
+  },
   gemini: {
     apiKey: process.env.GEMINI_API_KEY || '',
     model: 'gemini-2.0-flash',

--- a/src/services/pdf/seam-c-tag.service.ts
+++ b/src/services/pdf/seam-c-tag.service.ts
@@ -1,0 +1,95 @@
+import { PDFDocument } from 'pdf-lib';
+import { detectWithYolo } from '../zone-extractor/yolo-client';
+import { ensureYoloServiceUp, touchYoloIdleTimer } from '../zone-extractor/yolo-service-scaler';
+import { mapYoloLabel } from '../zone-extractor/yolo-label-mapper';
+import { buildStructTreeFromZones } from '../zone-extractor/seam-c/struct-tree-builder';
+import type { OrderableZone } from '../zone-extractor/seam-c/reading-order';
+import { s3Service } from '../s3.service';
+import { config } from '../../config';
+import { logger } from '../../lib/logger';
+
+// Seam C — Phase 3: the tagging producer.
+//
+// Turns an untagged PDF buffer into a tagged one, as a peer of adobeAutoTagService
+// with the SAME return shape so it drops into the worker's tag branch unchanged.
+// Pipeline: on-demand YOLO detection → canonical zones → buildStructTreeFromZones.
+//
+// The detector reads from S3, so the buffer is staged to a temp key, detected, and
+// the temp object removed. Only `taggedPdfBuffer` is load-bearing downstream; the
+// report/word/elementCounts/parsedFlags fields exist purely to match Adobe's shape
+// (they are UI-only and Seam C leaves them null/empty).
+
+export interface SeamCTagResult {
+  taggedPdfBuffer: Buffer;
+  reportBuffer: null;
+  wordBuffer: null;
+  elementCounts: null;
+  parsedFlags: never[];
+  source: 'seam-c';
+  buildResult: { elements: number; mcids: number; pages: number };
+}
+
+/** Seams injected for testing (the real detector needs a live GPU service). */
+export interface SeamCDeps {
+  ensureUp: () => Promise<void>;
+  touchIdle: () => void;
+  detect: (pdfPath: string, jobId: string) => Promise<{ zones: Array<{ page: number; bbox: { x: number; y: number; w: number; h: number }; label: string }> }>;
+  uploadTemp: (buffer: Buffer, jobId: string) => Promise<string>;   // returns s3://uri
+  deleteTemp: (uri: string) => Promise<void>;
+}
+
+const defaultDeps: SeamCDeps = {
+  ensureUp: ensureYoloServiceUp,
+  touchIdle: touchYoloIdleTimer,
+  detect: detectWithYolo,
+  uploadTemp: async (buffer, jobId) => {
+    const key = await s3Service.uploadBuffer('seam-c', `${jobId}.pdf`, buffer, 'application/pdf', 'seam-c-temp');
+    return `s3://${config.s3Bucket}/${key}`;
+  },
+  deleteTemp: async (uri) => {
+    const key = uri.replace(/^s3:\/\/[^/]+\//, '');
+    await s3Service.deleteFile(key).catch(() => {});
+  },
+};
+
+export class SeamCTagService {
+  async tagPdf(pdfBuffer: Buffer, jobId: string, deps: SeamCDeps = defaultDeps): Promise<SeamCTagResult> {
+    // 1 — detect zones via the on-demand YOLO service
+    await deps.ensureUp();
+    const uri = await deps.uploadTemp(pdfBuffer, jobId);
+    let zones: OrderableZone[];
+    try {
+      const response = await deps.detect(uri, jobId);
+      zones = response.zones
+        .filter((z) => z.bbox && typeof z.bbox.x === 'number')
+        .map((z) => ({ pageNumber: z.page, bbox: z.bbox, zoneType: mapYoloLabel(z.label) }));
+    } finally {
+      await deps.deleteTemp(uri);
+      deps.touchIdle();
+    }
+    if (zones.length === 0) {
+      throw new Error('SEAM_C_NO_ZONES: detector returned no zones');
+    }
+
+    // 2 — build the /StructTreeRoot (throws SEAM_C_ALREADY_TAGGED if not untagged)
+    const doc = await PDFDocument.load(pdfBuffer);
+    const buildResult = buildStructTreeFromZones(doc, zones);
+    const taggedPdfBuffer = Buffer.from(await doc.save());
+
+    logger.info(
+      `[SeamC] job ${jobId}: tagged ${zones.length} zones → ${buildResult.elements} elements, ` +
+      `${buildResult.mcids} MCIDs across ${buildResult.pages} pages`,
+    );
+    return {
+      taggedPdfBuffer,
+      reportBuffer: null,
+      wordBuffer: null,
+      elementCounts: null,
+      parsedFlags: [],
+      source: 'seam-c',
+      buildResult,
+    };
+  }
+}
+
+export const seamCTagService = new SeamCTagService();

--- a/src/workers/processors/accessibility.processor.ts
+++ b/src/workers/processors/accessibility.processor.ts
@@ -6,6 +6,7 @@ import { queueService } from '../../services/queue.service';
 import { pdfAuditService } from '../../services/pdf/pdf-audit.service';
 import { pdfParserService } from '../../services/pdf/pdf-parser.service';
 import { adobeAutoTagService } from '../../services/pdf/adobe-autotag.service';
+import { seamCTagService } from '../../services/pdf/seam-c-tag.service';
 import { aiAnalysisService } from '../../services/pdf/ai-analysis.service';
 import { pdfModifierService } from '../../services/pdf/pdf-modifier.service';
 import { pdfStructureWriterService } from '../../services/pdf/pdf-structure-writer.service';
@@ -151,10 +152,12 @@ async function processPdfAccessibility(
   // ── 2. Adobe AutoTag if untagged [20–40%] ───────────────────────────────────
   let auditBuffer = fileBuffer;
   let autoTagMeta: Record<string, unknown> = {};
-  const shouldAutoTag = !isTagged && aiConfig.adobe.enabled;
+  // Seam C is the DEFAULT tagger; Adobe is the fallback. Tag any untagged PDF when
+  // at least one tagger is available.
+  const shouldAutoTag = !isTagged && (aiConfig.seamC.enabled || aiConfig.adobe.enabled);
 
   if (shouldAutoTag) {
-    logger.info(`[PDF Worker] PDF is untagged — running Adobe AutoTag for job ${dbJobId}`);
+    logger.info(`[PDF Worker] PDF is untagged — tagging (${aiConfig.seamC.enabled ? 'Seam C' : 'Adobe'}) for job ${dbJobId}`);
 
     // Record autoTagProgress start in job.input
     const ejStart = await prisma.job.findUnique({ where: { id: dbJobId }, select: { input: true } });
@@ -166,7 +169,26 @@ async function processPdfAccessibility(
     });
 
     try {
-      const autoTagResult = await adobeAutoTagService.tagPdf(fileBuffer, { generateReport: true, exportWord: true });
+      let autoTagResult: {
+        taggedPdfBuffer: Buffer;
+        reportBuffer: Buffer | null;
+        wordBuffer: Buffer | null;
+        elementCounts: unknown;
+        parsedFlags: unknown;
+      };
+      let taggerSource: 'seam-c' | 'adobe' = 'adobe';
+      if (aiConfig.seamC.enabled) {
+        try {
+          autoTagResult = await seamCTagService.tagPdf(fileBuffer, dbJobId);
+          taggerSource = 'seam-c';
+        } catch (seamErr) {
+          if (!aiConfig.adobe.enabled) throw seamErr;
+          logger.warn(`[PDF Worker] Seam C tagging failed, falling back to Adobe: ${seamErr instanceof Error ? seamErr.message : String(seamErr)}`);
+          autoTagResult = await adobeAutoTagService.tagPdf(fileBuffer, { generateReport: true, exportWord: true });
+        }
+      } else {
+        autoTagResult = await adobeAutoTagService.tagPdf(fileBuffer, { generateReport: true, exportWord: true });
+      }
       auditBuffer = autoTagResult.taggedPdfBuffer;
 
       // Save tagged PDF as remediated file + report XML + Word export
@@ -202,11 +224,12 @@ async function processPdfAccessibility(
 
       autoTagMeta = {
         autoTagStatus: 'complete',
+        taggerSource,
         hasTaggingReport: !!autoTagResult.reportBuffer,
         hasWordExport: !!autoTagResult.wordBuffer,
         autoTagElementCounts: autoTagResult.elementCounts,
       };
-      logger.info(`[PDF Worker] Adobe AutoTag complete for job ${dbJobId}`);
+      logger.info(`[PDF Worker] ${taggerSource} tagging complete for job ${dbJobId}`);
     } catch (tagErr) {
       logger.warn(`[PDF Worker] Adobe AutoTag failed (continuing with untagged): ${tagErr instanceof Error ? tagErr.message : String(tagErr)}`);
 
@@ -227,8 +250,8 @@ async function processPdfAccessibility(
     }
   } else {
     autoTagMeta = { autoTagStatus: isTagged ? 'skipped' : 'skipped' };
-    if (isTagged) logger.info(`[PDF Worker] PDF is already tagged — skipping Adobe AutoTag for job ${dbJobId}`);
-    else logger.info(`[PDF Worker] Adobe not configured — skipping AutoTag for job ${dbJobId}`);
+    if (isTagged) logger.info(`[PDF Worker] PDF is already tagged — skipping tagging for job ${dbJobId}`);
+    else logger.info(`[PDF Worker] No tagger configured — skipping tagging for job ${dbJobId}`);
   }
 
   // Advance to audit start (40% if auto-tag ran, stays at 20% if skipped)

--- a/tests/unit/services/pdf/seam-c-tag.service.test.ts
+++ b/tests/unit/services/pdf/seam-c-tag.service.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PDFDocument, StandardFonts, PDFName } from 'pdf-lib';
+import { SeamCTagService, type SeamCDeps } from '../../../../src/services/pdf/seam-c-tag.service';
+
+const H = 600;
+async function makeUntaggedPdf(): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage([450, H]);
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  page.drawText('Heading', { x: 50, y: 558, size: 16, font });   // baseline in [550,570]
+  page.drawText('Body paragraph.', { x: 50, y: 520, size: 12, font }); // baseline in [510,530]
+  return Buffer.from(await doc.save());
+}
+
+// zones the (mocked) detector returns — bands chosen to contain the baselines above
+const DETECT_RESPONSE = {
+  zones: [
+    { page: 1, bbox: { x: 50, y: 30, w: 400, h: 20 }, label: 'section-header' }, // band [550,570]
+    { page: 1, bbox: { x: 50, y: 70, w: 400, h: 20 }, label: 'paragraph' },      // band [510,530]
+  ],
+};
+
+function mockDeps(overrides: Partial<SeamCDeps> = {}): SeamCDeps {
+  return {
+    ensureUp: vi.fn(async () => {}),
+    touchIdle: vi.fn(),
+    detect: vi.fn(async () => DETECT_RESPONSE),
+    uploadTemp: vi.fn(async () => 's3://bucket/seam-c-temp/job.pdf'),
+    deleteTemp: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe('SeamCTagService.tagPdf', () => {
+  const svc = new SeamCTagService();
+
+  it('detects → builds a StructTree and returns an Adobe-shaped result', async () => {
+    const buf = await makeUntaggedPdf();
+    const deps = mockDeps();
+    const res = await svc.tagPdf(buf, 'job1', deps);
+
+    expect(res.source).toBe('seam-c');
+    expect(res.reportBuffer).toBeNull();
+    expect(res.wordBuffer).toBeNull();
+    expect(res.parsedFlags).toEqual([]);
+    expect(res.buildResult.elements).toBeGreaterThan(0);
+    expect(res.buildResult.mcids).toBeGreaterThan(0);
+
+    // the returned buffer is a genuinely tagged PDF
+    const reloaded = await PDFDocument.load(res.taggedPdfBuffer);
+    expect(reloaded.catalog.get(PDFName.of('StructTreeRoot'))).toBeTruthy();
+    expect(reloaded.catalog.get(PDFName.of('MarkInfo'))).toBeTruthy();
+
+    // lifecycle: scaled the GPU up, staged+cleaned a temp object, re-armed idle
+    expect(deps.ensureUp).toHaveBeenCalledOnce();
+    expect(deps.uploadTemp).toHaveBeenCalledOnce();
+    expect(deps.detect).toHaveBeenCalledWith('s3://bucket/seam-c-temp/job.pdf', 'job1');
+    expect(deps.deleteTemp).toHaveBeenCalledWith('s3://bucket/seam-c-temp/job.pdf');
+    expect(deps.touchIdle).toHaveBeenCalledOnce();
+  });
+
+  it('throws SEAM_C_NO_ZONES when the detector returns nothing (temp still cleaned)', async () => {
+    const buf = await makeUntaggedPdf();
+    const deps = mockDeps({ detect: vi.fn(async () => ({ zones: [] })) });
+    await expect(svc.tagPdf(buf, 'job2', deps)).rejects.toThrow(/SEAM_C_NO_ZONES/);
+    expect(deps.deleteTemp).toHaveBeenCalledOnce();
+    expect(deps.touchIdle).toHaveBeenCalledOnce();
+  });
+
+  it('cleans up the temp object and re-arms idle even if detection throws', async () => {
+    const buf = await makeUntaggedPdf();
+    const deps = mockDeps({ detect: vi.fn(async () => { throw new Error('YOLO_TIMEOUT'); }) });
+    await expect(svc.tagPdf(buf, 'job3', deps)).rejects.toThrow(/YOLO_TIMEOUT/);
+    expect(deps.deleteTemp).toHaveBeenCalledOnce();
+    expect(deps.touchIdle).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Seam C — Phase 3 (worker integration, default tagger)

Wires the detector-driven tree-builder into the live accessibility worker so **Seam C is the default tagger for untagged PDFs**, with Adobe AutoTag as the fallback. This is the product driver realised — an in-house engine replacing the per-page third-party tagging spend.

### `seam-c-tag.service.ts` — the producer
`seamCTagService.tagPdf(buffer, jobId)` — a **peer of `adobeAutoTagService`** with the same return shape, so it drops into the worker's tag branch unchanged:
```
ensureYoloServiceUp → stage buffer to temp S3 key → detectWithYolo
  → mapYoloLabel → buildStructTreeFromZones → tagged buffer
```
- Temp S3 object is always removed and the idle timer re-armed (`finally`).
- Throws `SEAM_C_NO_ZONES` if the detector returns nothing; `buildStructTreeFromZones` throws `SEAM_C_ALREADY_TAGGED` on a pre-tagged doc.
- Detector / S3 seams are injectable → unit-testable without a live GPU.

### `ai.config.ts`
`aiConfig.seamC.enabled` — **on by default** when `YOLO_SERVICE_URL` is set; disable with `SEAM_C_ENABLED=false`.

### `accessibility.processor.ts`
Untagged branch runs **Seam C first**, falls back to Adobe on failure (if configured); `autoTagMeta.taggerSource` records which ran. Report/Word/elementCounts are `null` for Seam C (Adobe-only UI fields) and the existing save guards skip them — no other worker changes.

### Tests
3 producer unit tests (detect→build→Adobe-shaped result; `SEAM_C_NO_ZONES`; temp cleanup + idle re-arm on detector failure). 47 seam-c/producer tests total; tsc + eslint clean.

### Ops note
As the default, every untagged PDF triggers an on-demand YOLO detection — the first job after idle pays the GPU cold start (~6–7 min) via the scale-to-zero scaler; a batch stays warm. Worth deciding whether to keep the detector warm during business hours.

### Prior Phase-2 context
Builds on #435 (tree-builder) and #436 (veraPDF-driven fixes). veraPDF on a genuinely-untagged real PDF: passed checks 7.5k→239k (32×), failures −22%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Seam C as a detector-driven PDF auto-tagging option.
  * Seam C can automatically tag untagged PDFs and generate accessibility structure information.
  * Added environment-based configuration to enable or disable Seam C.

* **Bug Fixes**
  * Adobe AutoTag now serves as a fallback when Seam C is unavailable or encounters an error.
  * Temporary processing data is cleaned up even when tagging fails.

* **Tests**
  * Added coverage for successful tagging, missing detection zones, and detection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->