### PR TITLE
feat(seam-c): setActualText apply primitive (rec #2, apply side)

### DIFF
--- a/src/services/pdf/pdf-modifier.service.ts
+++ b/src/services/pdf/pdf-modifier.service.ts
@@ -705,21 +705,7 @@ export class PdfModifierService {
   ): PDFDict | null {
     const mcid = this.mcidForXObject(doc, targetPage, xObjectName);
     if (mcid === null) return null;
-    const matchesMcid = (k: unknown): boolean => {
-      if (k instanceof PDFNumber) return k.asNumber() === mcid;
-      if (k instanceof PDFArray) {
-        for (let i = 0; i < k.size(); i++) {
-          const item = k.get(i);
-          if (item instanceof PDFNumber && item.asNumber() === mcid) return true;
-          if (item instanceof PDFDict) {
-            const m = item.get(PDFName.of('MCID'));
-            if (m instanceof PDFNumber && m.asNumber() === mcid) return true;
-          }
-        }
-      }
-      return false;
-    };
-    return figuresOnPage.find((fig) => matchesMcid(fig.get(PDFName.of('K')))) ?? null;
+    return figuresOnPage.find((fig) => this.structElemHasMcid(fig, mcid)) ?? null;
   }
 
   /** MCID of the marked-content sequence enclosing `/xObjectName Do` on the page. */
@@ -764,6 +750,69 @@ export class PdfModifierService {
       return out;
     } catch {
       return null;
+    }
+  }
+
+  /** True if a StructElem's /K references the given MCID (bare number, array, or MCR dict). */
+  private structElemHasMcid(elem: PDFDict, mcid: number): boolean {
+    const k = elem.get(PDFName.of('K'));
+    if (k instanceof PDFNumber) return k.asNumber() === mcid;
+    if (k instanceof PDFArray) {
+      for (let i = 0; i < k.size(); i++) {
+        const item = k.get(i);
+        if (item instanceof PDFNumber && item.asNumber() === mcid) return true;
+        if (item instanceof PDFDict) {
+          const m = item.get(PDFName.of('MCID'));
+          if (m instanceof PDFNumber && m.asNumber() === mcid) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Set /ActualText on a Formula element in the PDF structure tree — e.g. a LaTeX
+   * or plain-text rendering of a math expression, which screen readers announce.
+   * Matches by formulaId "formula_p{page}_mc{mcid}" (MCID-exact) or
+   * "formula_p{page}_{index}" (positional fallback).
+   */
+  async setActualText(
+    doc: PDFDocument,
+    formulaId: string,
+    actualText: string,
+  ): Promise<ModificationResult> {
+    try {
+      const structTreeRoot = this.getStructTreeRoot(doc);
+      if (!structTreeRoot) {
+        return { success: false, description: 'No structure tree', error: 'PDF has no tagged structure tree — ActualText cannot be applied programmatically' };
+      }
+      const mc = formulaId.match(/formula_p(\d+)_mc(\d+)/);
+      const idx = formulaId.match(/formula_p(\d+)_(\d+)/);
+      const targetPage = mc ? parseInt(mc[1], 10) : idx ? parseInt(idx[1], 10) : 1;
+      const targetIndex = idx ? parseInt(idx[2], 10) : 0;
+
+      const formulas = this.findStructureElementsByType(structTreeRoot, new Set(['Formula', 'formula']), doc.context);
+      if (formulas.length === 0) {
+        return { success: false, description: 'No Formula elements in structure tree', error: 'The PDF structure tree has no Formula elements' };
+      }
+      const pageRef = doc.getPage(targetPage - 1).ref;
+      const formulasOnPage = formulas.filter((f) => {
+        const pg = f.get(PDFName.of('Pg'));
+        return pg && pg.toString() === pageRef.toString();
+      });
+
+      const exact = mc ? formulasOnPage.find((f) => this.structElemHasMcid(f, Number(mc[2]))) : undefined;
+      const target = exact ?? formulasOnPage[targetIndex] ?? formulasOnPage[0] ?? formulas[targetIndex] ?? formulas[0];
+      if (!target) {
+        return { success: false, description: 'Formula element not found', error: `No Formula element for ${formulaId}` };
+      }
+      const prev = target.get(PDFName.of('ActualText'));
+      const before = prev instanceof PDFString ? prev.decodeText() : 'None';
+      target.set(PDFName.of('ActualText'), PDFString.of(actualText));
+      logger.info(`[PdfModifier] Set ActualText on Formula (${formulaId})`);
+      return { success: true, description: `Set ActualText on Formula element (${formulaId})`, pageNumber: targetPage, before, after: actualText };
+    } catch (error) {
+      return { success: false, description: 'Failed to set ActualText', error: error instanceof Error ? error.message : String(error) };
     }
   }
 

--- a/tests/unit/services/pdf/pdf-modifier-alt-mcid.test.ts
+++ b/tests/unit/services/pdf/pdf-modifier-alt-mcid.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PDFDocument, PDFName, PDFString, PDFDict, PDFArray, PDFRef, decodePDFRawStream, PDFRawStream } from 'pdf-lib';
+import { PDFDocument, PDFName, PDFString, PDFDict, PDFArray, PDFRef, StandardFonts, decodePDFRawStream, PDFRawStream } from 'pdf-lib';
 import { pdfModifierService } from '../../../../src/services/pdf/pdf-modifier.service';
 import { buildStructTreeFromZones } from '../../../../src/services/zone-extractor/seam-c/struct-tree-builder';
 import type { OrderableZone } from '../../../../src/services/zone-extractor/seam-c/reading-order';
@@ -56,5 +56,34 @@ describe('setAltText — MCID-exact figure targeting', () => {
     };
     walk(root);
     expect(figureAlt).toBe('A red apple on a table');
+  });
+
+  it('writes /ActualText onto a Formula element (MCID-exact)', async () => {
+    const src = await PDFDocument.create();
+    const page = src.addPage([400, 600]);
+    const font = await src.embedFont(StandardFonts.Helvetica);
+    page.drawText('E = mc2', { x: 100, y: 450, size: 14, font }); // baseline 450
+    const doc = await PDFDocument.load(await src.save());
+
+    // formula zone covering the text (device band [420,480] ∋ 450; x [80,320] ∋ 100)
+    buildStructTreeFromZones(doc, [{ pageNumber: 1, bbox: { x: 80, y: 120, w: 240, h: 60 }, zoneType: 'formula' }]);
+
+    const res = await pdfModifierService.setActualText(doc, 'formula_p1_mc0', 'E equals m c squared');
+    expect(res.success).toBe(true);
+
+    const root = doc.context.lookup(doc.catalog.get(PDFName.of('StructTreeRoot'))) as PDFDict;
+    let actual: string | null = null;
+    const walk = (node: unknown): void => {
+      if (!(node instanceof PDFDict)) return;
+      if (node.get(PDFName.of('S'))?.toString() === '/Formula') {
+        const a = node.get(PDFName.of('ActualText'));
+        if (a instanceof PDFString) actual = a.decodeText();
+      }
+      const k = node.get(PDFName.of('K'));
+      const kids = k instanceof PDFArray ? k.asArray() : [k];
+      for (const kid of kids) if (kid instanceof PDFRef) walk(doc.context.lookup(kid));
+    };
+    walk(root);
+    expect(actual).toBe('E equals m c squared');
   });
 });


### PR DESCRIPTION
The apply mechanism for formula `/ActualText`, mirroring `setAltText`/`setTableSummary`. `setActualText` writes `/ActualText` onto a Formula StructElem, MCID-exact (`formula_p{page}_mc{mcid}`) with positional fallback. Shared `structElemHasMcid` helper (reused by the figure matcher). The generate half (formula validator + render-crop → Gemini LaTeX + controller apply) is a larger change landing separately. 2 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)