### PR TITLE
feat(seam-c): formula ActualText generate pipeline (B1–B4)

### DIFF
--- a/src/controllers/pdf-ai-analysis.controller.ts
+++ b/src/controllers/pdf-ai-analysis.controller.ts
@@ -250,6 +250,8 @@ export class PdfAiAnalysisController {
           modification = await pdfModifierService.setAltText(doc, elementId, value);
         } else if (suggestionType === 'table-summary') {
           modification = await pdfModifierService.setTableSummary(doc, elementId, value);
+        } else if (suggestionType === 'formula-actualtext') {
+          modification = await pdfModifierService.setActualText(doc, elementId, value);
         } else if (suggestionType === 'language') {
           modification = await pdfModifierService.addLanguage(doc, value);
         } else {
@@ -389,6 +391,8 @@ export class PdfAiAnalysisController {
             modification = await pdfModifierService.setAltText(doc, elementId, value!);
           } else if (suggestionType === 'table-summary') {
             modification = await pdfModifierService.setTableSummary(doc, elementId, value!);
+          } else if (suggestionType === 'formula-actualtext') {
+            modification = await pdfModifierService.setActualText(doc, elementId, value!);
           } else if (suggestionType === 'language') {
             modification = await pdfModifierService.addLanguage(doc, value!);
           } else {

--- a/src/services/pdf/ai-analysis.service.ts
+++ b/src/services/pdf/ai-analysis.service.ts
@@ -1348,11 +1348,21 @@ class AiAnalysisService {
       'No LaTeX, no markup, max ~200 characters.\n' +
       'Respond ONLY with JSON: {"latex":"...","actualText":"..."}';
 
-    const response = await geminiService.analyzeImage(base64, 'image/png', prompt, {
-      model: 'flash',
-      temperature: 0.2,
-      maxOutputTokens: 256,
-    });
+    let response;
+    try {
+      response = await geminiService.analyzeImage(base64, 'image/png', prompt, {
+        model: 'flash',
+        temperature: 0.2,
+        maxOutputTokens: 256,
+      });
+    } catch (err) {
+      logger.warn(
+        `[AiAnalysis] Formula ActualText draft failed on page ${issue.pageNumber}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return null;
+    }
 
     const parsed = this.parseAiJson<{ latex?: string; actualText?: string }>(response.text);
     const actualText = parsed?.actualText?.trim();

--- a/src/services/pdf/ai-analysis.service.ts
+++ b/src/services/pdf/ai-analysis.service.ts
@@ -95,6 +95,7 @@ const LINK_CODES = new Set(['LINK-NOT-DESCRIPTIVE', 'LINK-URL-AS-TEXT', 'LINK-GE
 const FORM_CODES = new Set(['FORM-FIELD-NO-LABEL', 'FORM-FIELD-MISSING-TOOLTIP']);
 const BOOKMARK_CODES = new Set(['BOOKMARK-MISSING', 'BOOKMARK-INSUFFICIENT', 'BOOKMARK-GENERIC-TEXT']);
 const PDFUA_IDENTIFIER_CODES = new Set(['PDFUA-IDENTIFIER-MISSING', 'MATTERHORN-06-002']);
+const FORMULA_ACTUALTEXT_CODES = new Set(['FORMULA-MISSING-ACTUALTEXT']);
 
 // ─── Service ─────────────────────────────────────────────────────────────────
 
@@ -490,6 +491,11 @@ class AiAnalysisService {
         model: 'rule-based',
         applyMode: 'apply-to-pdf',
       };
+    }
+
+    if (FORMULA_ACTUALTEXT_CODES.has(code)) {
+      if (!issue.pageNumber || !parsed.parsedPdf || !issue.boundingBox) return null;
+      return this.analyzeFormulaActualText(issue, parsed.parsedPdf, parsed.isTagged);
     }
 
     return null;
@@ -1314,6 +1320,104 @@ class AiAnalysisService {
       mimeType: 'image/png',
       base64: pageBase64,
     };
+  }
+
+  /**
+   * Draft ActualText for a Formula element by rendering its region and asking
+   * the vision model for a spoken-math reading (plus LaTeX for the reviewer).
+   * The suggestion's `value` is the ActualText string; the apply controller
+   * resolves issue.element ("formula_p{page}_mc{mcid}") → setActualText.
+   */
+  private async analyzeFormulaActualText(
+    issue: AuditIssue,
+    parsedPdf: ParsedPDF,
+    isTagged: boolean
+  ): Promise<AiSuggestionResult | null> {
+    const region = issue.boundingBox;
+    if (!issue.pageNumber || !region) return null;
+
+    const base64 = await this.renderRegionToBase64(parsedPdf, issue.pageNumber, region);
+    if (!base64) return null;
+
+    const prompt =
+      'This image is a single mathematical formula or equation cropped from a PDF page.\n' +
+      'Provide:\n' +
+      '1. "latex": the formula transcribed as LaTeX.\n' +
+      '2. "actualText": a concise natural-language reading a screen reader should speak ' +
+      '(e.g. "E equals m c squared"; "the integral from a to b of f of x d x"). ' +
+      'No LaTeX, no markup, max ~200 characters.\n' +
+      'Respond ONLY with JSON: {"latex":"...","actualText":"..."}';
+
+    const response = await geminiService.analyzeImage(base64, 'image/png', prompt, {
+      model: 'flash',
+      temperature: 0.2,
+      maxOutputTokens: 256,
+    });
+
+    const parsed = this.parseAiJson<{ latex?: string; actualText?: string }>(response.text);
+    const actualText = parsed?.actualText?.trim();
+    if (!actualText) return null;
+
+    const latex = parsed?.latex?.trim();
+    // A tagged struct tree is required to write /ActualText; otherwise offer guidance only.
+    const applyMode: AiSuggestionResult['applyMode'] = isTagged ? 'apply-to-pdf' : 'guidance-only';
+
+    return {
+      suggestionType: 'formula-actualtext',
+      value: actualText,
+      guidance:
+        `Suggested reading (ActualText): "${actualText}"` +
+        (latex ? `\nLaTeX: ${latex}` : '') +
+        (isTagged ? '' : '\n(PDF is untagged — apply after tagging, or add ActualText in the authoring tool.)'),
+      confidence: 0.7,
+      rationale:
+        'AI-drafted spoken-math reading from the rendered formula region. Math is high-stakes — review before applying.',
+      model: 'gemini-flash',
+      applyMode,
+      requiresManualReview: true,
+      usage: response.usage
+        ? { promptTokens: response.usage.promptTokens, completionTokens: response.usage.completionTokens }
+        : undefined,
+    };
+  }
+
+  /**
+   * Render a page region (top-left PDF-point boundingBox) to a cropped PNG
+   * base64. Renders the whole page at `scale`, then crops with a small pad so
+   * the model sees a little context around the formula.
+   */
+  private async renderRegionToBase64(
+    parsedPdf: ParsedPDF,
+    pageNumber: number,
+    region: { x: number; y: number; width: number; height: number },
+    scale = 2.0
+  ): Promise<string | null> {
+    try {
+      const page = await parsedPdf.pdfjsDoc.getPage(pageNumber);
+      const viewport = page.getViewport({ scale });
+      const full = createCanvas(Math.round(viewport.width), Math.round(viewport.height));
+      const fctx = full.getContext('2d');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await page.render({ canvas: full as any, canvasContext: fctx as any, viewport }).promise;
+
+      const pad = 4 * scale;
+      const sx = Math.max(0, Math.round(region.x * scale - pad));
+      const sy = Math.max(0, Math.round(region.y * scale - pad));
+      const sw = Math.min(full.width - sx, Math.round(region.width * scale + pad * 2));
+      const sh = Math.min(full.height - sy, Math.round(region.height * scale + pad * 2));
+      if (sw <= 0 || sh <= 0) return full.toBuffer('image/png').toString('base64');
+
+      const crop = createCanvas(sw, sh);
+      const cctx = crop.getContext('2d');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cctx.drawImage(full as any, sx, sy, sw, sh, 0, 0, sw, sh);
+      return crop.toBuffer('image/png').toString('base64');
+    } catch (err) {
+      logger.warn(
+        `[AiAnalysis] Failed to render region on page ${pageNumber}: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return null;
+    }
   }
 
   private async renderPageToBase64(parsedPdf: ParsedPDF, pageNumber: number): Promise<string | null> {

--- a/src/services/pdf/pdf-audit.service.ts
+++ b/src/services/pdf/pdf-audit.service.ts
@@ -20,6 +20,7 @@ import { pdfParserService } from './pdf-parser.service';
 import { PdfContrastValidator } from './validators/pdf-contrast.validator';
 import { pdfAltTextValidator } from './validators/pdf-alttext.validator';
 import { pdfTableValidator } from './validators/pdf-table.validator';
+import { pdfFormulaValidator } from './validators/pdf-formula.validator';
 import { pdfStructureValidator } from './validators/pdf-structure.validator';
 import { pdfLinkValidator } from './validators/pdf-link.validator';
 import { pdfFormValidator } from './validators/pdf-form.validator';
@@ -324,6 +325,22 @@ class PdfAuditService extends BaseAuditService<PdfParseResult, PdfValidationResu
           logger.error(`[PdfAudit] PdfAltTextValidator failed:`, error);
           result.validatorErrors.push({ validator: 'PdfAltTextValidator', error: errorMessage });
           onValidatorComplete?.('Alt Text', 0, ++completedValidators, totalValidators, altTextStart);
+        }
+      }
+
+      // 2b. Formula Validator (struct-tree walk for /Formula without /ActualText).
+      // Runs alongside structure; a bonus sub-check, so it stays out of the
+      // progress total and reports through result.issues only.
+      if (willRunStructure) {
+        try {
+          logger.info(`[PdfAudit] Running PdfFormulaValidator...`);
+          const formulaResult = await pdfFormulaValidator.validate(parsed.parsedPdf);
+          result.issues.push(...formulaResult.issues);
+          logger.info(`[PdfAudit] PdfFormulaValidator found ${formulaResult.issues.length} issues`);
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+          logger.error(`[PdfAudit] PdfFormulaValidator failed:`, error);
+          result.validatorErrors.push({ validator: 'PdfFormulaValidator', error: errorMessage });
         }
       }
 

--- a/src/services/pdf/validators/pdf-formula.validator.ts
+++ b/src/services/pdf/validators/pdf-formula.validator.ts
@@ -15,7 +15,7 @@
  * AI-analysis dispatch and the apply controller.
  */
 
-import { PDFName, PDFDict, PDFArray, PDFNumber, PDFRef, PDFString } from 'pdf-lib';
+import { PDFName, PDFDict, PDFArray, PDFNumber, PDFRef, PDFString, PDFHexString } from 'pdf-lib';
 import { AuditIssue } from '../../audit/base-audit.service';
 import { ParsedPDF } from '../pdf-parser.service';
 import { logger } from '../../../lib/logger';
@@ -104,7 +104,8 @@ class PdfFormulaValidator {
   private hasAlternate(elem: PDFDict): boolean {
     for (const key of ['ActualText', 'Alt'] as const) {
       const v = elem.get(PDFName.of(key));
-      if (v instanceof PDFString && v.decodeText().trim().length > 0) return true;
+      // Text values may be literal (PDFString) or hex-encoded (PDFHexString).
+      if ((v instanceof PDFString || v instanceof PDFHexString) && v.decodeText().trim().length > 0) return true;
     }
     return false;
   }

--- a/src/services/pdf/validators/pdf-formula.validator.ts
+++ b/src/services/pdf/validators/pdf-formula.validator.ts
@@ -1,0 +1,210 @@
+/**
+ * PDF Formula Validator
+ *
+ * Walks the tagged structure tree for /Formula elements that lack a text
+ * alternative (/ActualText or /Alt). A Formula without an alternate reading is
+ * announced by screen readers as its raw glyphs (e.g. "E mc 2"), which is
+ * meaningless — PDF/UA (veraPDF clause 7.7) and WCAG 1.1.1 require one.
+ *
+ * Emits an MCID-exact element id ("formula_p{page}_mc{mcid}") that
+ * pdfModifierService.setActualText can target precisely, plus the region's
+ * bounding box (from the /A /Layout /BBox that Seam C stamps on each Formula)
+ * so a downstream step can crop the formula and draft ActualText with AI.
+ *
+ * Detection only — no AI, no rendering. Drafting/applying happens later in the
+ * AI-analysis dispatch and the apply controller.
+ */
+
+import { PDFName, PDFDict, PDFArray, PDFNumber, PDFRef, PDFString } from 'pdf-lib';
+import { AuditIssue } from '../../audit/base-audit.service';
+import { ParsedPDF } from '../pdf-parser.service';
+import { logger } from '../../../lib/logger';
+
+export interface FormulaValidationResult {
+  issues: AuditIssue[];
+  metadata: {
+    totalFormulas: number;
+    formulasWithAlternate: number;
+    formulasMissingAlternate: number;
+  };
+}
+
+interface PageInfo {
+  pageNumber: number;
+  width: number;
+  height: number;
+}
+
+class PdfFormulaValidator {
+  private issueCounter = 0;
+
+  async validate(parsedPdf: ParsedPDF): Promise<FormulaValidationResult> {
+    this.issueCounter = 0;
+    const doc = parsedPdf.pdfLibDoc;
+    const issues: AuditIssue[] = [];
+    let totalFormulas = 0;
+    let withAlternate = 0;
+
+    const root = this.getStructTreeRoot(doc);
+    if (!root) {
+      return { issues, metadata: { totalFormulas: 0, formulasWithAlternate: 0, formulasMissingAlternate: 0 } };
+    }
+
+    // page ref → {pageNumber, width, height} (device-space heights match the /A /BBox convention)
+    const pageByRef = new Map<string, PageInfo>();
+    doc.getPages().forEach((page, i) => {
+      const { width, height } = page.getSize();
+      pageByRef.set(page.ref.toString(), { pageNumber: i + 1, width, height });
+    });
+
+    // positional index of formulas per page (fallback id when no MCID)
+    const perPageIndex = new Map<number, number>();
+    const seen = new Set<string>();
+
+    const visit = (nodeRef: unknown): void => {
+      const node = nodeRef instanceof PDFRef ? doc.context.lookup(nodeRef) : nodeRef;
+      if (!(node instanceof PDFDict)) return;
+      // guard against cycles / shared refs
+      if (nodeRef instanceof PDFRef) {
+        const key = nodeRef.toString();
+        if (seen.has(key)) return;
+        seen.add(key);
+      }
+
+      if (node.get(PDFName.of('S'))?.toString() === '/Formula') {
+        totalFormulas++;
+        if (this.hasAlternate(node)) {
+          withAlternate++;
+        } else {
+          issues.push(this.buildIssue(node, pageByRef, perPageIndex, doc));
+        }
+      }
+
+      const k = node.get(PDFName.of('K'));
+      const kids = k instanceof PDFArray ? k.asArray() : k === undefined ? [] : [k];
+      for (const kid of kids) if (kid instanceof PDFRef || kid instanceof PDFDict) visit(kid);
+    };
+
+    visit(root);
+
+    logger.info(
+      `[PdfFormulaValidator] ${totalFormulas} formula(s): ${withAlternate} with alternate, ${issues.length} missing`,
+    );
+
+    return {
+      issues,
+      metadata: {
+        totalFormulas,
+        formulasWithAlternate: withAlternate,
+        formulasMissingAlternate: issues.length,
+      },
+    };
+  }
+
+  private hasAlternate(elem: PDFDict): boolean {
+    for (const key of ['ActualText', 'Alt'] as const) {
+      const v = elem.get(PDFName.of(key));
+      if (v instanceof PDFString && v.decodeText().trim().length > 0) return true;
+    }
+    return false;
+  }
+
+  private buildIssue(
+    elem: PDFDict,
+    pageByRef: Map<string, PageInfo>,
+    perPageIndex: Map<number, number>,
+    doc: ParsedPDF['pdfLibDoc'],
+  ): AuditIssue {
+    const pgRef = elem.get(PDFName.of('Pg'));
+    const pageInfo = pgRef instanceof PDFRef ? pageByRef.get(pgRef.toString()) : undefined;
+    const pageNumber = pageInfo?.pageNumber ?? 1;
+
+    const positional = perPageIndex.get(pageNumber) ?? 0;
+    perPageIndex.set(pageNumber, positional + 1);
+
+    const mcid = this.firstMcid(elem, doc);
+    const element = mcid !== undefined ? `formula_p${pageNumber}_mc${mcid}` : `formula_p${pageNumber}_${positional}`;
+    const boundingBox = pageInfo ? this.regionBBox(elem, pageInfo, doc) : undefined;
+
+    return {
+      id: `pdf-formula-${++this.issueCounter}`,
+      source: 'pdf-formula',
+      severity: 'serious',
+      code: 'FORMULA-MISSING-ACTUALTEXT',
+      message: `Formula on page ${pageNumber} has no text alternative (ActualText)`,
+      wcagCriteria: ['1.1.1'],
+      location: `Page ${pageNumber}`,
+      suggestion:
+        'Provide an ActualText reading for the formula (e.g. a spoken-math or LaTeX-derived description). AI can draft this from the formula region.',
+      category: 'formula',
+      element,
+      pageNumber,
+      // veraPDF flags this under ISO 14289-1 clause 7.7 (non-text objects).
+      matterhornHow: 'M',
+      boundingBox,
+    };
+  }
+
+  /** First MCID referenced by the element's /K (single number or first number in an array). */
+  private firstMcid(elem: PDFDict, doc: ParsedPDF['pdfLibDoc']): number | undefined {
+    const k = elem.get(PDFName.of('K'));
+    if (k instanceof PDFNumber) return k.asNumber();
+    if (k instanceof PDFArray) {
+      for (const item of k.asArray()) {
+        const resolved = item instanceof PDFRef ? doc.context.lookup(item) : item;
+        if (resolved instanceof PDFNumber) return resolved.asNumber();
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Convert the element's /A /Layout /BBox (device space, bottom-left) into the
+   * top-left PDF-point boundingBox convention that validators emit.
+   */
+  private regionBBox(
+    elem: PDFDict,
+    pageInfo: PageInfo,
+    doc: ParsedPDF['pdfLibDoc'],
+  ): AuditIssue['boundingBox'] {
+    const aRaw = elem.get(PDFName.of('A'));
+    const a = aRaw instanceof PDFRef ? doc.context.lookup(aRaw) : aRaw;
+    const layoutDict = this.layoutAttr(a, doc);
+    if (!layoutDict) return undefined;
+
+    const bb = layoutDict.get(PDFName.of('BBox'));
+    if (!(bb instanceof PDFArray) || bb.size() !== 4) return undefined;
+    const nums = bb.asArray().map((n) => (n instanceof PDFNumber ? n.asNumber() : Number(n?.toString())));
+    if (nums.some((n) => Number.isNaN(n))) return undefined;
+
+    const [x1, y1, x2, y2] = nums;
+    return {
+      x: x1,
+      y: pageInfo.height - y2, // device bottom-left → top-left origin
+      width: x2 - x1,
+      height: y2 - y1,
+      pageWidth: pageInfo.width,
+      pageHeight: pageInfo.height,
+    };
+  }
+
+  /** /A may be a single attribute dict or an array of them; find the /Layout owner. */
+  private layoutAttr(a: unknown, doc: ParsedPDF['pdfLibDoc']): PDFDict | undefined {
+    if (a instanceof PDFDict) return a;
+    if (a instanceof PDFArray) {
+      for (const item of a.asArray()) {
+        const d = item instanceof PDFRef ? doc.context.lookup(item) : item;
+        if (d instanceof PDFDict && d.get(PDFName.of('O'))?.toString() === '/Layout') return d;
+      }
+    }
+    return undefined;
+  }
+
+  private getStructTreeRoot(doc: ParsedPDF['pdfLibDoc']): PDFDict | undefined {
+    const ref = doc.catalog.get(PDFName.of('StructTreeRoot'));
+    const root = ref instanceof PDFRef ? doc.context.lookup(ref) : ref;
+    return root instanceof PDFDict ? root : undefined;
+  }
+}
+
+export const pdfFormulaValidator = new PdfFormulaValidator();

--- a/src/services/zone-extractor/seam-c/struct-tree-builder.ts
+++ b/src/services/zone-extractor/seam-c/struct-tree-builder.ts
@@ -194,6 +194,18 @@ export function buildStructTreeFromZones(
     dict.set(PDFName.of('K'), doc.context.obj(childRefs as PDFObject[]));
   };
 
+  // Record the element's region as an /A /Layout /BBox (device space, bottom-left)
+  // so a downstream step can crop it — e.g. render a Formula to send to math-OCR.
+  const setLayoutBBox = (dict: PDFDict, zone: OrderableZone): void => {
+    const pageIdx = pageByNumber.get(zone.pageNumber);
+    if (pageIdx === undefined) return;
+    const H = pages[pageIdx].getHeight();
+    const b = zone.bbox;
+    const a = doc.context.obj({ O: PDFName.of('Layout') });
+    a.set(PDFName.of('BBox'), doc.context.obj([b.x, H - (b.y + b.h), b.x + b.w, H - b.y].map((n) => PDFNumber.of(n))));
+    dict.set(PDFName.of('A'), a);
+  };
+
   // Recursively realize a forest node under `parentRef`; returns the created ref (or null for artifacts).
   const build = (node: StructNode, parentRef: PDFRef): PDFRef | null => {
     switch (node.kind) {
@@ -202,6 +214,7 @@ export function buildStructTreeFromZones(
       case 'block': {
         const { ref, dict } = makeElem(node.tag, parentRef);
         bindLeaf(ref, dict, node.zone);
+        if (node.tag === 'Figure' || node.tag === 'Formula') setLayoutBBox(dict, node.zone);
         return ref;
       }
       case 'table': {
@@ -209,6 +222,7 @@ export function buildStructTreeFromZones(
         const table = makeElem('Table', parentRef);
         const tr = makeElem('TR', table.ref);
         const td = makeElem('TD', tr.ref);
+        setLayoutBBox(table.dict, node.zone);
         bindLeaf(td.ref, td.dict, node.zone);
         setKids(tr.dict, [td.ref]);
         setKids(table.dict, [tr.ref]);

--- a/tests/unit/services/pdf/ai-analysis-formula.test.ts
+++ b/tests/unit/services/pdf/ai-analysis-formula.test.ts
@@ -60,4 +60,10 @@ describe('analyzeFormulaActualText', () => {
     expect(res).toBeNull();
     expect(spy).not.toHaveBeenCalled(); // no wasted vision call
   });
+
+  it('returns null (not a rejected promise) when the vision call throws', async () => {
+    vi.spyOn(svc, 'renderRegionToBase64').mockResolvedValue('ZmFrZQ==');
+    vi.spyOn(geminiService, 'analyzeImage').mockRejectedValue(new Error('429 rate limit'));
+    await expect(svc.analyzeFormulaActualText(ISSUE, {}, true)).resolves.toBeNull();
+  });
 });

--- a/tests/unit/services/pdf/ai-analysis-formula.test.ts
+++ b/tests/unit/services/pdf/ai-analysis-formula.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { aiAnalysisService } from '../../../../src/services/pdf/ai-analysis.service';
+import { geminiService } from '../../../../src/services/ai/gemini.service';
+import type { AuditIssue } from '../../../../src/services/audit/base-audit.service';
+
+// analyzeFormulaActualText / renderRegionToBase64 are private; exercise via cast.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const svc = aiAnalysisService as any;
+
+const ISSUE: AuditIssue = {
+  id: 'pdf-formula-1',
+  source: 'pdf-formula',
+  severity: 'serious',
+  code: 'FORMULA-MISSING-ACTUALTEXT',
+  message: 'Formula on page 1 has no text alternative (ActualText)',
+  pageNumber: 1,
+  element: 'formula_p1_mc0',
+  boundingBox: { x: 80, y: 120, width: 240, height: 60, pageWidth: 400, pageHeight: 600 },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const gemini = (text: string, usage?: any) =>
+  vi.spyOn(geminiService, 'analyzeImage').mockResolvedValue({ text, usage } as never);
+
+describe('analyzeFormulaActualText', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('drafts ActualText from the formula region (tagged → apply-to-pdf, needs review)', async () => {
+    vi.spyOn(svc, 'renderRegionToBase64').mockResolvedValue('ZmFrZQ==');
+    gemini('{"latex":"E = mc^2","actualText":"E equals m c squared"}', { promptTokens: 10, completionTokens: 5 });
+
+    const res = await svc.analyzeFormulaActualText(ISSUE, {}, true);
+    expect(res).toBeTruthy();
+    expect(res.suggestionType).toBe('formula-actualtext');
+    expect(res.value).toBe('E equals m c squared');
+    expect(res.applyMode).toBe('apply-to-pdf');
+    expect(res.requiresManualReview).toBe(true);
+    expect(res.guidance).toContain('E = mc^2'); // LaTeX shown to the reviewer
+    expect(res.usage).toEqual({ promptTokens: 10, completionTokens: 5 });
+  });
+
+  it('downgrades to guidance-only when the PDF is untagged', async () => {
+    vi.spyOn(svc, 'renderRegionToBase64').mockResolvedValue('ZmFrZQ==');
+    gemini('{"actualText":"x squared"}');
+    const res = await svc.analyzeFormulaActualText(ISSUE, {}, false);
+    expect(res.value).toBe('x squared');
+    expect(res.applyMode).toBe('guidance-only');
+  });
+
+  it('returns null when the model yields no actualText', async () => {
+    vi.spyOn(svc, 'renderRegionToBase64').mockResolvedValue('ZmFrZQ==');
+    gemini('{"latex":"x"}');
+    expect(await svc.analyzeFormulaActualText(ISSUE, {}, true)).toBeNull();
+  });
+
+  it('returns null when the region cannot be rendered', async () => {
+    vi.spyOn(svc, 'renderRegionToBase64').mockResolvedValue(null);
+    const spy = vi.spyOn(geminiService, 'analyzeImage');
+    const res = await svc.analyzeFormulaActualText(ISSUE, {}, true);
+    expect(res).toBeNull();
+    expect(spy).not.toHaveBeenCalled(); // no wasted vision call
+  });
+});

--- a/tests/unit/services/pdf/pdf-formula-validator.test.ts
+++ b/tests/unit/services/pdf/pdf-formula-validator.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { pdfFormulaValidator } from '../../../../src/services/pdf/validators/pdf-formula.validator';
+import { pdfModifierService } from '../../../../src/services/pdf/pdf-modifier.service';
+import { buildStructTreeFromZones } from '../../../../src/services/zone-extractor/seam-c/struct-tree-builder';
+import type { ParsedPDF } from '../../../../src/services/pdf/pdf-parser.service';
+import type { OrderableZone } from '../../../../src/services/zone-extractor/seam-c/reading-order';
+
+// The validator only touches parsedPdf.pdfLibDoc.
+const asParsed = (doc: PDFDocument): ParsedPDF => ({ pdfLibDoc: doc } as unknown as ParsedPDF);
+
+async function taggedWithFormula(): Promise<PDFDocument> {
+  const src = await PDFDocument.create();
+  const page = src.addPage([400, 600]);
+  const font = await src.embedFont(StandardFonts.Helvetica);
+  page.drawText('E = mc2', { x: 100, y: 450, size: 14, font }); // baseline 450
+  // reload so the drawn content is flushed into a real content stream
+  const doc = await PDFDocument.load(await src.save());
+  // formula zone covering the text (device band [420,480] ∋ 450; x [80,320] ∋ 100)
+  const zones: OrderableZone[] = [{ pageNumber: 1, bbox: { x: 80, y: 120, w: 240, h: 60 }, zoneType: 'formula' }];
+  buildStructTreeFromZones(doc, zones);
+  return doc;
+}
+
+describe('pdfFormulaValidator', () => {
+  it('flags a Formula element with no ActualText and emits an MCID-exact, applyable id', async () => {
+    const doc = await taggedWithFormula();
+
+    const res = await pdfFormulaValidator.validate(asParsed(doc));
+    expect(res.metadata.totalFormulas).toBe(1);
+    expect(res.issues).toHaveLength(1);
+
+    const issue = res.issues[0];
+    expect(issue.code).toBe('FORMULA-MISSING-ACTUALTEXT');
+    expect(issue.pageNumber).toBe(1);
+    expect(issue.element).toMatch(/^formula_p1_mc\d+$/);
+    // region bbox recovered from the /A /Layout /BBox (top-left origin)
+    expect(issue.boundingBox).toBeTruthy();
+    expect(issue.boundingBox!.width).toBeCloseTo(240, 5);
+    expect(issue.boundingBox!.height).toBeCloseTo(60, 5);
+    expect(issue.boundingBox!.x).toBeCloseTo(80, 5);
+    expect(issue.boundingBox!.y).toBeCloseTo(120, 5); // top-left y == original zone y
+
+    // the emitted id is precisely what the apply primitive targets
+    const apply = await pdfModifierService.setActualText(doc, issue.element!, 'E equals m c squared');
+    expect(apply.success).toBe(true);
+
+    // re-running the validator now sees the alternate and reports clean
+    const after = await pdfFormulaValidator.validate(asParsed(doc));
+    expect(after.issues).toHaveLength(0);
+    expect(after.metadata.formulasWithAlternate).toBe(1);
+  });
+
+  it('is a no-op on a PDF with no structure tree', async () => {
+    const doc = await PDFDocument.create();
+    doc.addPage([400, 600]);
+    const res = await pdfFormulaValidator.validate(asParsed(doc));
+    expect(res.issues).toHaveLength(0);
+    expect(res.metadata.totalFormulas).toBe(0);
+  });
+});

--- a/tests/unit/services/pdf/pdf-formula-validator.test.ts
+++ b/tests/unit/services/pdf/pdf-formula-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { PDFDocument, StandardFonts, PDFName, PDFDict, PDFArray, PDFRef, PDFHexString } from 'pdf-lib';
 import { pdfFormulaValidator } from '../../../../src/services/pdf/validators/pdf-formula.validator';
 import { pdfModifierService } from '../../../../src/services/pdf/pdf-modifier.service';
 import { buildStructTreeFromZones } from '../../../../src/services/zone-extractor/seam-c/struct-tree-builder';
@@ -49,6 +49,27 @@ describe('pdfFormulaValidator', () => {
     const after = await pdfFormulaValidator.validate(asParsed(doc));
     expect(after.issues).toHaveLength(0);
     expect(after.metadata.formulasWithAlternate).toBe(1);
+  });
+
+  it('treats a hex-encoded (PDFHexString) ActualText as a valid alternate', async () => {
+    const doc = await taggedWithFormula();
+    // set ActualText directly as a hex string (as some authoring tools do)
+    const root = doc.context.lookup(doc.catalog.get(PDFName.of('StructTreeRoot'))) as PDFDict;
+    const setHexOnFormula = (n: unknown): void => {
+      if (!(n instanceof PDFDict)) return;
+      if (n.get(PDFName.of('S'))?.toString() === '/Formula') {
+        n.set(PDFName.of('ActualText'), PDFHexString.fromText('E equals m c squared'));
+      }
+      const k = n.get(PDFName.of('K'));
+      const kids = k instanceof PDFArray ? k.asArray() : [k];
+      for (const kid of kids) if (kid instanceof PDFRef) setHexOnFormula(doc.context.lookup(kid));
+    };
+    setHexOnFormula(root);
+
+    const res = await pdfFormulaValidator.validate(asParsed(doc));
+    expect(res.metadata.totalFormulas).toBe(1);
+    expect(res.metadata.formulasWithAlternate).toBe(1);
+    expect(res.issues).toHaveLength(0);
   });
 
   it('is a no-op on a PDF with no structure tree', async () => {

--- a/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
+++ b/tests/unit/services/zone-extractor/seam-c/struct-tree-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PDFDocument, StandardFonts, PDFName, PDFDict, PDFBool, PDFString, PDFArray, PDFRawStream, decodePDFRawStream } from 'pdf-lib';
+import { PDFDocument, StandardFonts, PDFName, PDFDict, PDFBool, PDFString, PDFArray, PDFRef, PDFRawStream, decodePDFRawStream } from 'pdf-lib';
 import { buildStructTreeFromZones } from '../../../../../src/services/zone-extractor/seam-c/struct-tree-builder';
 import { serializeStructTreeAsync } from '../../../../../src/services/zone-extractor/struct-tree-serializer';
 import type { OrderableZone } from '../../../../../src/services/zone-extractor/seam-c/reading-order';
@@ -118,6 +118,25 @@ describe('buildStructTreeFromZones (end-to-end)', () => {
     const doc = await PDFDocument.load(await makeUntaggedPdf());
     buildStructTreeFromZones(doc, ZONES);                 // now tagged
     expect(() => buildStructTreeFromZones(doc, ZONES)).toThrow(/ALREADY_TAGGED/);
+  });
+
+  it('sets an /A /BBox on Figure elements (region for downstream crop/alt)', async () => {
+    const doc = await PDFDocument.load(await makeUntaggedPdf());
+    buildStructTreeFromZones(doc, [{ pageNumber: 1, bbox: { x: 50, y: 100, w: 200, h: 80 }, zoneType: 'figure' }]);
+    const root = doc.context.lookup(doc.catalog.get(PDFName.of('StructTreeRoot'))) as PDFDict;
+    let figureBBox: unknown = null;
+    const walk = (n: unknown): void => {
+      if (!(n instanceof PDFDict)) return;
+      if (n.get(PDFName.of('S'))?.toString() === '/Figure') {
+        const a = n.get(PDFName.of('A'));
+        if (a instanceof PDFDict) figureBBox = a.get(PDFName.of('BBox'));
+      }
+      const k = n.get(PDFName.of('K'));
+      const kids = k instanceof PDFArray ? k.asArray() : [k];
+      for (const kid of kids) if (kid instanceof PDFRef) walk(doc.context.lookup(kid));
+    };
+    walk(root);
+    expect(figureBBox).toBeInstanceOf(PDFArray); // device-space [x1 y1 x2 y2]
   });
 
   it('is a no-op for a PDF with no zones', async () => {


### PR DESCRIPTION
## Summary

Completes recommendation #2's **generate side** — the pipeline that finds untagged formulas and drafts an `/ActualText` reading for them. The apply primitive (`setActualText`) landed earlier in #447; this wires up detection → AI drafting → apply end-to-end.

Before this, a Seam-C-tagged `/Formula` with no alternate was announced by screen readers as its raw glyphs (e.g. "E mc 2"). veraPDF flagged these under ISO 14289-1 clause 7.7 (the 92 `7.7-1` failures in the Nikitopoulos conformance run).

## Changes

- **B1 — Region bbox on structure elements** (`struct-tree-builder.ts`): Seam C now stamps an `/A /Layout /BBox` (device space, bottom-left) on every Figure / Formula / Table element, so a downstream step can crop the region.
- **B2 — Formula validator** (`pdf-formula.validator.ts`): walks the tagged struct tree for `/Formula` elements missing `/ActualText` (or `/Alt`). Emits an MCID-exact, applyable element id (`formula_p{page}_mc{mcid}`) plus the region bbox (converted to top-left PDF points). Registered under the structure gate in `pdf-audit.service`.
- **B3 — AI drafting** (`ai-analysis.service.ts`): new `FORMULA-MISSING-ACTUALTEXT` dispatch case renders the formula region (`renderRegionToBase64`, 2× scale + pad) and asks the vision model for LaTeX + a concise spoken-math reading. Stores the reading as the suggestion `value`; shows LaTeX to the reviewer. `requiresManualReview=true` (math is high-stakes); apply-to-pdf when tagged, else guidance-only.
- **B4 — Apply** (`pdf-ai-analysis.controller.ts`): routes `formula-actualtext` → `setActualText` in both single-apply and apply-all paths.

## Tests

- `pdf-formula-validator.test.ts` — proves the full round trip: flag → emitted id → `setActualText` applies → re-validate reports clean.
- `ai-analysis-formula.test.ts` — analyzer parse/shape/mode logic (tagged→apply, untagged→guidance, null on no-actualText / render failure).
- `struct-tree-builder.test.ts` — asserts Figure carries `/A /BBox`.
- Full suite: 61 passing, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to detect formulas missing accessible text alternatives, including bounding-box context.
  * AI can now analyze detected formula regions to propose LaTeX and spoken-math actual text, with manual-review guidance.
  * Approved formula actual-text suggestions can be applied individually or in bulk.
  * Formula/figure regions now carry layout metadata to improve analysis accuracy.
* **Bug Fixes**
  * Formula actual-text suggestions are now handled correctly during both single and batch application flows.
* **Tests**
  * Added/updated unit coverage for formula actual-text analysis, validator behavior, and struct tree bbox annotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->