### PR TITLE
feat(seam-c): mark images + paths (non-text content coverage)

### DIFF
--- a/src/services/zone-extractor/seam-c/content-stream.ts
+++ b/src/services/zone-extractor/seam-c/content-stream.ts
@@ -126,6 +126,7 @@ export function tagContentStream(content: string, bands: ZoneBand[], startMcid =
   let tmF = 0;               // text matrix f (baseline y, text space)
   let firstX: number | null = null;
   let firstY: number | null = null;
+  let pathStart: number | null = null;   // offset of the current path's first op
   const operands: Token[] = [];
 
   const deviceX = (tE: number): number => ctm.a * tE + ctm.e;
@@ -149,6 +150,15 @@ export function tagContentStream(content: string, bands: ZoneBand[], startMcid =
       if (dist < bestDist) { bestDist = dist; best = b; }
     }
     return bestDist <= NEAREST_TOL ? best : null;
+  };
+
+  // Images bind only to a FIGURE zone they sit inside; otherwise they're Artifacts.
+  const figureFor = (x: number, y: number): ZoneBand | null => {
+    for (const b of bands) {
+      if (b.tag === 'Figure' && !b.isArtifact &&
+          x >= b.xLeft && x <= b.xRight && y <= b.yTop && y >= b.yBottom) return b;
+    }
+    return null;
   };
 
   for (let k = 0; k < tokens.length; k++) {
@@ -195,6 +205,28 @@ export function tagContentStream(content: string, bands: ZoneBand[], startMcid =
         inText = false; btStart = -1;
         break;
       }
+
+      // ── non-text content must also be marked, or it fails PDF/UA 7.1-3 ──
+      case 'Do': {
+        // XObject paint. Position = the unit square [0,1]² transformed by the CTM.
+        const band = figureFor(ctm.e + ctm.a / 2, ctm.f + ctm.d / 2); // Figure or (null →) Artifact
+        const start = operands.length ? operands[operands.length - 1].start : tk.start; // include the /Name
+        units.push({ start, end: tk.end, band });
+        break;
+      }
+      case 'sh': {                                         // shading fill → Artifact
+        const start = operands.length ? operands[operands.length - 1].start : tk.start;
+        units.push({ start, end: tk.end, band: null });
+        break;
+      }
+      case 'm': case 're': case 'l': case 'c': case 'v': case 'y': case 'h':
+        if (pathStart === null) pathStart = operands.length ? operands[0].start : tk.start;
+        break;
+      case 'f': case 'F': case 'f*': case 'S': case 's': case 'B': case 'B*': case 'b': case 'b*':
+        if (pathStart !== null) { units.push({ start: pathStart, end: tk.end, band: null }); pathStart = null; }
+        break;
+      case 'n': pathStart = null; break;                   // path used for clipping — not painted content
+
       default: break;
     }
     operands.length = 0;

--- a/tests/unit/services/zone-extractor/seam-c/content-stream.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/content-stream.test.ts
@@ -120,4 +120,27 @@ describe('tagContentStream', () => {
       { mcid: 1, zoneIndex: 1 },
     ]);
   });
+
+  it('marks an image inside a figure zone as Figure, and a painted path as Artifact', () => {
+    // image drawn by `cm /Im0 Do` at center (100,440); a filled rect; a clip path
+    const stream = 'q 100 0 0 80 50 400 cm /Im0 Do Q\n50 50 200 100 re f\n10 10 30 30 re W n\n';
+    const bands: ZoneBand[] = [
+      { zoneIndex: 3, yTop: 480, yBottom: 400, xLeft: 40, xRight: 160, tag: 'Figure' },
+    ];
+    const { content, assignments } = tagContentStream(stream, bands);
+    expect(content).toContain('/Figure <</MCID 0>> BDC'); // image → Figure, bound to the figure zone
+    expect(content).toContain('/Im0 Do');
+    expect(assignments).toEqual([{ mcid: 0, zoneIndex: 3 }]);
+    expect((content.match(/BMC/g) || []).length).toBe(1); // only the painted fill; the clip (re W n) is not content
+  });
+
+  it('marks an image outside any figure zone as Artifact (no MCID)', () => {
+    const stream = 'q 100 0 0 80 50 400 cm /Im0 Do Q\n';
+    const { content, assignments } = tagContentStream(stream, [
+      { zoneIndex: 0, yTop: 480, yBottom: 400, xLeft: 40, xRight: 160, tag: 'P' }, // not a Figure
+    ]);
+    expect(assignments).toEqual([]);
+    expect(content).toContain('/Artifact BMC');
+    expect(content).toContain('/Im0 Do');
+  });
 });


### PR DESCRIPTION
## Seam C — non-text content coverage (the 40k lever)

The tagger only marked **text**, so images and vector graphics read as **untagged content** — the single dominant PDF/UA failure (`7.1-3`, ~40k on the test doc). Now every content-producing operator is marked:

- **Images** (`Do`): positioned from the CTM (unit square × CTM). Inside a **figure zone** → `Figure` with an MCID bound to the figure StructElem; otherwise `Artifact`.
- **Painted paths** (`re`/`m`/`l`/… then `f`/`S`/`B`/…) → `Artifact`. **Clip paths** (`… W n`) are correctly left unmarked (not painted content). **Shadings** (`sh`) → `Artifact`.

### veraPDF (Math_Nikitopoulos) — cumulative
| Stage | Passed | Failed |
|---|---|---|
| Untagged | 7,507 | 88,936 |
| + tree/MCID | 239,365 | 69,669 |
| + 2-D binding (#439) | 277,665 | 63,314 |
| + XY-cut (#440) | — | 63,314 |
| + /Lang + /Tabs (#441) | 295,804 | 45,176 |
| **+ non-text coverage** | **350,610** | **4,660** |

**`7.1-3` untagged content 40,688 → 152 (−99.6%).** Cumulative vs untagged: **failures −95%, passing checks 47×.** No new nesting/MCID errors (distinct failed rules held at 10). The remaining ~4,660 is **87% link annotations** (`7.18.x`), plus source-PDF font issues (`7.21.7`).

### Tests
4 new (image→Figure, image→Artifact, path→Artifact, clip-not-marked). 47 seam-c tests; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved tagging of images, shading, and drawn paths in document content.
  - Images within figure regions are now identified as figures with accessibility metadata.
  - Decorative or non-figure drawing elements are labeled as artifacts.

- **Bug Fixes**
  - Improved handling of clipping paths so they are not incorrectly counted as visible content.
  - Enhanced content tagging consistency for complex drawing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->