### PR TITLE
feat(seam-c): heading sequence + DisplayDocTitle + PDF/UA metadata

### DIFF
--- a/src/services/zone-extractor/seam-c/canonical-to-tag.ts
+++ b/src/services/zone-extractor/seam-c/canonical-to-tag.ts
@@ -107,5 +107,13 @@ export function inferHeadingLevels(
     heightToLevel.set(h, level);
   }
 
-  return headers.map((h) => heightToLevel.get(h.bbox.h) as number);
+  // PDF/UA (7.4.2): the first heading must be H1 and levels must not skip in a
+  // descending sequence. Clamp each heading (in reading order) to ≤ previous+1.
+  let prev = 0;
+  return headers.map((h) => {
+    const raw = heightToLevel.get(h.bbox.h) as number;
+    const lvl = Math.max(1, Math.min(raw, prev + 1));
+    prev = lvl;
+    return lvl;
+  });
 }

--- a/src/services/zone-extractor/seam-c/struct-tree-builder.ts
+++ b/src/services/zone-extractor/seam-c/struct-tree-builder.ts
@@ -48,6 +48,32 @@ function pageContent(doc: PDFDocument, pageNode: { get(n: PDFName): PDFObject | 
   return parts.join('\n');
 }
 
+// PDF/UA-1 identifier, injected into (or as) the XMP metadata packet (veraPDF 5-1).
+const PDFUA_DESC =
+  '<rdf:Description rdf:about="" xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/"><pdfuaid:part>1</pdfuaid:part></rdf:Description>';
+const MINIMAL_XMP =
+  '<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>' +
+  '<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">' +
+  PDFUA_DESC + '</rdf:RDF></x:xmpmeta><?xpacket end="w"?>';
+
+/** Declare the file as PDF/UA-1 in XMP — merging into existing metadata if present. */
+function setPdfUaIdentifier(doc: PDFDocument): void {
+  const existing = doc.catalog.get(PDFName.of('Metadata'));
+  const stream = existing instanceof PDFRef ? doc.context.lookup(existing) : existing;
+  let xmp: string | null = null;
+  if (stream instanceof PDFRawStream) {
+    try { xmp = Buffer.from(decodePDFRawStream(stream).decode()).toString('utf8'); } catch { /* */ }
+  }
+  if (xmp && xmp.includes('pdfuaid:part')) return;   // already declared
+  const next = xmp && xmp.includes('</rdf:RDF>')
+    ? xmp.replace('</rdf:RDF>', `${PDFUA_DESC}</rdf:RDF>`)
+    : MINIMAL_XMP;
+  const s = doc.context.flateStream(Buffer.from(next, 'utf8')) as PDFRawStream;
+  s.dict.set(PDFName.of('Type'), PDFName.of('Metadata'));
+  s.dict.set(PDFName.of('Subtype'), PDFName.of('XML'));
+  doc.catalog.set(PDFName.of('Metadata'), doc.context.register(s));
+}
+
 /** Alt description for a link: its URI action if present, else a generic label. */
 function linkDescription(doc: PDFDocument, annot: PDFDict): string {
   const a = annot.get(PDFName.of('A'));
@@ -267,6 +293,15 @@ export function buildStructTreeFromZones(
   doc.catalog.set(PDFName.of('MarkInfo'), doc.context.obj({ Marked: true }));
   doc.catalog.set(PDFName.of('Lang'), PDFString.of(lang));
   for (const page of pages) page.node.set(PDFName.of('Tabs'), PDFName.of('S'));
+
+  // /ViewerPreferences /DisplayDocTitle=true (7.1-10) — show the title, not the filename.
+  const vpRaw = doc.catalog.get(PDFName.of('ViewerPreferences'));
+  const vp = vpRaw instanceof PDFRef ? doc.context.lookup(vpRaw) : vpRaw;
+  if (vp instanceof PDFDict) vp.set(PDFName.of('DisplayDocTitle'), doc.context.obj(true));
+  else doc.catalog.set(PDFName.of('ViewerPreferences'), doc.context.obj({ DisplayDocTitle: true }));
+
+  // Declare PDF/UA-1 conformance in XMP (5-1).
+  setPdfUaIdentifier(doc);
 
   return { elements: elemCount, mcids: mcidCount, pages: zonesByPage.size };
 }

--- a/tests/unit/services/zone-extractor/seam-c/canonical-to-tag.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/canonical-to-tag.test.ts
@@ -74,13 +74,17 @@ describe('inferHeadingLevels', () => {
     expect(levels).toEqual([1, 2, 3]);
   });
 
-  it('preserves input order when heights are scrambled', () => {
+  it('never skips a level in reading order and starts at H1', () => {
+    // heights in order [small, large, medium] would be [3,1,2] by height alone;
+    // the sequential clamp (first=H1, ≤prev+1) makes it [1,1,2] — no skips.
     const levels = inferHeadingLevels([
       { bbox: { x: 0, y: 0, w: 100, h: 12 } }, // smallest
       { bbox: { x: 0, y: 0, w: 100, h: 30 } }, // largest
       { bbox: { x: 0, y: 0, w: 100, h: 20 } }, // middle
     ]);
-    expect(levels).toEqual([3, 1, 2]);
+    expect(levels).toEqual([1, 1, 2]);
+    // no gap greater than +1 anywhere in the sequence
+    for (let i = 1; i < levels.length; i++) expect(levels[i] - levels[i - 1]).toBeLessThanOrEqual(1);
   });
 
   it('groups near-equal heights into one level', () => {

--- a/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
@@ -53,6 +53,10 @@ describe('buildStructTreeFromZones (end-to-end)', () => {
     // /Lang (clears veraPDF 7.2-34) and /Tabs=S on the page
     expect(catalog.get(PDFName.of('Lang'))?.toString()).toContain('en-US');
     expect(reloaded.getPage(0).node.get(PDFName.of('Tabs'))?.toString()).toBe('/S');
+    // ViewerPreferences/DisplayDocTitle (7.1-10) and PDF/UA XMP metadata (5-1)
+    const vp = reloaded.context.lookup(catalog.get(PDFName.of('ViewerPreferences'))) as PDFDict;
+    expect(vp.get(PDFName.of('DisplayDocTitle'))).toBe(PDFBool.True);
+    expect(catalog.get(PDFName.of('Metadata'))).toBeTruthy();
 
     // content stream carries MCID marked content
     const page = reloaded.getPage(0);


### PR DESCRIPTION
## Seam C — structural + metadata hardening

The three **genuinely Seam-C-fixable** items from the remaining failures:

- **Heading levels (7.4.2-1):** `inferHeadingLevels` now enforces a sequential reading-order sequence — first heading is **H1** and levels never skip (clamp each to ≤ previous+1). Bbox-height alone could jump H1→H5.
- **/ViewerPreferences /DisplayDocTitle=true (7.1-10)** — show the title, not the filename (merges into an existing dict).
- **PDF/UA-1 identifier in XMP metadata (5-1)** — declares conformance, merging the `pdfuaid` schema into existing metadata (or a minimal packet if none).

### veraPDF (Math_Nikitopoulos)
7.4.2-1 (14), 7.1-10 (1), 5-1 (1) all cleared → **failed 610 → 594**. Cumulative vs untagged: **88,936 → 594 (−99.3%)**.

### The remaining 594 are NOT structure (and not Seam C's job)
- **Fonts** — `7.21.7` (253): source-PDF glyphs with no ToUnicode. A **font-remediation** concern (Matterhorn CP31), not structure tagging — requires synthesizing ToUnicode from embedded font programs (hard, esp. math fonts).
- **Figure/formula alt** — `7.3-1`/`7.7-1` (189): Figures and Formulas need Alt/ActualText — supplied by the **downstream AI alt-text flow**, which runs on Seam-C output.
- **Untagged remainder** — `7.1-3` (152): long tail (inline images, form XObjects, edge ops).

51 seam-c tests; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved heading structure so headings follow a logical hierarchy and begin at H1.
  * Added PDF/UA-1 conformance metadata to generated documents.
  * Enabled display of the document title in PDF viewers.

* **Tests**
  * Added validation for heading order, PDF/UA metadata, and document title display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->