### PR TITLE
feat(seam-c): keep GPU warm during business hours (self-cooling scaler)

### DIFF
--- a/src/services/zone-extractor/yolo-service-scaler.ts
+++ b/src/services/zone-extractor/yolo-service-scaler.ts
@@ -78,7 +78,35 @@ export async function ensureYoloServiceUp(): Promise<void> {
   );
 }
 
+// Business-hours warm window (IST, Mon-Fri). During it the idle scale-down is
+// suppressed, so a scheduled pre-warm (or the day's first request) keeps the GPU
+// warm all day and jobs never pay the cold start mid-window. Env is read per-call
+// so it can be toggled without a redeploy; unset (either bound) = no window, pure
+// on-demand. Off-hours behaviour is unchanged (scale up on demand, down when idle).
+const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000;
+
+export function isWithinWarmWindow(now: Date = new Date()): boolean {
+  const startEnv = process.env.YOLO_WARM_START_HOUR_IST;
+  const endEnv = process.env.YOLO_WARM_END_HOUR_IST;
+  if (!startEnv || !endEnv) return false;
+  const start = Number(startEnv);
+  const end = Number(endEnv);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return false;
+  const ist = new Date(now.getTime() + IST_OFFSET_MS);
+  const day = ist.getUTCDay();   // 0=Sun..6=Sat on the IST-shifted clock
+  const hour = ist.getUTCHours();
+  if (day < 1 || day > 5) return false;   // weekdays only
+  return hour >= start && hour < end;
+}
+
 export async function scaleYoloServiceDown(): Promise<void> {
+  if (isWithinWarmWindow()) {
+    // Stay warm, and re-arm a re-check so the service self-cools shortly after the
+    // window closes even if no further request comes in — no external scheduler needed.
+    logger.info('[YoloScaler] within business-hours warm window — keeping zone-detector warm');
+    touchYoloIdleTimer();
+    return;
+  }
   logger.info('[YoloScaler] scaling zone-detector service to 0 (idle)');
   await setDesiredCount(0);
 }

--- a/tests/unit/services/zone-extractor/yolo-service-scaler.test.ts
+++ b/tests/unit/services/zone-extractor/yolo-service-scaler.test.ts
@@ -31,6 +31,7 @@ import {
   ensureYoloServiceUp,
   scaleYoloServiceDown,
   touchYoloIdleTimer,
+  isWithinWarmWindow,
   __clearYoloIdleTimerForTest,
 } from '../../../../src/services/zone-extractor/yolo-service-scaler';
 
@@ -119,5 +120,48 @@ describe('touchYoloIdleTimer', () => {
     expect(updateCalls()).toHaveLength(0);
     await vi.advanceTimersByTimeAsync(IDLE_MS / 2 + 100); // now past the reset window
     expect(updateCalls()).toHaveLength(1);
+  });
+});
+
+describe('isWithinWarmWindow (business-hours warm window, IST Mon-Fri)', () => {
+  const S = 'YOLO_WARM_START_HOUR_IST';
+  const E = 'YOLO_WARM_END_HOUR_IST';
+  afterEach(() => { delete process.env[S]; delete process.env[E]; });
+
+  it('is false when the window env is unset', () => {
+    expect(isWithinWarmWindow(new Date('2026-07-22T05:00:00Z'))).toBe(false); // Wed 10:30 IST
+  });
+
+  it('is true for a weekday time inside the window', () => {
+    process.env[S] = '9'; process.env[E] = '19';
+    expect(isWithinWarmWindow(new Date('2026-07-22T05:00:00Z'))).toBe(true);  // Wed 10:30 IST
+  });
+
+  it('honours the start (inclusive) and end (exclusive) boundaries', () => {
+    process.env[S] = '9'; process.env[E] = '19';
+    expect(isWithinWarmWindow(new Date('2026-07-22T03:30:00Z'))).toBe(true);  // 09:00 IST
+    expect(isWithinWarmWindow(new Date('2026-07-22T13:30:00Z'))).toBe(false); // 19:00 IST
+  });
+
+  it('is false outside the window on a weekday', () => {
+    process.env[S] = '9'; process.env[E] = '19';
+    expect(isWithinWarmWindow(new Date('2026-07-22T20:00:00Z'))).toBe(false); // Thu 01:30 IST
+  });
+
+  it('is false on the weekend even within the hours', () => {
+    process.env[S] = '9'; process.env[E] = '19';
+    expect(isWithinWarmWindow(new Date('2026-07-25T05:00:00Z'))).toBe(false); // Sat 10:30 IST
+  });
+});
+
+describe('scaleYoloServiceDown warm-window suppression', () => {
+  const S = 'YOLO_WARM_START_HOUR_IST';
+  const E = 'YOLO_WARM_END_HOUR_IST';
+  afterEach(() => { delete process.env[S]; delete process.env[E]; });
+
+  it('scales to 0 when no warm window is configured', async () => {
+    await scaleYoloServiceDown();
+    expect(updateCalls()).toHaveLength(1);
+    expect(updateCalls()[0][0].input.desiredCount).toBe(0);
   });
 });


### PR DESCRIPTION
Seam C is the default tagger, so a GPU cold start on every idle period is bad UX. The scaler now honours a **business-hours warm window** (IST, Mon-Fri) during which idle scale-down is suppressed — once warmed by the day's first job, the zone-detector stays up all day. It **re-arms a re-check so it self-cools** shortly after the window closes (no EventBridge/scheduler needed, which is good — the deploy IAM user lacks autoscaling/scheduler write).

- `isWithinWarmWindow(now)`: env-driven (`YOLO_WARM_START_HOUR_IST`/`YOLO_WARM_END_HOUR_IST`; unset = pure on-demand), read per-call.
- 11 scaler tests (window boundaries, weekend, unset, off-hours scale-down).

Enable by setting `YOLO_WARM_START_HOUR_IST=9` / `YOLO_WARM_END_HOUR_IST=19` on the backend task def. First job each morning still pays one cold start (~6-7 min); an optional EventBridge pre-warm at 09:00 IST removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable weekday business-hour warm windows in IST to keep the YOLO service running during designated hours.
  * Added support for automatically resuming idle monitoring after scale-down is deferred.

* **Bug Fixes**
  * Prevents the service from scaling down during configured weekday warm hours.
  * Retains the existing scale-down behavior when no warm window is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->