### PR TITLE
feat(seam-c): 2-D full-bbox content binding (coverage hardening)

### DIFF
--- a/src/services/zone-extractor/seam-c/content-stream.ts
+++ b/src/services/zone-extractor/seam-c/content-stream.ts
@@ -20,6 +20,9 @@ export interface ZoneBand {
   /** device-space (bottom-left origin) vertical extent; yTop > yBottom. */
   yTop: number;
   yBottom: number;
+  /** device-space horizontal extent (X is not Y-flipped): xLeft ≤ xRight. */
+  xLeft: number;
+  xRight: number;
   /** PDF tag for the BDC (e.g. 'P', 'H1'); artifacts use 'Artifact' with no MCID. */
   tag: string;
   isArtifact?: boolean;
@@ -112,21 +115,40 @@ export function tagContentStream(content: string, bands: ZoneBand[], startMcid =
   interface Unit { start: number; end: number; band: ZoneBand | null; }
   const units: Unit[] = [];
 
-  // graphics + text state (axis-aligned assumption: track scale d and translate f)
-  let ctm: { d: number; f: number } = { d: 1, f: 0 };
-  const ctmStack: Array<{ d: number; f: number }> = [];
+  // graphics + text state (axis-aligned assumption: track x/y scale + translate)
+  type Ctm = { a: number; d: number; e: number; f: number };
+  let ctm: Ctm = { a: 1, d: 1, e: 0, f: 0 };
+  const ctmStack: Ctm[] = [];
   let inText = false;
   let btStart = -1;
   let tld = 0;               // text leading (TL)
-  let tmF = 0;               // current text matrix f (baseline y, text space)
-  let firstShownY: number | null = null;
+  let tmE = 0;               // text matrix e (x, text space)
+  let tmF = 0;               // text matrix f (baseline y, text space)
+  let firstX: number | null = null;
+  let firstY: number | null = null;
   const operands: Token[] = [];
 
-  const deviceY = (textF: number): number => ctm.d * textF + ctm.f;
+  const deviceX = (tE: number): number => ctm.a * tE + ctm.e;
+  const deviceY = (tF: number): number => ctm.d * tF + ctm.f;
 
-  const bandFor = (y: number): ZoneBand | null => {
-    for (const b of bands) if (y <= b.yTop && y >= b.yBottom) return b;
-    return null;
+  // Full-bbox assignment: a text object's first-shown anchor (x, baseline y) must
+  // fall inside a zone's 2-D box; else the nearest zone within tolerance. The X test
+  // separates columns — baseline-Y alone can't tell a left-column line from a
+  // right-column line at the same height.
+  const NEAREST_TOL = 12;
+  const regionFor = (x: number, y: number): ZoneBand | null => {
+    for (const b of bands) {
+      if (x >= b.xLeft && x <= b.xRight && y <= b.yTop && y >= b.yBottom) return b;
+    }
+    let best: ZoneBand | null = null;
+    let bestDist = Infinity;
+    for (const b of bands) {
+      const dx = x < b.xLeft ? b.xLeft - x : x > b.xRight ? x - b.xRight : 0;
+      const dy = y > b.yTop ? y - b.yTop : y < b.yBottom ? b.yBottom - y : 0;
+      const dist = Math.hypot(dx, dy);
+      if (dist < bestDist) { bestDist = dist; best = b; }
+    }
+    return bestDist <= NEAREST_TOL ? best : null;
   };
 
   for (let k = 0; k < tokens.length; k++) {
@@ -135,33 +157,40 @@ export function tagContentStream(content: string, bands: ZoneBand[], startMcid =
     const op = tk.v;
     switch (op) {
       case 'q': ctmStack.push({ ...ctm }); break;
-      case 'Q': { const p = ctmStack.pop(); if (p) ctm = { d: p.d, f: p.f }; break; }
+      case 'Q': { const p = ctmStack.pop(); if (p) ctm = { ...p }; break; }
       case 'cm': {
-        // a b c d e f cm — compose (axis-aligned): new d *= d, new f = d*f_old + f
+        // a b c d e f cm — compose (axis-aligned)
+        const a = num(operands[operands.length - 6]);
         const d = num(operands[operands.length - 3]);
+        const e = num(operands[operands.length - 2]);
         const f = num(operands[operands.length - 1]);
-        ctm = { d: ctm.d * d, f: ctm.d * f + ctm.f };
+        ctm = { a: ctm.a * a, d: ctm.d * d, e: ctm.a * e + ctm.e, f: ctm.d * f + ctm.f };
         break;
       }
-      case 'BT': inText = true; btStart = tk.start; tmF = 0; firstShownY = null; break;
+      case 'BT': inText = true; btStart = tk.start; tmE = 0; tmF = 0; firstX = null; firstY = null; break;
       case 'TL': tld = num(operands[operands.length - 1]); break;
       case 'Td': case 'TD': {
+        const tx = num(operands[operands.length - 2]);
         const ty = num(operands[operands.length - 1]);
         if (op === 'TD') tld = -ty;
+        tmE += tx;
         tmF += ty;
         break;
       }
-      case 'Tm': tmF = num(operands[operands.length - 1]); break;   // a b c d e f
+      case 'Tm':                                                   // a b c d e f
+        tmE = num(operands[operands.length - 2]);
+        tmF = num(operands[operands.length - 1]);
+        break;
       case 'T*': tmF -= tld; break;
       case 'Tj': case 'TJ': case "'": case '"': {
-        if (op === "'" || op === '"') tmF -= tld;   // these move to next line first
-        if (firstShownY === null) firstShownY = deviceY(tmF);
+        if (op === "'" || op === '"') tmF -= tld;   // these move to the next line first
+        if (firstY === null) { firstX = deviceX(tmE); firstY = deviceY(tmF); }
         break;
       }
       case 'ET': {
         if (inText) {
-          const y = firstShownY;
-          units.push({ start: btStart, end: tk.end, band: y === null ? null : bandFor(y) });
+          const band = firstY === null ? null : regionFor(firstX as number, firstY);
+          units.push({ start: btStart, end: tk.end, band });
         }
         inText = false; btStart = -1;
         break;
@@ -194,7 +223,7 @@ export function tagContentStream(content: string, bands: ZoneBand[], startMcid =
   };
 
   // Text in no zone is still marked /Artifact — untagged content fails PDF/UA.
-  const ARTIFACT: ZoneBand = { zoneIndex: -1, tag: 'Artifact', isArtifact: true, yTop: 0, yBottom: 0 };
+  const ARTIFACT: ZoneBand = { zoneIndex: -1, tag: 'Artifact', isArtifact: true, yTop: 0, yBottom: 0, xLeft: 0, xRight: 0 };
   for (const u of units) {
     const band = u.band ?? ARTIFACT;
     if (run && run.band.zoneIndex === band.zoneIndex && !!run.band.isArtifact === !!band.isArtifact) {

--- a/src/services/zone-extractor/seam-c/struct-tree-builder.ts
+++ b/src/services/zone-extractor/seam-c/struct-tree-builder.ts
@@ -93,6 +93,8 @@ export function buildStructTreeFromZones(doc: PDFDocument, zones: OrderableZone[
         zoneIndex: m.index,
         yTop: H - z.bbox.y,
         yBottom: H - (z.bbox.y + z.bbox.h),
+        xLeft: z.bbox.x,
+        xRight: z.bbox.x + z.bbox.w,
         tag: m.tag,
         isArtifact: m.isArtifact,
       };

--- a/tests/unit/services/zone-extractor/seam-c/content-stream.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/content-stream.test.ts
@@ -50,8 +50,8 @@ describe('tokenize', () => {
 describe('tagContentStream', () => {
   // page height 200; two zones stacked. Line 1 baseline y=150, line 2 y=120.
   const bands: ZoneBand[] = [
-    { zoneIndex: 0, yTop: 165, yBottom: 140, tag: 'H1' },   // contains y=150
-    { zoneIndex: 1, yTop: 135, yBottom: 100, tag: 'P' },    // contains y=120
+    { zoneIndex: 0, yTop: 165, yBottom: 140, xLeft: 0, xRight: 1000, tag: 'H1' },   // contains y=150
+    { zoneIndex: 1, yTop: 135, yBottom: 100, xLeft: 0, xRight: 1000, tag: 'P' },    // contains y=120
   ];
 
   it('wraps each text object in its zone tag with a unique MCID', () => {
@@ -75,7 +75,7 @@ describe('tagContentStream', () => {
 
   it('merges consecutive same-zone text objects under one MCID', () => {
     // both lines fall in one wide band
-    const oneBand: ZoneBand[] = [{ zoneIndex: 0, yTop: 165, yBottom: 100, tag: 'P' }];
+    const oneBand: ZoneBand[] = [{ zoneIndex: 0, yTop: 165, yBottom: 100, xLeft: 0, xRight: 1000, tag: 'P' }];
     const { content, assignments } = tagContentStream(twoLineStream, oneBand);
     expect(assignments).toEqual([{ mcid: 0, zoneIndex: 0 }]);
     expect((content.match(/BDC/g) || []).length).toBe(1);
@@ -84,7 +84,7 @@ describe('tagContentStream', () => {
 
   it('marks text with no matching zone as Artifact (no MCID)', () => {
     const { content, assignments } = tagContentStream(twoLineStream, [
-      { zoneIndex: 0, yTop: 999, yBottom: 900, tag: 'P' }, // matches neither line
+      { zoneIndex: 0, yTop: 999, yBottom: 900, xLeft: 0, xRight: 1000, tag: 'P' }, // matches neither line
     ]);
     expect(assignments).toEqual([]);
     expect(content).toContain('/Artifact BMC');
@@ -98,11 +98,26 @@ describe('tagContentStream', () => {
 
   it('respects an artifact band (header/footer) with no MCID', () => {
     const { content, assignments } = tagContentStream(twoLineStream, [
-      { zoneIndex: 0, yTop: 165, yBottom: 140, tag: 'Artifact', isArtifact: true },
-      { zoneIndex: 1, yTop: 135, yBottom: 100, tag: 'P' },
+      { zoneIndex: 0, yTop: 165, yBottom: 140, xLeft: 0, xRight: 1000, tag: 'Artifact', isArtifact: true },
+      { zoneIndex: 1, yTop: 135, yBottom: 100, xLeft: 0, xRight: 1000, tag: 'P' },
     ]);
     expect(content).toContain('/Artifact BMC');
     expect(content).toContain('/P <</MCID 0>> BDC');
     expect(assignments).toEqual([{ mcid: 0, zoneIndex: 1 }]);
+  });
+
+  it('separates columns by X — two lines at the same Y go to different zones', () => {
+    // left line at x=50, right line at x=350, both baseline y=150
+    const twoCol = 'q BT 1 0 0 1 50 150 Tm <4C> Tj ET Q\nq BT 1 0 0 1 350 150 Tm <52> Tj ET Q\n';
+    const colBands: ZoneBand[] = [
+      { zoneIndex: 0, yTop: 160, yBottom: 140, xLeft: 30, xRight: 250, tag: 'P' },   // left column
+      { zoneIndex: 1, yTop: 160, yBottom: 140, xLeft: 300, xRight: 520, tag: 'P' },  // right column, same Y
+    ];
+    const { assignments } = tagContentStream(twoCol, colBands);
+    // baseline-Y alone would put both in zone 0; the X test splits them
+    expect(assignments).toEqual([
+      { mcid: 0, zoneIndex: 0 },
+      { mcid: 1, zoneIndex: 1 },
+    ]);
   });
 });


### PR DESCRIPTION
## Seam C — coverage hardening: 2-D content binding

The content-stream tagger assigned each text object to a zone by **baseline-Y alone** (a vertical band). That can't distinguish a left-column line from a right-column line at the same height, and a baseline just outside a band bound nothing — so on a dense multi-column doc ~half the content went unbound.

Assignment is now **2-D**: the text object's first-shown anchor `(x, baseline y)` must fall inside a zone's **full box**, else the **nearest zone within tolerance** (12 pt).
- Track text X (CTM a/e + text-matrix e via Tm/Td); `deviceX = a·e_text + e`.
- `ZoneBand` gains `xLeft`/`xRight` (X isn't Y-flipped); `struct-tree-builder` fills them from the zone bbox.
- Nearest-zone fallback recovers baseline-vs-bbox near-misses.

### Impact (real doc: Math_Nikitopoulos, 1556 zones, genuinely untagged)
**MCID content bindings 689 → 1145 (+66%)** on the same 1786 structure elements — content the baseline-Y approach missed (columns + near-misses) is now bound.

### Tests
New column-separation test (two lines at one Y → different zones). 45 seam-c tests; tsc + eslint clean.

### Still open
Multi-column *reading order* refinement, image `OBJR` binding, alt text, `/Lang`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zone detection for text by considering both horizontal and vertical positioning.
  * Correctly distinguishes content in separate columns even when they share the same baseline.
  * Preserves accurate handling of artifact regions such as headers and footers.

* **Tests**
  * Added coverage for two-dimensional zone assignment and column separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->