### PR TITLE
feat(seam-c): MCID-exact alt-text targeting (#1)

### DIFF
--- a/src/services/pdf/pdf-modifier.service.ts
+++ b/src/services/pdf/pdf-modifier.service.ts
@@ -5,7 +5,7 @@
  * Handles metadata modifications, structure changes, and backup/rollback
  */
 
-import { PDFDocument, PDFName, PDFString, PDFBool, PDFDict, PDFArray, PDFRef, PDFRawStream } from 'pdf-lib';
+import { PDFDocument, PDFName, PDFString, PDFBool, PDFDict, PDFArray, PDFRef, PDFNumber, PDFRawStream, decodePDFRawStream } from 'pdf-lib';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
@@ -646,7 +646,17 @@ export class PdfModifierService {
         return pg && pg.toString() === pageRef.toString();
       });
 
+      // MCID-exact first: for a detector-tagged tree (Seam C), the image's XObject
+      // is bound to a specific MCID and the Figure's /K references that MCID — so we
+      // can hit the exact Figure instead of guessing by page position. Falls back to
+      // positional matching for trees without that binding (e.g. Adobe-tagged).
+      const xObjectName = imageId.match(/^img_p\d+_\d+_(.+)$/)?.[1];
+      const exact = xObjectName
+        ? this.findFigureByImageMcid(doc, figuresOnPage, targetPage, xObjectName)
+        : null;
+
       let target: PDFDict | undefined =
+        exact ??
         figuresOnPage[targetIndex] ??
         figuresOnPage[0] ??
         figures[targetIndex] ??
@@ -679,6 +689,81 @@ export class PdfModifierService {
         description: 'Failed to set alt text',
         error: error instanceof Error ? error.message : String(error),
       };
+    }
+  }
+
+  /**
+   * MCID-exact figure match: find the MCID that marks `xObjectName`'s image on the
+   * page, then the Figure whose /K references that MCID. Returns null if the tree
+   * isn't MCID-bound (positional matching then applies).
+   */
+  private findFigureByImageMcid(
+    doc: PDFDocument,
+    figuresOnPage: PDFDict[],
+    targetPage: number,
+    xObjectName: string,
+  ): PDFDict | null {
+    const mcid = this.mcidForXObject(doc, targetPage, xObjectName);
+    if (mcid === null) return null;
+    const matchesMcid = (k: unknown): boolean => {
+      if (k instanceof PDFNumber) return k.asNumber() === mcid;
+      if (k instanceof PDFArray) {
+        for (let i = 0; i < k.size(); i++) {
+          const item = k.get(i);
+          if (item instanceof PDFNumber && item.asNumber() === mcid) return true;
+          if (item instanceof PDFDict) {
+            const m = item.get(PDFName.of('MCID'));
+            if (m instanceof PDFNumber && m.asNumber() === mcid) return true;
+          }
+        }
+      }
+      return false;
+    };
+    return figuresOnPage.find((fig) => matchesMcid(fig.get(PDFName.of('K')))) ?? null;
+  }
+
+  /** MCID of the marked-content sequence enclosing `/xObjectName Do` on the page. */
+  private mcidForXObject(doc: PDFDocument, targetPage: number, xObjectName: string): number | null {
+    const content = this.decodePageContent(doc, targetPage);
+    if (!content) return null;
+    // BDC(with MCID) | BMC | EMC | `/name Do` — walk in source order tracking the MCID stack.
+    const re = /<<\s*\/MCID\s+(\d+)\s*>>\s*BDC|\/[\w.#+-]+\s+BMC|\bEMC\b|\/([\w.#+-]+)\s+Do\b/g;
+    const stack: number[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(content)) !== null) {
+      if (m[1] !== undefined) stack.push(Number(m[1]));       // BDC with /MCID
+      else if (m[2] !== undefined) {                          // `/name Do`
+        if (m[2] === xObjectName) {
+          for (let i = stack.length - 1; i >= 0; i--) if (stack[i] >= 0) return stack[i];
+          return null;
+        }
+      } else if (/BMC$/.test(m[0])) stack.push(-1);           // artifact BMC (no MCID)
+      else stack.pop();                                       // EMC
+    }
+    return null;
+  }
+
+  /** Decode a page's content stream(s) to a single string (latin1). */
+  private decodePageContent(doc: PDFDocument, targetPage: number): string | null {
+    try {
+      const page = doc.getPage(targetPage - 1);
+      const raw = page.node.get(PDFName.of('Contents'));
+      const resolve = (o: unknown): unknown => (o instanceof PDFRef ? doc.context.lookup(o) : o);
+      const c = resolve(raw);
+      const streams = c instanceof PDFArray
+        ? Array.from({ length: c.size() }, (_, i) => resolve(c.get(i)))
+        : [c];
+      let out = '';
+      for (const s of streams) {
+        let bytes: Uint8Array | null = null;
+        const anyS = s as { decode?: () => Uint8Array };
+        if (anyS && typeof anyS.decode === 'function') { try { bytes = anyS.decode(); } catch { /* */ } }
+        if (!bytes && s instanceof PDFRawStream) { try { bytes = decodePDFRawStream(s).decode(); } catch { /* */ } }
+        if (bytes) out += Buffer.from(bytes).toString('latin1');
+      }
+      return out;
+    } catch {
+      return null;
     }
   }
 

--- a/tests/unit/services/pdf/pdf-modifier-alt-mcid.test.ts
+++ b/tests/unit/services/pdf/pdf-modifier-alt-mcid.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { PDFDocument, PDFName, PDFString, PDFDict, PDFArray, PDFRef, decodePDFRawStream, PDFRawStream } from 'pdf-lib';
+import { pdfModifierService } from '../../../../src/services/pdf/pdf-modifier.service';
+import { buildStructTreeFromZones } from '../../../../src/services/zone-extractor/seam-c/struct-tree-builder';
+import type { OrderableZone } from '../../../../src/services/zone-extractor/seam-c/reading-order';
+
+// 1×1 PNG (base64 → bytes without Buffer, which isn't in the test tsconfig scope)
+const PNG = Uint8Array.from(
+  atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC'),
+  (c) => c.charCodeAt(0),
+);
+
+function decodeContent(doc: PDFDocument): string {
+  const streamObj = doc.context.lookup(doc.getPage(0).node.get(PDFName.of('Contents')));
+  const bytes = streamObj instanceof PDFRawStream
+    ? decodePDFRawStream(streamObj).decode()
+    : (streamObj as unknown as { decode(): Uint8Array }).decode();
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return s;
+}
+
+describe('setAltText — MCID-exact figure targeting', () => {
+  it('writes /Alt onto the Figure whose MCID marks the target image', async () => {
+    const src = await PDFDocument.create();
+    const srcPage = src.addPage([400, 600]);
+    const img = await src.embedPng(PNG);
+    srcPage.drawImage(img, { x: 100, y: 400, width: 200, height: 100 }); // center (200,450) device
+    // save + reload so the image Do is flushed into a real content stream
+    const doc = await PDFDocument.load(await src.save());
+
+    // one figure zone covering the image (device band [360,480] ∋ 450; x [80,320] ∋ 200)
+    const zones: OrderableZone[] = [{ pageNumber: 1, bbox: { x: 80, y: 120, w: 240, h: 120 }, zoneType: 'figure' }];
+    const built = buildStructTreeFromZones(doc, zones);
+    expect(built.elements).toBeGreaterThan(0);
+
+    // the image's XObject name, from the (now MCID-marked) content stream
+    const xobj = decodeContent(doc).match(/\/([\w.#+-]+)\s+Do\b/)?.[1];
+    expect(xobj).toBeTruthy();
+
+    const res = await pdfModifierService.setAltText(doc, `img_p1_0_${xobj}`, 'A red apple on a table');
+    expect(res.success).toBe(true);
+
+    // the Figure StructElem now carries the alt
+    const root = doc.context.lookup(doc.catalog.get(PDFName.of('StructTreeRoot'))) as PDFDict;
+    let figureAlt: string | null = null;
+    const walk = (node: unknown): void => {
+      if (!(node instanceof PDFDict)) return;
+      if (node.get(PDFName.of('S'))?.toString() === '/Figure') {
+        const alt = node.get(PDFName.of('Alt'));
+        if (alt instanceof PDFString) figureAlt = alt.decodeText();
+      }
+      const k = node.get(PDFName.of('K'));
+      const kids = k instanceof PDFArray ? k.asArray() : [k];
+      for (const kid of kids) if (kid instanceof PDFRef) walk(doc.context.lookup(kid));
+    };
+    walk(root);
+    expect(figureAlt).toBe('A red apple on a table');
+  });
+});


### PR DESCRIPTION
First of four post-conformance recommendations. `setAltText` bound alt to a Figure **positionally** (page + XObject index), which can mis-assign when a page has multiple figures. Seam C binds each image to a specific **MCID** and the Figure's `/K` references it — so we now match the exact Figure by MCID, falling back to the positional path for non-MCID (Adobe) trees. Integration-tested; fallback unchanged. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF accessibility tagging by applying image alternative text to the precisely matching figure.
  * Added a fallback selection method for PDFs where exact matching information is unavailable.
* **Tests**
  * Added coverage to verify that image alternative text is correctly assigned in generated PDFs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->