### PR TITLE
feat(seam-c): set /Lang + /Tabs=S (metadata hardening)

### DIFF
--- a/src/services/zone-extractor/seam-c/struct-tree-builder.ts
+++ b/src/services/zone-extractor/seam-c/struct-tree-builder.ts
@@ -1,5 +1,5 @@
 import {
-  PDFDocument, PDFName, PDFNumber, PDFRef, PDFArray, PDFDict, PDFRawStream, PDFObject,
+  PDFDocument, PDFName, PDFNumber, PDFString, PDFRef, PDFArray, PDFDict, PDFRawStream, PDFObject,
   decodePDFRawStream,
 } from 'pdf-lib';
 import { synthesizeReadingOrder, type OrderableZone } from './reading-order';
@@ -48,7 +48,11 @@ function pageContent(doc: PDFDocument, pageNode: { get(n: PDFName): PDFObject | 
   return parts.join('\n');
 }
 
-export function buildStructTreeFromZones(doc: PDFDocument, zones: OrderableZone[]): BuildResult {
+export function buildStructTreeFromZones(
+  doc: PDFDocument,
+  zones: OrderableZone[],
+  lang = 'en-US',
+): BuildResult {
   if (zones.length === 0) return { elements: 0, mcids: 0, pages: 0 };
 
   // Seam C only tags GENUINELY untagged PDFs. Running on a doc that already has a
@@ -210,9 +214,14 @@ export function buildStructTreeFromZones(doc: PDFDocument, zones: OrderableZone[
   rootObj.set(PDFName.of('ParentTree'), parentTreeRef);
   rootObj.set(PDFName.of('ParentTreeNextKey'), PDFNumber.of(pages.length));
 
-  // ── catalog: /StructTreeRoot + /MarkInfo <</Marked true>>
+  // ── catalog: /StructTreeRoot + /MarkInfo + /Lang; /Tabs=S on every page.
+  // /Lang alone clears veraPDF 7.2-34 ("natural language cannot be determined")
+  // for all page text — the single biggest metadata win. /Tabs=S makes tab order
+  // follow structure (required on pages carrying annotations, 7.18.3).
   doc.catalog.set(PDFName.of('StructTreeRoot'), rootRef);
   doc.catalog.set(PDFName.of('MarkInfo'), doc.context.obj({ Marked: true }));
+  doc.catalog.set(PDFName.of('Lang'), PDFString.of(lang));
+  for (const page of pages) page.node.set(PDFName.of('Tabs'), PDFName.of('S'));
 
   return { elements: elemCount, mcids: mcidCount, pages: zonesByPage.size };
 }

--- a/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
@@ -50,6 +50,9 @@ describe('buildStructTreeFromZones (end-to-end)', () => {
     expect(catalog.get(PDFName.of('StructTreeRoot'))).toBeTruthy();
     const markInfo = reloaded.context.lookup(catalog.get(PDFName.of('MarkInfo'))) as PDFDict;
     expect(markInfo.get(PDFName.of('Marked'))).toBe(PDFBool.True);
+    // /Lang (clears veraPDF 7.2-34) and /Tabs=S on the page
+    expect(catalog.get(PDFName.of('Lang'))?.toString()).toContain('en-US');
+    expect(reloaded.getPage(0).node.get(PDFName.of('Tabs'))?.toString()).toBe('/S');
 
     // content stream carries MCID marked content
     const page = reloaded.getPage(0);


### PR DESCRIPTION
## Seam C — metadata hardening (/Lang + /Tabs)

**Priorities corrected by data.** A veraPDF rule-description capture showed there are **no table failures in the top list** — `7.21.7` is a **font** rule (ISO 14289-1 §7.21=Fonts, §7.5=Tables), so the earlier 'coarse Table>TR>TD' concern was a misdiagnosis. The real top failures were untagged content (7.1-3) and **missing document language** (7.2-34, 17,900 fails).

- **/Lang** on the catalog (default `en-US`, param on `buildStructTreeFromZones`) → clears veraPDF **7.2-34** ('natural language cannot be determined') for all page text.
- **/Tabs=S** on every page (tab order follows structure; required on annotated pages, 7.18.3).

### veraPDF (Math_Nikitopoulos), cumulative
| Stage | Passed | Failed |
|---|---|---|
| Untagged | 7,507 | 88,936 |
| + tree/MCID | 239,365 | 69,669 |
| + 2-D binding | 277,665 | 63,314 |
| **+ /Lang + /Tabs** | **295,804** | **45,176** |

**−49% failures vs untagged, 39× passing checks.** Distinct failed rules 14→10.

e2e test asserts /Lang + /Tabs. 45 seam-c tests; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tagged PDFs now include language metadata, defaulting to English (US).
  * PDF pages now include structured tab-order metadata to improve accessibility and navigation.

* **Bug Fixes**
  * Improved compatibility with PDF readers and accessibility tools that rely on document language and tab-order information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->