### PR TITLE
feat(seam-c): tag Link annotations (7.18.x)

### DIFF
--- a/src/services/zone-extractor/seam-c/struct-tree-builder.ts
+++ b/src/services/zone-extractor/seam-c/struct-tree-builder.ts
@@ -48,6 +48,17 @@ function pageContent(doc: PDFDocument, pageNode: { get(n: PDFName): PDFObject | 
   return parts.join('\n');
 }
 
+/** Alt description for a link: its URI action if present, else a generic label. */
+function linkDescription(doc: PDFDocument, annot: PDFDict): string {
+  const a = annot.get(PDFName.of('A'));
+  const action = a instanceof PDFRef ? doc.context.lookup(a) : a;
+  if (action instanceof PDFDict) {
+    const uri = action.get(PDFName.of('URI'));
+    if (uri instanceof PDFString) return uri.decodeText();
+  }
+  return 'Link';
+}
+
 export function buildStructTreeFromZones(
   doc: PDFDocument,
   zones: OrderableZone[],
@@ -201,6 +212,38 @@ export function buildStructTreeFromZones(
 
   const docKids: PDFRef[] = [];
   for (const node of forest) { const r = build(node, docRef); if (r) docKids.push(r); }
+
+  // ── Link annotations → a Link StructElem with an OBJR + a /Contents alt, wired
+  // into the ParentTree. Clears veraPDF 7.18.5-1 (annotation tagged as Link),
+  // 7.18.5-2 / 7.18.1-2 (link has an alternate description via /Contents).
+  let nextKey = pages.length;   // annotation /StructParent keys follow the page keys
+  const annotEntries: Array<{ key: number; ref: PDFRef }> = [];
+  pages.forEach((page) => {
+    const annotsRaw = page.node.get(PDFName.of('Annots'));
+    const annots = annotsRaw instanceof PDFRef ? doc.context.lookup(annotsRaw) : annotsRaw;
+    if (!(annots instanceof PDFArray)) return;
+    for (let i = 0; i < annots.size(); i++) {
+      const annotRef = annots.get(i);
+      if (!(annotRef instanceof PDFRef)) continue;
+      const annot = doc.context.lookup(annotRef);
+      if (!(annot instanceof PDFDict)) continue;
+      const subtype = annot.get(PDFName.of('Subtype'));
+      if (!(subtype instanceof PDFName) || subtype.decodeText() !== 'Link') continue;
+
+      if (!annot.get(PDFName.of('Contents'))) {
+        annot.set(PDFName.of('Contents'), PDFString.of(linkDescription(doc, annot)));
+      }
+      const link = makeElem('Link', docRef);
+      const objr = doc.context.obj({ Type: PDFName.of('OBJR'), Obj: annotRef, Pg: page.ref });
+      setKids(link.dict, [doc.context.register(objr)]);
+      docKids.push(link.ref);
+
+      const key = nextKey++;
+      annot.set(PDFName.of('StructParent'), PDFNumber.of(key));
+      annotEntries.push({ key, ref: link.ref });
+    }
+  });
+
   setKids(docObj, docKids);
 
   // ── /ParentTree number tree (flat Nums: [key, [refs...], ...])
@@ -209,10 +252,12 @@ export function buildStructTreeFromZones(
     const arr = slots.map((r) => (r ?? doc.context.obj({})) as PDFObject); // dense over MCIDs
     nums.push(PDFNumber.of(pageIdx), doc.context.obj(arr));
   }
+  // Annotation keys follow the page keys (ascending), each mapping to its Link elem.
+  for (const { key, ref } of annotEntries) nums.push(PDFNumber.of(key), ref);
   const parentTreeObj = doc.context.obj({ Nums: doc.context.obj(nums) });
   const parentTreeRef = doc.context.register(parentTreeObj);
   rootObj.set(PDFName.of('ParentTree'), parentTreeRef);
-  rootObj.set(PDFName.of('ParentTreeNextKey'), PDFNumber.of(pages.length));
+  rootObj.set(PDFName.of('ParentTreeNextKey'), PDFNumber.of(nextKey));
 
   // ── catalog: /StructTreeRoot + /MarkInfo + /Lang; /Tabs=S on every page.
   // /Lang alone clears veraPDF 7.2-34 ("natural language cannot be determined")

--- a/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PDFDocument, StandardFonts, PDFName, PDFDict, PDFBool, PDFRawStream, decodePDFRawStream } from 'pdf-lib';
+import { PDFDocument, StandardFonts, PDFName, PDFDict, PDFBool, PDFString, PDFArray, PDFRawStream, decodePDFRawStream } from 'pdf-lib';
 import { buildStructTreeFromZones } from '../../../../../src/services/zone-extractor/seam-c/struct-tree-builder';
 import { serializeStructTreeAsync } from '../../../../../src/services/zone-extractor/struct-tree-serializer';
 import type { OrderableZone } from '../../../../../src/services/zone-extractor/seam-c/reading-order';
@@ -83,6 +83,31 @@ describe('buildStructTreeFromZones (end-to-end)', () => {
     const firstLi = list.children![0];
     expect((firstLi.children || []).map((c) => c.tag)).toEqual(['LBody']);
     expect(firstLi.children![0].mcids).toEqual([3]);
+  });
+
+  it('tags a Link annotation as a Link element with an OBJR and /Contents', async () => {
+    const doc = await PDFDocument.load(await makeUntaggedPdf());
+    const page = doc.getPage(0);
+    const linkRef = doc.context.register(doc.context.obj({
+      Type: PDFName.of('Annot'), Subtype: PDFName.of('Link'),
+      Rect: doc.context.obj([50, 40, 150, 60]),
+      A: doc.context.obj({ S: PDFName.of('URI'), URI: PDFString.of('https://example.com') }),
+    }));
+    page.node.set(PDFName.of('Annots'), doc.context.obj([linkRef]));
+
+    buildStructTreeFromZones(doc, ZONES);
+    const tagged = await doc.save();
+
+    // a Link element now sits under the Document
+    const { tree } = await serializeStructTreeAsync(tagged as unknown as Parameters<typeof serializeStructTreeAsync>[0]);
+    expect((tree[0].children || []).map((c) => c.tag)).toContain('Link');
+
+    // the annotation gained a /Contents alt (the URI) and a /StructParent
+    const reloaded = await PDFDocument.load(tagged);
+    const annots = reloaded.context.lookup(reloaded.getPage(0).node.get(PDFName.of('Annots'))) as PDFArray;
+    const annot = reloaded.context.lookup(annots.get(0)) as PDFDict;
+    expect(annot.get(PDFName.of('Contents'))?.toString()).toContain('example.com');
+    expect(annot.get(PDFName.of('StructParent'))).toBeTruthy();
   });
 
   it('refuses a PDF that already has a /StructTreeRoot (no double-tagging)', async () => {


### PR DESCRIPTION
## Seam C — Link annotation tagging

Each `/Link` annotation becomes a **Link StructElem** with an **OBJR** to the annotation and a **/Contents** alt description (its URI, else 'Link'), wired into the ParentTree via the annotation's `/StructParent`. Clears veraPDF **7.18.5-1** (annotation tagged as Link), **7.18.5-2** and **7.18.1-2** (link alternate description).

### veraPDF (Math_Nikitopoulos)
The three `7.18.x` rules (**4,050 failures**) are gone → total **failed 4,660 → 610**. Build 1,786 → 3,136 elements (+1,350 Link elems). **Cumulative vs untagged: failures 88,936 → 610 (−99.3%).**

Remaining 610: source-PDF font ToUnicode (253, not fixable by us), figure/formula alt (189 — downstream AI alt-text), untagged remainder (152), heading-skip + doc-title + PDF/UA-metadata (16, next PR).

New link-tagging test (Link element + OBJR + /Contents + /StructParent). 48 seam-c tests; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)